### PR TITLE
feat: Add schema support for tools in streamable HTTP implementation

### DIFF
--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-25 23:56:59 UTC
+Generated on: 2025-09-26 00:15:53 UTC
 
 ## Summary Metrics
 

--- a/QUALITY_REPORT.md
+++ b/QUALITY_REPORT.md
@@ -1,6 +1,6 @@
 # PMAT Quality Report
 
-Generated on: 2025-09-26 00:15:53 UTC
+Generated on: 2025-09-26 06:11:42 UTC
 
 ## Summary Metrics
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,9 @@ pub use error::{Error, ErrorCode, Result};
 pub use server::cancellation::RequestHandlerExtra;
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{
-    auth, PromptHandler, ResourceHandler, SamplingHandler, Server, ServerBuilder, ToolHandler,
+    auth,
+    simple_tool::{SimpleTool, SyncTool},
+    PromptHandler, ResourceHandler, SamplingHandler, Server, ServerBuilder, ToolHandler,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use shared::StdioTransport;

--- a/src/server/core.rs
+++ b/src/server/core.rs
@@ -192,11 +192,20 @@ impl ServerCore {
     async fn handle_list_tools(&self, _req: &ListToolsParams) -> Result<ListToolsResult> {
         let tools = self
             .tools
-            .keys()
-            .map(|name| ToolInfo {
-                name: name.clone(),
-                description: None,
-                input_schema: serde_json::json!({}),
+            .iter()
+            .map(|(name, handler)| {
+                // Use tool metadata if provided, otherwise use defaults
+                if let Some(mut info) = handler.metadata() {
+                    // Ensure the name matches the registered name
+                    info.name.clone_from(name);
+                    info
+                } else {
+                    ToolInfo {
+                        name: name.clone(),
+                        description: None,
+                        input_schema: serde_json::json!({}),
+                    }
+                }
             })
             .collect();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -41,6 +41,9 @@ pub mod auth;
 pub mod batch;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod cancellation;
+/// Simple tool implementations with schema support.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod simple_tool;
 
 // For WASM, provide a simple stub for RequestHandlerExtra
 #[cfg(target_arch = "wasm32")]
@@ -104,6 +107,8 @@ mod wasi_protocol {
 mod adapter_tests;
 #[cfg(test)]
 mod core_tests;
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod simple_tool_tests;
 
 /// Handler for tool execution.
 #[cfg(not(target_arch = "wasm32"))]
@@ -111,6 +116,12 @@ mod core_tests;
 pub trait ToolHandler: Send + Sync {
     /// Handle a tool call with the given arguments.
     async fn handle(&self, args: Value, extra: cancellation::RequestHandlerExtra) -> Result<Value>;
+
+    /// Get tool metadata including description and schema.
+    /// Returns None to use default empty metadata.
+    fn metadata(&self) -> Option<crate::types::ToolInfo> {
+        None
+    }
 }
 
 /// Handler for prompt generation.

--- a/src/server/simple_tool.rs
+++ b/src/server/simple_tool.rs
@@ -1,0 +1,165 @@
+//! Simple tool implementations with schema support.
+
+use crate::{types::ToolInfo, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+
+use super::cancellation::RequestHandlerExtra;
+use super::ToolHandler;
+
+/// A simple tool implementation with schema support.
+pub struct SimpleTool<F>
+where
+    F: Fn(Value, RequestHandlerExtra) -> Pin<Box<dyn Future<Output = Result<Value>> + Send>>
+        + Send
+        + Sync,
+{
+    name: String,
+    description: Option<String>,
+    input_schema: Value,
+    handler: F,
+}
+
+impl<F> fmt::Debug for SimpleTool<F>
+where
+    F: Fn(Value, RequestHandlerExtra) -> Pin<Box<dyn Future<Output = Result<Value>> + Send>>
+        + Send
+        + Sync,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SimpleTool")
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("input_schema", &self.input_schema)
+            .finish()
+    }
+}
+
+impl<F> SimpleTool<F>
+where
+    F: Fn(Value, RequestHandlerExtra) -> Pin<Box<dyn Future<Output = Result<Value>> + Send>>
+        + Send
+        + Sync,
+{
+    /// Create a new tool with a name and handler.
+    pub fn new(name: impl Into<String>, handler: F) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            }),
+            handler,
+        }
+    }
+
+    /// Set the description for this tool.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the input schema for this tool.
+    pub fn with_schema(mut self, schema: Value) -> Self {
+        self.input_schema = schema;
+        self
+    }
+}
+
+#[async_trait]
+impl<F> ToolHandler for SimpleTool<F>
+where
+    F: Fn(Value, RequestHandlerExtra) -> Pin<Box<dyn Future<Output = Result<Value>> + Send>>
+        + Send
+        + Sync,
+{
+    async fn handle(&self, args: Value, extra: RequestHandlerExtra) -> Result<Value> {
+        (self.handler)(args, extra).await
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        Some(ToolInfo {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            input_schema: self.input_schema.clone(),
+        })
+    }
+}
+
+/// A simpler tool for synchronous handlers.
+pub struct SyncTool<F>
+where
+    F: Fn(Value) -> Result<Value> + Send + Sync,
+{
+    name: String,
+    description: Option<String>,
+    input_schema: Value,
+    handler: F,
+}
+
+impl<F> fmt::Debug for SyncTool<F>
+where
+    F: Fn(Value) -> Result<Value> + Send + Sync,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyncTool")
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("input_schema", &self.input_schema)
+            .finish()
+    }
+}
+
+impl<F> SyncTool<F>
+where
+    F: Fn(Value) -> Result<Value> + Send + Sync,
+{
+    /// Create a new synchronous tool with a name and handler.
+    pub fn new(name: impl Into<String>, handler: F) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            }),
+            handler,
+        }
+    }
+
+    /// Set the description for this tool.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the input schema for this tool.
+    pub fn with_schema(mut self, schema: Value) -> Self {
+        self.input_schema = schema;
+        self
+    }
+}
+
+#[async_trait]
+impl<F> ToolHandler for SyncTool<F>
+where
+    F: Fn(Value) -> Result<Value> + Send + Sync,
+{
+    async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> Result<Value> {
+        (self.handler)(args)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        Some(ToolInfo {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            input_schema: self.input_schema.clone(),
+        })
+    }
+}

--- a/src/server/simple_tool_tests.rs
+++ b/src/server/simple_tool_tests.rs
@@ -1,0 +1,171 @@
+#[cfg(test)]
+mod tests {
+    use super::super::simple_tool::{SimpleTool, SyncTool};
+    use crate::server::cancellation::RequestHandlerExtra;
+    use crate::server::ToolHandler;
+    use serde_json::{json, Value};
+
+    #[tokio::test]
+    async fn test_simple_tool_with_schema() {
+        let tool = SimpleTool::new(
+            "test_tool",
+            Box::new(|args: Value, _extra: RequestHandlerExtra| {
+                Box::pin(async move {
+                    let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0);
+                    Ok(json!({ "result": x * 2 }))
+                })
+                    as std::pin::Pin<
+                        Box<dyn std::future::Future<Output = crate::Result<Value>> + Send>,
+                    >
+            }),
+        )
+        .with_description("Test tool that doubles input")
+        .with_schema(json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "integer",
+                    "description": "Input value to double"
+                }
+            },
+            "required": ["x"]
+        }));
+
+        // Test metadata
+        let metadata = tool.metadata().unwrap();
+        assert_eq!(metadata.name, "test_tool");
+        assert_eq!(
+            metadata.description,
+            Some("Test tool that doubles input".to_string())
+        );
+        assert_eq!(
+            metadata.input_schema["properties"]["x"]["description"],
+            "Input value to double"
+        );
+
+        // Test execution
+        let extra = RequestHandlerExtra {
+            cancellation_token: tokio_util::sync::CancellationToken::new(),
+            request_id: "test-req".to_string(),
+            session_id: None,
+            auth_info: None,
+            auth_context: None,
+        };
+        let result = tool.handle(json!({ "x": 5 }), extra).await.unwrap();
+        assert_eq!(result["result"], 10);
+    }
+
+    #[tokio::test]
+    async fn test_sync_tool_with_schema() {
+        let tool = SyncTool::new("sync_tool", |args| {
+            let msg = args
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("default");
+            Ok(json!({ "echo": msg }))
+        })
+        .with_description("Sync echo tool")
+        .with_schema(json!({
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "Message to echo"
+                }
+            }
+        }));
+
+        // Test metadata
+        let metadata = tool.metadata().unwrap();
+        assert_eq!(metadata.name, "sync_tool");
+        assert_eq!(metadata.description, Some("Sync echo tool".to_string()));
+        assert_eq!(
+            metadata.input_schema["properties"]["message"]["type"],
+            "string"
+        );
+
+        // Test execution
+        let extra = RequestHandlerExtra {
+            cancellation_token: tokio_util::sync::CancellationToken::new(),
+            request_id: "test-req".to_string(),
+            session_id: None,
+            auth_info: None,
+            auth_context: None,
+        };
+        let result = tool
+            .handle(json!({ "message": "hello" }), extra)
+            .await
+            .unwrap();
+        assert_eq!(result["echo"], "hello");
+    }
+
+    #[test]
+    fn test_default_schema() {
+        let tool = SyncTool::new("default_tool", |_args| Ok(json!({})));
+
+        let metadata = tool.metadata().unwrap();
+        assert_eq!(metadata.name, "default_tool");
+        assert_eq!(metadata.description, None);
+        // Check default schema allows any properties
+        assert_eq!(metadata.input_schema["type"], "object");
+        assert_eq!(metadata.input_schema["additionalProperties"], true);
+    }
+
+    #[tokio::test]
+    async fn test_tool_error_handling() {
+        let tool = SimpleTool::new(
+            "error_tool",
+            Box::new(|_args: Value, _extra: RequestHandlerExtra| {
+                Box::pin(async move { Err(crate::Error::validation("Test error")) })
+                    as std::pin::Pin<
+                        Box<dyn std::future::Future<Output = crate::Result<Value>> + Send>,
+                    >
+            }),
+        );
+
+        let extra = RequestHandlerExtra {
+            cancellation_token: tokio_util::sync::CancellationToken::new(),
+            request_id: "test-error".to_string(),
+            session_id: None,
+            auth_info: None,
+            auth_context: None,
+        };
+        let result = tool.handle(json!({}), extra).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[test]
+    fn test_tool_info_structure() {
+        let tool = SyncTool::new("info_test", |_| Ok(json!({})))
+            .with_description("Tool for testing ToolInfo structure")
+            .with_schema(json!({
+                "type": "object",
+                "properties": {
+                    "param1": {
+                        "type": "string",
+                        "enum": ["option1", "option2"]
+                    },
+                    "param2": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 100
+                    }
+                },
+                "required": ["param1"]
+            }));
+
+        let info = tool.metadata().unwrap();
+
+        // Verify the ToolInfo structure matches expected format
+        assert_eq!(info.name, "info_test");
+        assert!(info.description.is_some());
+
+        // Check schema details
+        let schema = &info.input_schema;
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["param1"]["enum"].is_array());
+        assert_eq!(schema["properties"]["param2"]["minimum"], 0);
+        assert_eq!(schema["required"][0], "param1");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds schema support for tools in the regular (non-WASM) server implementation
- Brings feature parity with WASM implementation which already had `SimpleTool::with_schema()`
- Matches TypeScript SDK's approach for tool metadata

## Changes

### Core Implementation
- **Enhanced ToolHandler trait**: Added optional `metadata()` method to provide tool information including schemas
- **New helper types**: Created `SimpleTool` and `SyncTool` for easy tool creation with schema support
- **Updated ServerCore**: Modified list_tools handler to use tool metadata when available

### Developer Experience
- Tools can now define JSON schemas with full validation rules
- Builder pattern with `.with_description()` and `.with_schema()` methods
- Backward compatible - existing tools without metadata continue to work

### Examples & Tests
- Updated example 22 to demonstrate schema usage with multiple tools
- Added comprehensive unit tests for SimpleTool and SyncTool
- Added integration test verifying schemas are exposed in list_tools response

## Test Plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Examples build and run correctly
- [x] Quality gates pass (formatting, clippy, etc.)
- [x] Backward compatibility verified

## Breaking Changes
None - all changes are backward compatible.

🤖 Generated with [Claude Code](https://claude.ai/code)