### PR TITLE
chore: release v1.5.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
     - uses: actions/checkout@v4
     
@@ -38,15 +36,20 @@ jobs:
     
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ steps.get_version.outputs.VERSION }}
-        body: ${{ steps.changelog.outputs.CHANGELOG }}
-        draft: false
-        prerelease: false
+      run: |
+        # Check if release already exists
+        if gh release view "${{ steps.get_version.outputs.VERSION }}" &>/dev/null; then
+          echo "Release ${{ steps.get_version.outputs.VERSION }} already exists, skipping creation"
+          echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
+        else
+          gh release create "${{ steps.get_version.outputs.VERSION }}" \
+            --title "${{ steps.get_version.outputs.VERSION }}" \
+            --notes "${{ steps.changelog.outputs.CHANGELOG }}" \
+            --verify-tag
+          echo "RELEASE_EXISTS=false" >> $GITHUB_OUTPUT
+        fi
 
   publish-crate:
     name: Publish to crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-09-25
+
+### Fixed
+- Release workflow to handle existing releases gracefully
+- Cargo.toml version alignment for proper crates.io publishing
+
+### Changed
+- Updated release workflow to use GitHub CLI instead of deprecated actions/create-release
+
+## [1.5.0] - 2025-09-25
+
+### Added
+- **WASM MCP Server Support**: Complete WebAssembly deployment capabilities
+  - Platform-agnostic WasmMcpServer implementation using PMCP SDK
+  - Cloudflare Workers deployment with worker crate
+  - Fermyon Spin deployment with spin-sdk
+  - "Write once, deploy everywhere" architecture
+  - Calculator tool example with comprehensive operations
+- **MCP Scenario Testing**: YAML/JSON-based test scenarios
+  - Declarative test definitions for MCP servers
+  - Support for tool testing with assertions
+  - Integration with mcp-tester for automated validation
+  - Example scenarios for calculator tool testing
+- **Streamable HTTP Transport**: Enhanced HTTP transport with empty response handling
+  - Support for 200 OK with empty body
+  - Proper Content-Type detection for responses
+  - Improved error handling for edge cases
+
+### Fixed
+- JSON-RPC notification handling in WASM servers (notifications have no 'id' field)
+- Verbose flag propagation in mcp-tester
+- Scenario executor assertion logic for Success/Failure cases
+- Windows release asset upload paths in GitHub Actions
+
+### Changed
+- Refactored WASM server into platform-specific implementations
+- Separated core MCP logic from transport/platform layers
+- Improved scenario executor to return actual tool responses
+
 ## [1.4.2] - 2025-01-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] - 2025-09-25
+## [1.5.2] - 2025-09-25
+
+### Fixed
+- Release workflow to handle existing releases gracefully
+- Cargo.toml version alignment for proper crates.io publishing
+- Ensure correct tag checkout in GitHub Actions workflow
+
+### Changed
+- Updated release workflow to use GitHub CLI instead of deprecated actions/create-release
+
+## [1.5.1] - 2025-09-25 (Skipped)
 
 ### Fixed
 - Release workflow to handle existing releases gracefully

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.4.2"
+version = "1.5.0"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-24 06:12:23 UTC
+Generated on: 2025-09-25 06:12:34 UTC
 
 ## Summary Metrics
 

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-25 20:05:53 UTC
+Generated on: 2025-09-25 20:10:31 UTC
 
 ## Summary Metrics
 

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-23 06:11:50 UTC
+Generated on: 2025-09-24 06:12:23 UTC
 
 ## Summary Metrics
 

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-25 06:12:34 UTC
+Generated on: 2025-09-25 20:05:53 UTC
 
 ## Summary Metrics
 

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-25 23:08:39 UTC
+Generated on: 2025-09-25 23:35:49 UTC
 
 ## Summary Metrics
 

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-25 20:10:31 UTC
+Generated on: 2025-09-25 23:08:39 UTC
 
 ## Summary Metrics
 


### PR DESCRIPTION
## Summary
- Bump version to v1.5.2 for clean release to crates.io
- Fix release workflow to handle existing releases gracefully
- Skip v1.5.1 due to workflow issues

## Changes
- Updated Cargo.toml version to 1.5.2
- Updated CHANGELOG.md with v1.5.2 entry
- Fixed release workflow to use GitHub CLI instead of deprecated actions

## Release Notes
The v1.5.2 release includes all the improvements from the v1.5.0 attempt:
- WASM MCP Server support with platform-specific deployments
- MCP Scenario Testing framework
- Enhanced HTTP transport handling
- Various bug fixes and improvements

This ensures proper crates.io publishing with correct version alignment.