### PR TITLE
fix(mcp-tester): add schema validation and consistent error handling

### DIFF
--- a/examples/26-server-tester/src/scenario_executor.rs
+++ b/examples/26-server-tester/src/scenario_executor.rs
@@ -295,40 +295,73 @@ impl<'a> ScenarioExecutor<'a> {
                 }
             },
 
-            Operation::ListTools => {
-                let tools = self.tester.list_tools().await?;
-                Ok(json!({
-                    "tools": tools.tools
-                }))
+            Operation::ListTools => match self.tester.list_tools().await {
+                Ok(tools) => Ok(json!({
+                    "success": true,
+                    "tools": tools.tools,
+                    "error": null
+                })),
+                Err(e) => Ok(json!({
+                    "success": false,
+                    "tools": [],
+                    "error": e.to_string()
+                })),
             },
 
-            Operation::ListResources => {
-                let resources = self.tester.list_resources().await?;
-                Ok(json!({
-                    "resources": resources.resources
-                }))
+            Operation::ListResources => match self.tester.list_resources().await {
+                Ok(resources) => Ok(json!({
+                    "success": true,
+                    "resources": resources.resources,
+                    "error": null
+                })),
+                Err(e) => Ok(json!({
+                    "success": false,
+                    "resources": [],
+                    "error": e.to_string()
+                })),
             },
 
-            Operation::ReadResource { uri } => {
-                let result = self.tester.read_resource(&uri).await?;
-                Ok(json!({
-                    "contents": result.contents
-                }))
+            Operation::ReadResource { uri } => match self.tester.read_resource(&uri).await {
+                Ok(result) => Ok(json!({
+                    "success": true,
+                    "contents": result.contents,
+                    "error": null
+                })),
+                Err(e) => Ok(json!({
+                    "success": false,
+                    "contents": [],
+                    "error": e.to_string()
+                })),
             },
 
-            Operation::ListPrompts => {
-                let prompts = self.tester.list_prompts().await?;
-                Ok(json!({
-                    "prompts": prompts.prompts
-                }))
+            Operation::ListPrompts => match self.tester.list_prompts().await {
+                Ok(prompts) => Ok(json!({
+                    "success": true,
+                    "prompts": prompts.prompts,
+                    "error": null
+                })),
+                Err(e) => Ok(json!({
+                    "success": false,
+                    "prompts": [],
+                    "error": e.to_string()
+                })),
             },
 
             Operation::GetPrompt { name, arguments } => {
-                let result = self.tester.get_prompt(&name, arguments).await?;
-                Ok(json!({
-                    "messages": result.messages,
-                    "description": result.description
-                }))
+                match self.tester.get_prompt(&name, arguments).await {
+                    Ok(result) => Ok(json!({
+                        "success": true,
+                        "messages": result.messages,
+                        "description": result.description,
+                        "error": null
+                    })),
+                    Err(e) => Ok(json!({
+                        "success": false,
+                        "messages": [],
+                        "description": null,
+                        "error": e.to_string()
+                    })),
+                }
             },
 
             Operation::Custom { method, params } => {


### PR DESCRIPTION
## Summary

This PR addresses two critical issues in mcp-tester that prevented it from catching problems that real MCP clients like Claude Code detect.

## Issue 1: JSON Schema Type Validation

### Problem
mcp-tester accepted invalid JSON schemas like `"type": "null"` that are rejected by MCP clients.

**Example error from Claude Code:**
```
Invalid literal value, expected "object"
Path: tools[2].inputSchema.type
Received: "null"
```

### Root Cause
Tools using Rust unit type `()` serialize to `"type": "null"` which is not a valid JSON Schema type.

**Invalid schema that mcp-tester missed:**
```json
{
  "name": "list_pages",
  "inputSchema": {
    "type": "null",     // ❌ Invalid - should be caught
    "title": "null"
  }
}
```

### Solution
Enhanced `validate_tool_schema()` in `tester.rs` to:
- ✅ Validate `type` field against valid JSON Schema types
- ✅ Flag `"type": "null"` with specific, actionable error message
- ✅ Suggest using empty struct instead of unit type `()`
- ✅ Check for other invalid type values

**Valid JSON Schema types**: object, array, string, number, integer, boolean

**New validation output:**
```
⚠ Tool 'list_pages' has invalid inputSchema.type = "null" - this will be rejected by MCP clients like Claude Code. 
  Expected "object" for structured input, or omit inputSchema if no parameters required. 
  (This often happens when using unit type () in Rust - use an empty struct instead)
```

## Issue 2: Consistent Error Handling for Resource Operations

### Problem
Resource read error assertions failed even when error messages contained expected substrings, while identical assertions on tool call errors passed correctly.

**Example scenario that failed:**
```yaml
- name: 'Read resource [expected error]'
  operation:
    type: read_resource
    uri: docs://logseq/nonexistent
  assertions:
  - type: failure              # ❌ Failed
  - type: contains
    path: error
    value: not found           # ❌ Failed
```

**Same assertion on tool call:**
```yaml
- name: 'Test tool [expected error]'
  operation:
    type: tool_call
    tool: get_journal_entries
  assertions:
  - type: failure              # ✅ Passed
  - type: contains
    path: error
    value: recent_days         # ✅ Passed
```

### Root Cause
Inconsistent error handling in scenario executor:
- `ToolCall` operations **caught errors** → returned `{success: false, error: "..."}`
- `ReadResource` operations **propagated errors** with `?` → prevented assertions from running

### Solution
Made all MCP operations handle errors consistently in `scenario_executor.rs`:

**Operations updated:**
- `ListTools`, `ListResources`, `ReadResource`
- `ListPrompts`, `GetPrompt`

**Uniform response structure:**
```json
{
  "success": true/false,
  "result": ...,
  "error": null or "error message"
}
```

**Now enables:**
- ✅ `type: failure` assertions on resource errors
- ✅ `type: contains` assertions on error messages
- ✅ Comprehensive error testing across all MCP operations

## Impact

### Benefits
1. **Catches schema bugs early**: Issues found during testing, not integration
2. **Matches real MCP client behavior**: Validates like Claude Code does
3. **Prevents false confidence**: Tests that pass → actually work in production
4. **Enables comprehensive testing**: Error assertions now work for all operations

### Test Results
- ✅ All tests pass: 557 tests run, 557 passed, 2 skipped
- ✅ Quality gate: PASSED (formatting, clippy, build, doctests)
- ✅ All examples build successfully

## Files Changed
- `examples/26-server-tester/src/tester.rs` - Schema validation (lines 1464-1516)
- `examples/26-server-tester/src/scenario_executor.rs` - Error handling (lines 298-365)

## Related Issues
This addresses user-reported issues where:
- mcp-tester tests passed ✅
- Real MCP clients (Claude Code) failed ❌
- Gap in validation caused late discovery of bugs

## Migration Notes
No breaking changes. Existing tests continue to work, but will now report additional warnings for invalid schemas.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)