### PR TITLE
Feat: Add Workflow to Release Tester Binaries

### DIFF
--- a/.github/workflows/release-tester.yml
+++ b/.github/workflows/release-tester.yml
@@ -1,0 +1,52 @@
+# .github/workflows/release-tester.yml
+name: Release Tester Binary
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-release:
+    name: Build and Release Tester
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_name: mcp-tester-linux-x86_64
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            asset_name: mcp-tester-macos-x86_64
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            asset_name: mcp-tester-windows-x86_64.exe
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build binary
+        run: cargo build --release --package mcp-server-tester --target ${{ matrix.target }}
+        working-directory: ./examples/26-server-tester
+
+      - name: Prepare artifact for upload
+        shell: bash
+        run: |
+          cd examples/26-server-tester/target/${{ matrix.target }}/release
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            mv mcp-tester.exe ${{ matrix.asset_name }}
+          else
+            mv mcp-tester ${{ matrix.asset_name }}
+          fi
+          echo "ASSET_PATH=$(pwd)/${{ matrix.asset_name }}" >> $GITHUB_ENV
+
+      - name: Upload release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ env.ASSET_PATH }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow that automates the process of building and releasing pre-compiled binaries for the mcp-server-tester example. This will allow developers who are not using Rust to easily download and run a client tester for their MCP server implementations, improving the overall developer experience.