### PR TITLE
fix: handle missing corpus in scheduled fuzz coverage job

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -89,6 +89,31 @@ jobs:
           cargo install cargo-fuzz
           cargo install rustfilt
       
+      - name: Cache fuzz corpus
+        uses: actions/cache@v4
+        with:
+          path: fuzz/corpus
+          key: fuzz-corpus-all-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-all-
+            fuzz-corpus-
+      
+      - name: Generate minimal corpus if needed
+        run: |
+          for target in protocol_parsing jsonrpc_handling transport_layer auth_flows; do
+            # Create corpus directory if it doesn't exist
+            mkdir -p fuzz/corpus/$target
+            
+            # If corpus is empty, run fuzzer briefly to generate some inputs
+            if [ -z "$(ls -A fuzz/corpus/$target 2>/dev/null)" ]; then
+              echo "No corpus found for $target, generating minimal corpus..."
+              cargo fuzz run $target -- \
+                -max_total_time=10 \
+                -print_final_stats=1 \
+                -detect_leaks=0 || true
+            fi
+          done
+      
       - name: Generate coverage
         run: |
           for target in protocol_parsing jsonrpc_handling transport_layer auth_flows; do


### PR DESCRIPTION
## Summary
- Fixes scheduled fuzzing workflow failures due to missing corpus files
- Adds corpus generation step before coverage generation
- Prevents "The corpus does not contain program-input files" error

## Changes
- Added corpus caching to persist generated test inputs between runs
- Added minimal corpus generation (10 seconds per target) if corpus is empty
- Ensures coverage job has valid inputs to work with

## Test plan
- [x] Workflow syntax validated
- [x] Corpus generation logic tested locally
- [ ] Will be verified in next scheduled run or manual workflow_dispatch

Fixes the scheduled fuzzing failures reported in CI.

🤖 Generated with [Claude Code](https://claude.ai/code)