### PR TITLE
feat(cargo-pmcp): add OAuth integration for pmcp.run deployment

### DIFF
--- a/cargo-pmcp/docs/PMCP_RUN_INTEGRATION_UPDATE.md
+++ b/cargo-pmcp/docs/PMCP_RUN_INTEGRATION_UPDATE.md
@@ -1,0 +1,126 @@
+# pmcp.run Service Integration Update Required
+
+## Summary
+
+The cargo-pmcp SDK has been updated to generate Lambda-only CDK templates (no API Gateway) for pmcp-run deployments. However, the pmcp.run Step Functions workflow still expects the old template format with `ApiUrl` output.
+
+## Current Error
+
+```
+Deployment failed: Failed to extract stack outputs
+```
+
+This occurs because the workflow tries to extract `ApiUrl` from CloudFormation outputs, but the Lambda-only template doesn't have an API Gateway.
+
+## cargo-pmcp Changes (Completed)
+
+1. **CDK Template for pmcp-run** now only deploys:
+   - Lambda function
+   - IAM execution role (implicit)
+   - Log group
+
+2. **Outputs from CDK template**:
+   - `LambdaArn` - The Lambda function ARN
+   - `LambdaName` - The Lambda function name
+   - `ApiUrl` - Placeholder: `https://api.pmcp.run/{use-deployment-id}/mcp` (for backward compat)
+   - `DashboardUrl` - CloudWatch console URL
+
+3. **URL Construction**: cargo-pmcp constructs the MCP endpoint URL from the deployment ID:
+   ```
+   https://api.pmcp.run/{deployment_id}/mcp
+   ```
+
+## pmcp.run Service Changes Required
+
+### 1. Update Step Functions Workflow
+
+**File**: `amplify/functions/deployment-workflow/state-machine.json`
+
+**Current** (line 320):
+```json
+"apiUrl": "{% $states.result.Stacks[0].Outputs[OutputKey='ApiUrl'].OutputValue %}"
+```
+
+**New**:
+```json
+"lambdaArn": "{% $states.result.Stacks[0].Outputs[OutputKey='LambdaArn'].OutputValue %}",
+"lambdaName": "{% $states.result.Stacks[0].Outputs[OutputKey='LambdaName'].OutputValue %}",
+"apiUrl": "{% 'https://api.pmcp.run/' + $deploymentId + '/mcp' %}"
+```
+
+### 2. Wire Lambda to Shared API Gateway
+
+After CloudFormation deployment succeeds, the workflow needs to:
+
+1. **Create Lambda integration** on the shared API Gateway:
+   ```typescript
+   const integration = new apigatewayv2.CfnIntegration(this, 'Integration', {
+     apiId: SHARED_API_GATEWAY_ID,
+     integrationType: 'AWS_PROXY',
+     integrationUri: lambdaArn,
+     payloadFormatVersion: '2.0',
+   });
+   ```
+
+2. **Create route** for `/{serverId}/mcp`:
+   ```typescript
+   new apigatewayv2.CfnRoute(this, 'Route', {
+     apiId: SHARED_API_GATEWAY_ID,
+     routeKey: `POST /${serverId}/mcp`,
+     target: `integrations/${integration.ref}`,
+   });
+   ```
+
+3. **Grant API Gateway permission** to invoke the Lambda:
+   ```typescript
+   new lambda.CfnPermission(this, 'ApiGatewayPermission', {
+     action: 'lambda:InvokeFunction',
+     functionName: lambdaName,
+     principal: 'apigateway.amazonaws.com',
+     sourceArn: `arn:aws:execute-api:${region}:${account}:${SHARED_API_GATEWAY_ID}/*/*`,
+   });
+   ```
+
+### 3. Update DynamoDB Record
+
+Store `lambdaArn` in the deployment record:
+```json
+{
+  "id": "dep_xxxxx",
+  "projectName": "chess",
+  "status": "success",
+  "lambdaArn": "arn:aws:lambda:us-west-2:123456789:function:chess",
+  "lambdaName": "chess",
+  "url": "https://api.pmcp.run/dep_xxxxx/mcp"
+}
+```
+
+## Alternative: Quick Fix for Backward Compatibility
+
+If the service-side changes take time, cargo-pmcp can temporarily generate templates with a per-server API Gateway (the old way) for pmcp-run target. However, this defeats the cost optimization benefits of the shared API Gateway architecture.
+
+## Testing
+
+Once pmcp.run service is updated:
+
+```bash
+cd ~/Development/mcp/pmcp/test-chess/chess
+rm -rf .pmcp deploy
+cargo pmcp deploy init --oauth cognito --target pmcp-run
+cargo pmcp deploy --target pmcp-run
+```
+
+Expected output:
+```
+🎉 Deployment successful!
+
+📊 Deployment Details:
+   Name: chess
+   ID: dep_xxxxx
+
+🔌 MCP Endpoint:
+   URL: https://api.pmcp.run/dep_xxxxx/mcp
+
+🏥 Health Check:
+   URL: https://api.pmcp.run/dep_xxxxx/health
+```

--- a/cargo-pmcp/docs/oauth-design.md
+++ b/cargo-pmcp/docs/oauth-design.md
@@ -1,0 +1,548 @@
+# OAuth Design for cargo-pmcp
+
+Production-ready OAuth 2.0 authentication for MCP servers deployed with cargo-pmcp.
+
+## Design Principles
+
+1. **MCP server developer is OAuth-agnostic** - No authentication code required in server logic
+2. **Layered security** - Platform auth (API Gateway + Cognito) handles everything
+3. **Stateless token validation** - JWT + JWKS, no token storage tables
+4. **Dynamic Client Registration** - MCP clients self-register via RFC 7591
+5. **Low cost** - Minimal Lambda invocations, JWKS caching
+6. **Future-proof** - Easy migration to AWS AgentCore when ready
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              API Gateway                                     │
+│                                                                             │
+│  ┌───────────────────┐  ┌────────────────┐  ┌───────────────────────────┐  │
+│  │ /.well-known/*    │  │ /oauth2/*      │  │ /mcp/*                    │  │
+│  │ (No Auth)         │  │ (No Auth)      │  │ (JWT Authorizer)          │  │
+│  │                   │  │                │  │                           │  │
+│  │ • openid-config   │  │ • /register    │  │ Lambda Authorizer         │  │
+│  │ • jwks.json       │  │ • /authorize   │  │ (stateless JWT check)     │  │
+│  │                   │  │ • /token       │  │                           │  │
+│  └─────────┬─────────┘  └───────┬────────┘  └─────────────┬─────────────┘  │
+└────────────┼────────────────────┼─────────────────────────┼─────────────────┘
+             │                    │                         │
+             │                    ▼                         ▼
+             │         ┌─────────────────────┐   ┌─────────────────────────┐
+             │         │  OAuth Proxy        │   │  User's MCP Server      │
+             │         │  Lambda             │   │  Lambda                 │
+             │         │                     │   │                         │
+             │         │  Handles:           │   │  • Zero OAuth code      │
+             │         │  • DCR → Cognito    │   │  • User context via     │
+             │         │  • Token exchange   │   │    request headers      │
+             │         │  • Authorize redirect│  │  • Optional: pmcp-auth  │
+             │         └──────────┬──────────┘   └─────────────────────────┘
+             │                    │
+             │                    ▼
+             │         ┌─────────────────────────────────────────┐
+             │         │              DynamoDB                    │
+             │         │                                          │
+             │         │  ClientRegistrationTable (ONLY TABLE)   │
+             │         │  ┌─────────────────────────────────┐    │
+             │         │  │ PK: client_id                   │    │
+             │         │  │ • client_secret                 │    │
+             │         │  │ • client_name                   │    │
+             │         │  │ • redirect_uris                 │    │
+             │         │  │ • is_public                     │    │
+             │         │  │ • created_at                    │    │
+             │         │  │ • server_id (links to MCP srv)  │    │
+             │         │  └─────────────────────────────────┘    │
+             │         └─────────────────────────────────────────┘
+             │                    │
+             └────────────────────┼────────────────────────────────┐
+                                  ▼                                │
+                       ┌─────────────────────┐                     │
+                       │      Cognito        │◀────────────────────┘
+                       │    User Pool        │   (JWKS for validation)
+                       │                     │
+                       │  • User identity    │
+                       │  • Token issuance   │
+                       │  • Hosted UI        │
+                       │  • Social logins    │
+                       └─────────────────────┘
+```
+
+## Key Design Decisions
+
+### Single DynamoDB Table
+
+Only `ClientRegistrationTable` is needed. No token storage tables because:
+
+- Token validation is stateless (JWT + JWKS)
+- MCP clients send tokens on every request
+- Cognito handles token issuance and refresh
+- The OAuth proxy forwards to Cognito for token exchange
+
+### Who Registers Clients?
+
+**MCP Clients (Primary)** - Via Dynamic Client Registration:
+- Claude Desktop, ChatGPT, Cursor auto-register when user adds server URL
+- User just provides server URL, client handles OAuth transparently
+
+**Testing & CI/CD (Secondary)**:
+- `cargo pmcp test` uses built-in test client
+- CI/CD pipelines use pre-registered service accounts
+
+**Admin Portal (Future)**:
+- Organization admins manage/revoke clients
+- Audit client usage
+
+### Stateless Token Validation
+
+```
+Request Flow:
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                  │
+│  Request 1: POST /mcp                                           │
+│  Authorization: Bearer eyJhbG...                                │
+│  → Validate JWT signature (JWKS cached in Lambda)               │
+│  → Check expiry                                                 │
+│  → Extract claims (sub, scopes)                                 │
+│  → Process MCP request                                          │
+│                                                                  │
+│  Request 2: POST /mcp                                           │
+│  Authorization: Bearer eyJhbG... (same or refreshed token)      │
+│  → Same validation (no state from Request 1)                    │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+
+Benefits:
+✓ No DynamoDB reads for token validation
+✓ Infinite horizontal scaling
+✓ No token table costs
+✓ Cognito handles token lifecycle
+✓ JWKS cached in Lambda (1 hour TTL)
+```
+
+## OAuth Flows
+
+### 1. OpenID Connect Discovery
+
+MCP clients discover OAuth endpoints automatically:
+
+```
+GET https://api.example.com/.well-known/openid-configuration
+
+Response:
+{
+  "issuer": "https://api.example.com",
+  "authorization_endpoint": "https://xxx.amazoncognito.com/oauth2/authorize",
+  "token_endpoint": "https://api.example.com/oauth2/token",
+  "registration_endpoint": "https://api.example.com/oauth2/register",
+  "jwks_uri": "https://cognito-idp.{region}.amazonaws.com/{pool-id}/.well-known/jwks.json",
+  "scopes_supported": ["openid", "email", "mcp/read", "mcp/write"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "code_challenge_methods_supported": ["S256"]
+}
+```
+
+### 2. Dynamic Client Registration (RFC 7591)
+
+```
+POST https://api.example.com/oauth2/register
+Content-Type: application/json
+
+{
+  "client_name": "Claude Desktop",
+  "redirect_uris": ["http://localhost:8080/callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "token_endpoint_auth_method": "none"
+}
+
+Response:
+{
+  "client_id": "abc123xyz",
+  "client_name": "Claude Desktop",
+  "token_endpoint_auth_method": "none"
+}
+```
+
+**Public vs Confidential Clients:**
+- Public clients (Claude Desktop, native apps): No client_secret, auth method = "none"
+- Confidential clients (server-side): client_secret generated, auth method = "client_secret_post"
+
+Auto-detection based on client_name patterns:
+```rust
+fn is_public_client(client_name: &str) -> bool {
+    client_name.contains("claude") ||
+    client_name.contains("desktop") ||
+    client_name.contains("cursor") ||
+    client_name.contains("mcp-inspector") ||
+    client_name.contains("chatgpt")
+}
+```
+
+### 3. Authorization Code Flow with PKCE
+
+```
+1. Client redirects user to:
+   GET /oauth2/authorize
+   ?client_id=abc123
+   &redirect_uri=http://localhost:8080/callback
+   &code_challenge=xxx (PKCE S256)
+   &scope=openid email mcp/read
+   &state=random123
+
+2. OAuth Proxy redirects to Cognito Hosted UI
+
+3. User authenticates (email/password, GitHub, etc.)
+
+4. Cognito redirects back:
+   GET http://localhost:8080/callback?code=AUTH_CODE&state=random123
+
+5. Client exchanges code for tokens:
+   POST /oauth2/token
+   grant_type=authorization_code
+   &code=AUTH_CODE
+   &code_verifier=xxx (PKCE)
+   &client_id=abc123
+
+6. Response:
+   {
+     "access_token": "eyJhbG...",
+     "token_type": "Bearer",
+     "expires_in": 3600,
+     "refresh_token": "xxx"
+   }
+```
+
+### 4. MCP Request with Token
+
+```
+POST https://api.example.com/mcp
+Authorization: Bearer eyJhbG...
+Content-Type: application/json
+
+{"jsonrpc": "2.0", "method": "tools/list", "id": 1}
+
+Flow:
+1. API Gateway invokes Lambda Authorizer
+2. Authorizer validates JWT signature using cached JWKS
+3. Authorizer extracts claims, returns Allow policy + context
+4. API Gateway forwards request to MCP Server Lambda
+5. MCP Server processes request (no OAuth code!)
+6. Response returned to client
+```
+
+## CLI Commands
+
+### Initialize with OAuth
+
+```bash
+$ cargo pmcp deploy init --target aws-lambda
+
+? Enable OAuth authentication? (Y/n) Y
+
+? OAuth provider:
+  ❯ cognito     - AWS Cognito (recommended)
+    oidc        - External OIDC provider (future)
+
+? Cognito setup:
+  ❯ Create new  - New User Pool for this server
+    Existing    - Use existing User Pool
+    Shared      - Use organization's shared pool
+
+? User Pool name: my-mcp-users
+
+? Enable social sign-in?
+  [x] GitHub
+  [ ] Google
+  [ ] Apple
+
+Creating OAuth infrastructure...
+  ✓ Cognito User Pool: us-west-2_Abc123XyZ
+  ✓ Resource Server: mcp (scopes: mcp/read, mcp/write)
+  ✓ OAuth Proxy Lambda: my-server-oauth-proxy
+  ✓ Authorizer Lambda: my-server-authorizer
+  ✓ ClientRegistrationTable: my-server-clients
+
+OAuth configuration saved to pmcp.toml
+```
+
+### Deploy with OAuth
+
+```bash
+$ cargo pmcp deploy
+
+Building MCP server...
+  ✓ Compiled: target/lambda/my-server/bootstrap
+
+Deploying...
+  ✓ Lambda: my-server-mcp
+  ✓ API Gateway routes configured:
+      GET  /.well-known/openid-configuration  (public)
+      POST /oauth2/register                   (public, DCR)
+      GET  /oauth2/authorize                  (public, redirect)
+      POST /oauth2/token                      (public, exchange)
+      POST /mcp                               (protected)
+      POST /mcp/{proxy+}                      (protected)
+
+Your MCP server is live:
+
+  ┌─────────────────────────────────────────────────────────────┐
+  │  Endpoint: https://abc123.execute-api.us-west-2.amazonaws.com│
+  │  OAuth:    Enabled (Cognito)                                │
+  │                                                             │
+  │  MCP Clients can discover OAuth via:                        │
+  │  https://abc123.execute-api.../.well-known/openid-configuration
+  └─────────────────────────────────────────────────────────────┘
+```
+
+### Test with OAuth
+
+```bash
+$ cargo pmcp test --server myserver
+
+Testing MCP server at https://abc123.execute-api...
+
+? OAuth authentication required. Login method:
+  ❯ Browser    - Open browser for OAuth login
+    Token      - Paste existing access token
+
+Opening browser for authentication...
+  ✓ Authentication successful (user: guy@example.com)
+
+Running MCP tests...
+  ✓ tools/list (3 tools found)
+  ✓ tools/call: get_weather (200ms)
+  ✓ resources/list (2 resources)
+
+All tests passed!
+```
+
+### View Registered Clients
+
+```bash
+$ cargo pmcp oauth clients
+
+Registered OAuth Clients:
+
+  CLIENT ID              NAME                REGISTERED        TYPE
+  abc123def456          Claude Desktop       2025-12-01        public
+  xyz789ghi012          ChatGPT              2025-12-02        public
+  mcp-tester-ci         CI Pipeline          2025-11-28        confidential
+
+3 clients registered via Dynamic Client Registration
+
+# Note: Clients register themselves via /oauth2/register
+# Use Cognito Console or Admin API to revoke clients
+```
+
+## Configuration
+
+### pmcp.toml
+
+```toml
+[package]
+name = "my-mcp-server"
+version = "0.1.0"
+
+[deploy]
+target = "aws-lambda"
+region = "us-west-2"
+
+[deploy.oauth]
+enabled = true
+provider = "cognito"
+
+[deploy.oauth.cognito]
+# Created by `cargo pmcp deploy init`, or reference existing
+user_pool_id = "us-west-2_Abc123XyZ"
+
+# Resource server identifier (for scopes)
+resource_server_id = "mcp"
+
+# Social identity providers
+social_providers = ["github"]
+
+# Token TTLs (managed by Cognito)
+access_token_ttl = "1h"
+refresh_token_ttl = "30d"
+
+[deploy.oauth.scopes]
+"mcp/read" = "Read access to MCP tools and resources"
+"mcp/write" = "Write access to MCP tools"
+"mcp/admin" = "Administrative operations"
+
+[deploy.oauth.dcr]
+enabled = true
+
+# Auto-detect public clients
+public_client_patterns = [
+    "claude",
+    "desktop",
+    "cursor",
+    "mcp-inspector",
+    "chatgpt"
+]
+
+# Default scopes for new clients
+default_scopes = ["openid", "email", "mcp/read"]
+```
+
+## Shared Infrastructure
+
+For organizations with multiple MCP servers:
+
+```
+Option A: Per-Server (Simple)          Option B: Shared (Enterprise)
+─────────────────────────────          ────────────────────────────
+
+┌─────────┐ ┌─────────┐ ┌─────────┐              ┌─────────────────┐
+│Server A │ │Server B │ │Server C │              │ Shared Cognito  │
+│+ OAuth  │ │+ OAuth  │ │+ OAuth  │              │ + OAuth Proxy   │
+│+ Cognito│ │+ Cognito│ │+ Cognito│              │ + Authorizer    │
+└─────────┘ └─────────┘ └─────────┘              └────────┬────────┘
+                                                          │
+                                       ┌──────────────────┼──────────────────┐
+                                       ▼                  ▼                  ▼
+                                  ┌─────────┐        ┌─────────┐        ┌─────────┐
+                                  │Server A │        │Server B │        │Server C │
+                                  │(no OAuth│        │(no OAuth│        │(no OAuth│
+                                  │ infra)  │        │ infra)  │        │ infra)  │
+                                  └─────────┘        └─────────┘        └─────────┘
+```
+
+### Shared Infrastructure Setup
+
+```bash
+# Initialize shared infrastructure (once per organization)
+$ cargo pmcp oauth infra init --shared --name acme-corp
+
+Creating shared OAuth infrastructure...
+  ✓ Cognito User Pool: us-west-2_AcmeCorp
+  ✓ OAuth Proxy Lambda: acme-corp-oauth-proxy
+  ✓ Authorizer Lambda: acme-corp-authorizer
+  ✓ ClientRegistrationTable: acme-corp-clients
+
+Configuration saved to ~/.pmcp/shared-oauth/acme-corp.toml
+
+# Individual servers use shared infra
+$ cargo pmcp deploy init --oauth shared:acme-corp
+
+Using shared OAuth infrastructure: acme-corp
+  ✓ Authorizer: acme-corp-authorizer
+  ✓ Adding resource server scopes: my-server/read, my-server/write
+```
+
+## Optional: pmcp-auth Middleware
+
+For servers that need user context in tools (defense-in-depth):
+
+```rust
+use pmcp::prelude::*;
+use pmcp_auth::{AuthContext, OAuthMiddleware};
+
+#[derive(McpServer)]
+struct MyServer {
+    auth: Option<OAuthMiddleware>,
+}
+
+impl MyServer {
+    fn new() -> Self {
+        Self {
+            // Auto-configures if OAUTH_* env vars present
+            auth: OAuthMiddleware::from_env().ok(),
+        }
+    }
+}
+
+#[tool]
+impl MyServer {
+    /// Tool that uses user context
+    #[tool(description = "Get user-specific data")]
+    async fn get_my_data(&self, ctx: &RequestContext) -> Result<UserData> {
+        if let Some(auth) = &self.auth {
+            let user = auth.validate(ctx.bearer_token()?).await?;
+
+            // Check scopes
+            user.require_scope("mcp/read")?;
+
+            // Use user context
+            let data = self.db.get_user_data(&user.user_id).await?;
+            Ok(data)
+        } else {
+            // No middleware = trust API Gateway validation
+            Ok(default_data())
+        }
+    }
+}
+```
+
+## Cost Estimate
+
+Per 1M MCP requests/month:
+
+| Component | Requests | Cost |
+|-----------|----------|------|
+| OAuth Proxy Lambda | ~10K (auth flows only) | ~$0.02 |
+| Token Validator Lambda | ~200K (cached 5min) | ~$0.40 |
+| MCP Server Lambda | 1M | ~$2.00 |
+| API Gateway | 1M | ~$3.50 |
+| DynamoDB (clients table) | ~10K R/W | ~$0.05 |
+| Cognito | 1K MAU | $0 (50K free) |
+| **Total** | | **~$6/month** |
+| **OAuth overhead** | | **~$0.50/month** |
+
+## Migration Path
+
+### Phase 1: Cognito + Lambda (Current)
+- OAuth Proxy Lambda
+- Token Validator Lambda Authorizer
+- DynamoDB ClientRegistrationTable
+- `cargo pmcp deploy init --oauth cognito`
+
+### Phase 2: pmcp-auth Crate
+- Optional in-server middleware
+- Defense-in-depth validation
+- User context extraction
+
+### Phase 3: AWS AgentCore (Future)
+- Replace OAuth Proxy with AgentCore Gateway
+- Keep DynamoDB (client registration persists)
+- Keep token format (JWT compatible)
+- MCP server code: ZERO changes
+
+### Phase 4: Multi-Platform (Future)
+- Cloudflare Workers: Edge JWT validation
+- Cloud Run: IAP or sidecar
+- Generic OIDC: Auth0, Okta, Azure AD
+
+## Reference Implementation
+
+See the Interactive Fiction Cloud project for a working example:
+- OAuth Proxy Lambda implementation
+- Token Validator Lambda Authorizer
+- Amplify backend configuration
+- DynamoDB table schema
+
+## Security Considerations
+
+1. **JWKS Caching**: 1-hour TTL prevents token validation failures
+2. **PKCE Required**: S256 code challenge for all clients
+3. **Short-lived Access Tokens**: 15-60 minute expiry
+4. **Stateless Validation**: No session database attack surface
+5. **Scope Enforcement**: Resource server scopes in Cognito
+6. **Client Auto-Detection**: Public clients don't receive secrets
+
+## FAQ
+
+**Q: Do I need to write OAuth code in my MCP server?**
+A: No. API Gateway + Lambda Authorizer handles all authentication. Your server just processes MCP requests.
+
+**Q: How do clients register?**
+A: MCP clients (Claude, ChatGPT, etc.) automatically register via Dynamic Client Registration when users add your server URL.
+
+**Q: Where are tokens stored?**
+A: Nowhere on the server side. Tokens are JWTs validated statelessly. MCP clients store their own tokens.
+
+**Q: How do I revoke a client?**
+A: Use the Cognito Console or AWS CLI to delete the app client. Or delete from ClientRegistrationTable.
+
+**Q: Can I use my own identity provider?**
+A: Future support for `--oauth oidc` with external providers (Auth0, Okta, etc.).

--- a/cargo-pmcp/docs/pmcp-run-oauth-design.md
+++ b/cargo-pmcp/docs/pmcp-run-oauth-design.md
@@ -1,0 +1,838 @@
+# pmcp.run Multi-Tenant OAuth Architecture
+
+## Overview
+
+This document describes the OAuth architecture for pmcp.run using AWS Lambda's new tenant isolation mode (announced November 2025). This approach enables shared OAuth infrastructure across all MCP servers while maintaining security isolation per server.
+
+## Goals
+
+1. **Simplify deployment**: Users only upload the MCP Server Lambda
+2. **Cost efficiency**: Share OAuth Lambdas across all pmcp.run servers
+3. **Security isolation**: Leverage Lambda tenant isolation for per-server data separation
+4. **Flexibility**: Support both per-server and shared Cognito User Pools
+
+## Architecture
+
+### Current State (without OAuth)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  pmcp.run Infrastructure                                        │
+│                                                                 │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐         │
+│  │ Server A    │    │ Server B    │    │ Server C    │         │
+│  │ Lambda      │    │ Lambda      │    │ Lambda      │         │
+│  └──────┬──────┘    └──────┬──────┘    └──────┬──────┘         │
+│         │                  │                  │                 │
+│         └──────────────────┼──────────────────┘                 │
+│                            │                                    │
+│                   ┌────────▼────────┐                           │
+│                   │  API Gateway    │                           │
+│                   │  (per server)   │                           │
+│                   └─────────────────┘                           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Proposed State (with Multi-Tenant OAuth)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  pmcp.run Infrastructure                                        │
+│                                                                 │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Shared OAuth Infrastructure                             │   │
+│  │                                                          │   │
+│  │  ┌────────────────────┐    ┌────────────────────┐       │   │
+│  │  │ OAuth Proxy Lambda │    │ Authorizer Lambda  │       │   │
+│  │  │ (PER_TENANT mode)  │    │ (PER_TENANT mode)  │       │   │
+│  │  │                    │    │                    │       │   │
+│  │  │ Tenants:           │    │ Tenants:           │       │   │
+│  │  │ - server-a         │    │ - server-a         │       │   │
+│  │  │ - server-b         │    │ - server-b         │       │   │
+│  │  │ - server-c         │    │ - server-c         │       │   │
+│  │  └────────────────────┘    └────────────────────┘       │   │
+│  │                                                          │   │
+│  │  ┌────────────────────────────────────────────┐         │   │
+│  │  │ ServerOAuthConfig (DynamoDB)               │         │   │
+│  │  │ ClientRegistration (DynamoDB)              │         │   │
+│  │  └────────────────────────────────────────────┘         │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐         │
+│  │ Server A    │    │ Server B    │    │ Server C    │         │
+│  │ Lambda      │    │ Lambda      │    │ Lambda      │         │
+│  └─────────────┘    └─────────────┘    └─────────────┘         │
+│                                                                 │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  API Gateway (shared, tenant-aware routing)              │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Lambda Tenant Isolation Mode
+
+AWS Lambda's tenant isolation mode (November 2025) provides:
+
+- **Per-tenant execution environments**: Each tenant gets isolated compute
+- **Memory/disk isolation**: Data cached in memory or `/tmp` is tenant-specific
+- **Warm start benefits**: Execution environments are reused within a tenant
+- **Automatic routing**: Lambda routes requests based on `X-Amz-Tenant-Id` header
+
+### Creating Tenant-Isolated Lambdas
+
+```bash
+# OAuth Proxy Lambda
+aws lambda create-function \
+  --function-name pmcp-run-oauth-proxy \
+  --runtime provided.al2023 \
+  --handler bootstrap \
+  --zip-file fileb://oauth-proxy.zip \
+  --role arn:aws:iam::ACCOUNT:role/pmcp-run-oauth-role \
+  --tenancy-config '{"TenantIsolationMode": "PER_TENANT"}'
+
+# Authorizer Lambda
+aws lambda create-function \
+  --function-name pmcp-run-authorizer \
+  --runtime provided.al2023 \
+  --handler bootstrap \
+  --zip-file fileb://authorizer.zip \
+  --role arn:aws:iam::ACCOUNT:role/pmcp-run-authorizer-role \
+  --tenancy-config '{"TenantIsolationMode": "PER_TENANT"}'
+```
+
+### Invoking with Tenant ID
+
+```bash
+# Via AWS CLI
+aws lambda invoke \
+  --function-name pmcp-run-oauth-proxy \
+  --tenant-id chess-server-abc123 \
+  response.json
+
+# Via API Gateway (automatic header injection)
+# X-Amz-Tenant-Id: chess-server-abc123
+```
+
+## Data Model
+
+### ServerOAuthConfig Table
+
+Stores OAuth configuration per MCP server.
+
+```
+Table: pmcp-run-server-oauth-config
+Partition Key: server_id (String)
+
+Attributes:
+┌─────────────────────┬─────────────────────────────────────────┐
+│ server_id           │ "chess-abc123" (PK)                     │
+│ user_pool_id        │ "eu-west-1_XyZ123"                      │
+│ user_pool_region    │ "eu-west-1"                             │
+│ oauth_enabled       │ true                                    │
+│ provider            │ "cognito"                               │
+│ scopes              │ ["openid", "email", "mcp/read"]         │
+│ dcr_enabled         │ true                                    │
+│ public_client_patterns │ ["claude", "cursor", "chatgpt"]      │
+│ shared_pool_name    │ null (or "org-main" if shared)          │
+│ created_at          │ 1701619200                              │
+│ updated_at          │ 1701619200                              │
+└─────────────────────┴─────────────────────────────────────────┘
+```
+
+### ClientRegistration Table
+
+Stores dynamically registered OAuth clients.
+
+```
+Table: pmcp-run-client-registration
+Partition Key: client_id (String)
+GSI: server_id-index (server_id -> client_id)
+
+Attributes:
+┌─────────────────────┬─────────────────────────────────────────┐
+│ client_id           │ "uuid-xxxx-xxxx" (PK)                   │
+│ server_id           │ "chess-abc123" (GSI)                    │
+│ client_name         │ "claude-desktop"                        │
+│ client_secret_hash  │ "sha256:xxxx" (null if public)          │
+│ redirect_uris       │ ["http://localhost:8080/callback"]      │
+│ grant_types         │ ["authorization_code", "refresh_token"] │
+│ response_types      │ ["code"]                                │
+│ scope               │ "openid email mcp/read"                 │
+│ is_public           │ true                                    │
+│ created_at          │ 1701619200                              │
+└─────────────────────┴─────────────────────────────────────────┘
+```
+
+## API Gateway Configuration
+
+### Route Structure
+
+All routes include the server ID for tenant routing:
+
+```
+Base URL: https://api.pmcp.run
+
+OAuth Routes (public, no auth required):
+  GET  /{serverId}/.well-known/openid-configuration
+  GET  /{serverId}/.well-known/oauth-authorization-server
+  POST /{serverId}/oauth2/register
+  GET  /{serverId}/oauth2/authorize
+  POST /{serverId}/oauth2/token
+  POST /{serverId}/oauth2/revoke
+
+MCP Routes (protected, requires valid token):
+  POST /{serverId}/mcp
+  POST /{serverId}/mcp/{proxy+}
+
+Health Check (public):
+  GET  /{serverId}/health
+```
+
+### Tenant ID Injection (CDK)
+
+```typescript
+import * as apigateway from 'aws-cdk-lib/aws-apigatewayv2';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+// Shared OAuth Proxy Lambda
+const oauthProxyLambda = lambda.Function.fromFunctionName(
+  this, 'OAuthProxy', 'pmcp-run-oauth-proxy'
+);
+
+// Integration with tenant ID mapping
+const oauthIntegration = new apigateway.HttpLambdaIntegration(
+  'OAuthIntegration',
+  oauthProxyLambda,
+  {
+    parameterMapping: new apigateway.ParameterMapping()
+      .custom('X-Amz-Tenant-Id', '$request.path.serverId'),
+  }
+);
+
+// OAuth discovery route
+httpApi.addRoutes({
+  path: '/{serverId}/.well-known/openid-configuration',
+  methods: [apigateway.HttpMethod.GET],
+  integration: oauthIntegration,
+});
+
+// OAuth register route
+httpApi.addRoutes({
+  path: '/{serverId}/oauth2/register',
+  methods: [apigateway.HttpMethod.POST],
+  integration: oauthIntegration,
+});
+
+// ... other OAuth routes
+```
+
+### Authorizer Configuration
+
+```typescript
+import * as authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
+
+// Shared Authorizer Lambda
+const authorizerLambda = lambda.Function.fromFunctionName(
+  this, 'Authorizer', 'pmcp-run-authorizer'
+);
+
+// Lambda authorizer with tenant ID
+const authorizer = new authorizers.HttpLambdaAuthorizer(
+  'TenantAuthorizer',
+  authorizerLambda,
+  {
+    authorizerName: 'pmcp-run-tenant-authorizer',
+    identitySource: [
+      '$request.header.Authorization',
+      '$request.path.serverId',  // Used for tenant routing
+    ],
+    responseTypes: [authorizers.HttpLambdaResponseType.SIMPLE],
+    resultsCacheTtl: cdk.Duration.seconds(300),
+  }
+);
+
+// MCP route with authorizer
+httpApi.addRoutes({
+  path: '/{serverId}/mcp',
+  methods: [apigateway.HttpMethod.POST],
+  integration: mcpIntegration,
+  authorizer: authorizer,
+});
+```
+
+## OAuth Proxy Lambda Implementation
+
+### Request Handler (Rust)
+
+```rust
+use lambda_http::{run, service_fn, Body, Error, Request, Response};
+use aws_sdk_dynamodb::Client as DynamoClient;
+
+// Tenant config is cached in memory (isolated per tenant by Lambda)
+static TENANT_CONFIG: OnceLock<ServerOAuthConfig> = OnceLock::new();
+
+async fn handler(event: Request, context: lambda_runtime::Context) -> Result<Response<Body>, Error> {
+    // Get tenant ID from Lambda context (injected by Lambda runtime)
+    let tenant_id = context.tenant_id
+        .ok_or_else(|| Error::from("Missing tenant ID"))?;
+
+    let path = event.uri().path();
+
+    // Load tenant config (cached in tenant-isolated memory)
+    let config = get_tenant_config(&tenant_id).await?;
+
+    match path {
+        p if p.ends_with("/.well-known/openid-configuration") => {
+            handle_oidc_discovery(&config).await
+        }
+        p if p.ends_with("/oauth2/register") => {
+            handle_client_registration(&config, &tenant_id, event).await
+        }
+        p if p.ends_with("/oauth2/authorize") => {
+            handle_authorize(&config, event).await
+        }
+        p if p.ends_with("/oauth2/token") => {
+            handle_token(&config, event).await
+        }
+        _ => Ok(Response::builder().status(404).body(Body::Empty)?)
+    }
+}
+
+async fn get_tenant_config(tenant_id: &str) -> Result<&'static ServerOAuthConfig, Error> {
+    // Check cache first (isolated per tenant!)
+    if let Some(config) = TENANT_CONFIG.get() {
+        return Ok(config);
+    }
+
+    // Load from DynamoDB
+    let dynamodb = get_dynamodb_client().await;
+    let result = dynamodb
+        .get_item()
+        .table_name("pmcp-run-server-oauth-config")
+        .key("server_id", AttributeValue::S(tenant_id.to_string()))
+        .send()
+        .await?;
+
+    let config = parse_config(result.item())?;
+    let _ = TENANT_CONFIG.set(config);
+
+    Ok(TENANT_CONFIG.get().unwrap())
+}
+```
+
+### OIDC Discovery Response
+
+```rust
+async fn handle_oidc_discovery(config: &ServerOAuthConfig) -> Result<Response<Body>, Error> {
+    let base_url = format!("https://api.pmcp.run/{}", config.server_id);
+    let cognito_issuer = format!(
+        "https://cognito-idp.{}.amazonaws.com/{}",
+        config.user_pool_region, config.user_pool_id
+    );
+
+    let discovery = serde_json::json!({
+        "issuer": cognito_issuer,
+        "authorization_endpoint": format!("{}/oauth2/authorize", base_url),
+        "token_endpoint": format!("{}/oauth2/token", base_url),
+        "registration_endpoint": format!("{}/oauth2/register", base_url),
+        "jwks_uri": format!("{}/.well-known/jwks.json", cognito_issuer),
+        "revocation_endpoint": format!("{}/oauth2/revoke", base_url),
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post", "none"],
+        "code_challenge_methods_supported": ["S256"],
+        "scopes_supported": config.scopes,
+    });
+
+    Ok(Response::builder()
+        .status(200)
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&discovery)?))?)
+}
+```
+
+## Authorizer Lambda Implementation
+
+### JWT Validation with Tenant Isolation
+
+```rust
+use jsonwebtoken::{decode, DecodingKey, Validation, Algorithm};
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+// JWKS cache - isolated per tenant by Lambda!
+static JWKS_CACHE: OnceLock<HashMap<String, DecodingKey>> = OnceLock::new();
+
+async fn handler(event: AuthorizerRequest, context: lambda_runtime::Context) -> Result<AuthorizerResponse, Error> {
+    let tenant_id = context.tenant_id
+        .ok_or_else(|| Error::from("Missing tenant ID"))?;
+
+    // Extract token
+    let token = extract_bearer_token(&event)?;
+
+    // Load tenant config (cached per tenant)
+    let config = get_tenant_config(&tenant_id).await?;
+
+    // Validate token (JWKS cached per tenant!)
+    match validate_token(&config, &token).await {
+        Ok(claims) => {
+            // Return allow policy with claims in context
+            Ok(AuthorizerResponse {
+                is_authorized: true,
+                context: HashMap::from([
+                    ("sub".to_string(), claims.sub),
+                    ("scope".to_string(), claims.scope),
+                    ("tenantId".to_string(), tenant_id),
+                ]),
+            })
+        }
+        Err(e) => {
+            tracing::warn!("Token validation failed for tenant {}: {}", tenant_id, e);
+            Ok(AuthorizerResponse {
+                is_authorized: false,
+                context: HashMap::new(),
+            })
+        }
+    }
+}
+
+async fn validate_token(config: &ServerOAuthConfig, token: &str) -> Result<Claims, Error> {
+    // Get or fetch JWKS (cached in tenant-isolated memory)
+    let jwks = get_jwks(config).await?;
+
+    // Decode and validate
+    let header = jsonwebtoken::decode_header(token)?;
+    let kid = header.kid.ok_or("No kid in token")?;
+    let key = jwks.get(&kid).ok_or("Unknown key ID")?;
+
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_issuer(&[format!(
+        "https://cognito-idp.{}.amazonaws.com/{}",
+        config.user_pool_region, config.user_pool_id
+    )]);
+
+    let token_data = decode::<Claims>(token, key, &validation)?;
+    Ok(token_data.claims)
+}
+```
+
+## Cognito User Pool Management
+
+### Per-Server Mode (Default)
+
+Each MCP server gets its own Cognito User Pool:
+
+```rust
+async fn create_user_pool_for_server(server_id: &str, region: &str) -> Result<String, Error> {
+    let cognito = get_cognito_client(region).await;
+
+    let result = cognito
+        .create_user_pool()
+        .pool_name(format!("pmcp-{}", server_id))
+        .auto_verified_attributes(VerifiedAttributeType::Email)
+        .username_attributes(UsernameAttributeType::Email)
+        .policies(UserPoolPolicyType::builder()
+            .password_policy(PasswordPolicyType::builder()
+                .minimum_length(8)
+                .require_lowercase(true)
+                .require_numbers(true)
+                .build())
+            .build())
+        .send()
+        .await?;
+
+    let user_pool_id = result.user_pool().unwrap().id().unwrap();
+
+    // Create resource server for MCP scopes
+    cognito
+        .create_resource_server()
+        .user_pool_id(user_pool_id)
+        .identifier("mcp")
+        .name("MCP Server")
+        .scopes(
+            ResourceServerScopeType::builder()
+                .scope_name("read")
+                .scope_description("Read access to MCP tools")
+                .build(),
+        )
+        .scopes(
+            ResourceServerScopeType::builder()
+                .scope_name("write")
+                .scope_description("Write access to MCP tools")
+                .build(),
+        )
+        .send()
+        .await?;
+
+    Ok(user_pool_id.to_string())
+}
+```
+
+### Shared Mode (Opt-in)
+
+Multiple servers share a User Pool:
+
+```rust
+async fn get_or_create_shared_pool(shared_name: &str, region: &str) -> Result<String, Error> {
+    let dynamodb = get_dynamodb_client().await;
+
+    // Check if shared pool exists
+    let result = dynamodb
+        .get_item()
+        .table_name("pmcp-run-shared-pools")
+        .key("pool_name", AttributeValue::S(shared_name.to_string()))
+        .send()
+        .await?;
+
+    if let Some(item) = result.item() {
+        return Ok(item.get("user_pool_id").unwrap().as_s().unwrap().to_string());
+    }
+
+    // Create new shared pool
+    let user_pool_id = create_shared_user_pool(shared_name, region).await?;
+
+    // Store reference
+    dynamodb
+        .put_item()
+        .table_name("pmcp-run-shared-pools")
+        .item("pool_name", AttributeValue::S(shared_name.to_string()))
+        .item("user_pool_id", AttributeValue::S(user_pool_id.clone()))
+        .item("region", AttributeValue::S(region.to_string()))
+        .send()
+        .await?;
+
+    Ok(user_pool_id)
+}
+```
+
+## GraphQL API Extensions
+
+### Schema Additions
+
+```graphql
+input OAuthConfigInput {
+  enabled: Boolean!
+  provider: String!  # "cognito"
+  sharedPoolName: String  # null for per-server, or "org-main" for shared
+  scopes: [String!]
+  dcrEnabled: Boolean
+  publicClientPatterns: [String!]
+}
+
+type OAuthEndpoints {
+  discoveryUrl: String!
+  registrationUrl: String!
+  authorizeUrl: String!
+  tokenUrl: String!
+  userPoolId: String!
+  userPoolRegion: String!
+}
+
+type DeploymentWithOAuth {
+  deploymentId: String!
+  status: String!
+  url: String
+  oauth: OAuthEndpoints
+}
+
+type Mutation {
+  # Extended deployment mutation with OAuth support
+  createDeploymentFromS3WithOAuth(
+    templateS3Key: String!
+    bootstrapS3Key: String!
+    serverName: String!
+    oauthConfig: OAuthConfigInput
+  ): DeploymentWithOAuth!
+
+  # Standalone OAuth configuration
+  configureOAuth(
+    serverId: String!
+    oauthConfig: OAuthConfigInput!
+  ): OAuthEndpoints!
+
+  # Disable OAuth for a server
+  disableOAuth(serverId: String!): Boolean!
+}
+
+type Query {
+  # Get OAuth configuration for a server
+  getOAuthConfig(serverId: String!): OAuthEndpoints
+
+  # List registered clients for a server
+  listOAuthClients(serverId: String!): [OAuthClient!]!
+}
+
+type OAuthClient {
+  clientId: String!
+  clientName: String!
+  isPublic: Boolean!
+  createdAt: String!
+}
+```
+
+### Resolver Implementation
+
+```typescript
+// createDeploymentFromS3WithOAuth resolver
+export async function createDeploymentFromS3WithOAuth(
+  _: any,
+  args: {
+    templateS3Key: string;
+    bootstrapS3Key: string;
+    serverName: string;
+    oauthConfig?: OAuthConfigInput;
+  },
+  context: Context
+): Promise<DeploymentWithOAuth> {
+  const { templateS3Key, bootstrapS3Key, serverName, oauthConfig } = args;
+  const userId = context.identity.sub;
+
+  // Generate server ID
+  const serverId = `${serverName}-${generateShortId()}`;
+
+  let oauthEndpoints: OAuthEndpoints | undefined;
+
+  if (oauthConfig?.enabled) {
+    // Create or get Cognito User Pool
+    const userPoolId = oauthConfig.sharedPoolName
+      ? await getOrCreateSharedPool(oauthConfig.sharedPoolName)
+      : await createUserPoolForServer(serverId);
+
+    // Store OAuth config
+    await dynamodb.put({
+      TableName: 'pmcp-run-server-oauth-config',
+      Item: {
+        server_id: serverId,
+        user_pool_id: userPoolId,
+        user_pool_region: process.env.AWS_REGION,
+        oauth_enabled: true,
+        provider: oauthConfig.provider,
+        scopes: oauthConfig.scopes || ['openid', 'email', 'mcp/read'],
+        dcr_enabled: oauthConfig.dcrEnabled ?? true,
+        public_client_patterns: oauthConfig.publicClientPatterns ||
+          ['claude', 'cursor', 'chatgpt', 'mcp-inspector'],
+        shared_pool_name: oauthConfig.sharedPoolName || null,
+        created_at: Date.now(),
+      },
+    }).promise();
+
+    // Build OAuth endpoints
+    const baseUrl = `https://api.pmcp.run/${serverId}`;
+    oauthEndpoints = {
+      discoveryUrl: `${baseUrl}/.well-known/openid-configuration`,
+      registrationUrl: `${baseUrl}/oauth2/register`,
+      authorizeUrl: `${baseUrl}/oauth2/authorize`,
+      tokenUrl: `${baseUrl}/oauth2/token`,
+      userPoolId,
+      userPoolRegion: process.env.AWS_REGION!,
+    };
+  }
+
+  // Create deployment (existing logic)
+  const deployment = await createDeployment({
+    userId,
+    serverId,
+    serverName,
+    templateS3Key,
+    bootstrapS3Key,
+    oauthEnabled: oauthConfig?.enabled ?? false,
+  });
+
+  return {
+    deploymentId: deployment.id,
+    status: deployment.status,
+    url: deployment.url,
+    oauth: oauthEndpoints,
+  };
+}
+```
+
+## Deployment Flow
+
+### From cargo-pmcp Perspective
+
+```bash
+# 1. Initialize with OAuth
+cargo pmcp deploy init --oauth cognito --target pmcp-run
+
+# 2. Deploy (only uploads MCP Server Lambda)
+cargo pmcp deploy --target pmcp-run
+
+# Output:
+# 🎉 Deployment successful!
+#
+# 📊 Deployment Details:
+#    Name: chess
+#    ID: chess-abc123
+#    URL: https://api.pmcp.run/chess-abc123/mcp
+#
+# 🔐 OAuth Endpoints:
+#    Discovery: https://api.pmcp.run/chess-abc123/.well-known/openid-configuration
+#    Register:  https://api.pmcp.run/chess-abc123/oauth2/register
+#    Authorize: https://api.pmcp.run/chess-abc123/oauth2/authorize
+#    Token:     https://api.pmcp.run/chess-abc123/oauth2/token
+#
+#    User Pool ID: eu-west-1_XyZ123
+```
+
+### Sequence Diagram
+
+```
+┌─────────┐     ┌───────────┐     ┌──────────┐     ┌─────────┐
+│cargo-   │     │pmcp.run   │     │Cognito   │     │DynamoDB │
+│pmcp     │     │Backend    │     │          │     │         │
+└────┬────┘     └─────┬─────┘     └────┬─────┘     └────┬────┘
+     │                │                │                │
+     │ deploy init    │                │                │
+     │ --oauth cognito│                │                │
+     │────────────────>                │                │
+     │                │                │                │
+     │ Upload Lambda  │                │                │
+     │ + OAuth config │                │                │
+     │────────────────>                │                │
+     │                │                │                │
+     │                │ Create User    │                │
+     │                │ Pool           │                │
+     │                │───────────────>│                │
+     │                │                │                │
+     │                │ user_pool_id   │                │
+     │                │<───────────────│                │
+     │                │                │                │
+     │                │ Store OAuth    │                │
+     │                │ config         │                │
+     │                │───────────────────────────────>│
+     │                │                │                │
+     │                │ Deploy MCP     │                │
+     │                │ Lambda         │                │
+     │                │ (existing flow)│                │
+     │                │                │                │
+     │ Deployment +   │                │                │
+     │ OAuth endpoints│                │                │
+     │<────────────────                │                │
+     │                │                │                │
+```
+
+## Security Considerations
+
+### Tenant Isolation
+
+1. **Execution Environment Isolation**: Lambda's `PER_TENANT` mode ensures each server's invocations run in isolated execution environments
+2. **Memory Isolation**: JWKS cache, tenant config, and any in-memory data is isolated per tenant
+3. **Disk Isolation**: Any files written to `/tmp` are isolated per tenant
+
+### Cognito Security
+
+1. **User Pool Isolation**: Per-server mode provides complete user isolation
+2. **Scope Enforcement**: MCP scopes (`mcp/read`, `mcp/write`) are enforced by the authorizer
+3. **Token Validation**: JWTs are validated against the correct User Pool for each tenant
+
+### API Gateway Security
+
+1. **Authorization**: All MCP routes require valid JWT tokens
+2. **Rate Limiting**: Apply per-tenant rate limits to prevent abuse
+3. **CORS**: Configure appropriate CORS headers per server
+
+## Monitoring and Observability
+
+### CloudWatch Logs
+
+With JSON logging enabled, Lambda includes `tenantId` in all logs:
+
+```json
+{
+  "timestamp": "2025-12-03T12:00:00.000Z",
+  "level": "INFO",
+  "message": "Processing OAuth request",
+  "tenantId": "chess-abc123",
+  "requestId": "xxx-xxx"
+}
+```
+
+### CloudWatch Queries
+
+```sql
+-- Find logs for a specific tenant
+fields @message
+| filter tenantId='chess-abc123' or record.tenantId='chess-abc123'
+| limit 1000
+
+-- Count requests per tenant
+fields tenantId
+| filter tenantId != ''
+| stats count() by tenantId
+| sort count desc
+```
+
+### Metrics
+
+Emit custom metrics per tenant:
+
+```rust
+cloudwatch.put_metric_data()
+    .namespace("pmcp-run/oauth")
+    .metric_data(
+        MetricDatum::builder()
+            .metric_name("TokenValidations")
+            .value(1.0)
+            .dimensions(
+                Dimension::builder()
+                    .name("TenantId")
+                    .value(&tenant_id)
+                    .build()
+            )
+            .build()
+    )
+    .send()
+    .await?;
+```
+
+## Implementation Checklist
+
+### Phase 1: Infrastructure Setup
+
+- [ ] Create `pmcp-run-server-oauth-config` DynamoDB table
+- [ ] Create `pmcp-run-client-registration` DynamoDB table
+- [ ] Create `pmcp-run-shared-pools` DynamoDB table (for shared Cognito)
+- [ ] Create IAM roles for OAuth Lambdas
+
+### Phase 2: Shared Lambda Deployment
+
+- [ ] Build OAuth Proxy Lambda (Rust)
+- [ ] Build Authorizer Lambda (Rust)
+- [ ] Deploy with `PER_TENANT` tenancy config
+- [ ] Test tenant isolation
+
+### Phase 3: API Gateway Integration
+
+- [ ] Update API Gateway routes for OAuth endpoints
+- [ ] Configure tenant ID injection from path parameter
+- [ ] Configure Lambda authorizer with tenant support
+- [ ] Test end-to-end OAuth flow
+
+### Phase 4: GraphQL API
+
+- [ ] Add `OAuthConfigInput` and related types
+- [ ] Implement `createDeploymentFromS3WithOAuth` resolver
+- [ ] Implement `configureOAuth` resolver
+- [ ] Implement `getOAuthConfig` query
+- [ ] Implement `listOAuthClients` query
+
+### Phase 5: Cognito Management
+
+- [ ] Implement per-server User Pool creation
+- [ ] Implement shared User Pool management
+- [ ] Implement resource server creation (MCP scopes)
+- [ ] Test User Pool lifecycle
+
+### Phase 6: cargo-pmcp Integration
+
+- [ ] Update GraphQL client to send OAuth config
+- [ ] Update deployment outputs to show OAuth endpoints
+- [ ] Update documentation
+
+## References
+
+- [AWS Lambda Tenant Isolation Mode](https://aws.amazon.com/blogs/compute/building-multi-tenant-saas-applications-with-aws-lambdas-new-tenant-isolation-mode/)
+- [MCP OAuth 2.1 Specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authentication/)
+- [RFC 7591 - Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591)
+- [AWS Cognito Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/)

--- a/cargo-pmcp/src/deployment/targets/aws_lambda/init.rs
+++ b/cargo-pmcp/src/deployment/targets/aws_lambda/init.rs
@@ -4,9 +4,17 @@ use anyhow::Result;
 /// Initialize AWS Lambda deployment (calls the original InitCommand)
 pub async fn init_aws_lambda(config: &DeployConfig) -> Result<()> {
     // Use the existing InitCommand from commands/deploy/init.rs
-    let init_cmd = crate::commands::deploy::init::InitCommand::new(config.project_root.clone())
+    let mut init_cmd = crate::commands::deploy::init::InitCommand::new(config.project_root.clone())
         .with_region(&config.aws.region)
         .with_credentials_check(true);
+
+    // Pass through OAuth configuration if enabled
+    if config.auth.enabled {
+        init_cmd = init_cmd.with_oauth_provider(&config.auth.provider);
+    }
+
+    // Pass through target type (for pmcp-run vs aws-lambda distinction)
+    init_cmd = init_cmd.with_target_type(&config.target.target_type);
 
     init_cmd.execute()
 }

--- a/cargo-pmcp/src/deployment/targets/pmcp_run/mod.rs
+++ b/cargo-pmcp/src/deployment/targets/pmcp_run/mod.rs
@@ -143,7 +143,16 @@ impl DeploymentTarget for PmcpRunTarget {
 
         // Call pmcp.run API to delete deployment
         let credentials = auth::get_credentials().await?;
-        graphql::delete_deployment(&credentials.access_token, &config.server.name).await?;
+
+        // First, find the deployment ID by project name
+        let deployment_id =
+            graphql::find_deployment_id_by_name(&credentials.access_token, &config.server.name)
+                .await?;
+
+        println!("   Found deployment: {}", deployment_id);
+
+        // Destroy the deployment (complete cleanup including CloudFormation stack)
+        graphql::destroy_deployment(&credentials.access_token, &deployment_id).await?;
 
         println!("✅ pmcp.run deployment destroyed successfully");
 

--- a/cargo-pmcp/src/templates/mod.rs
+++ b/cargo-pmcp/src/templates/mod.rs
@@ -1,5 +1,6 @@
 pub mod calculator;
 pub mod complete_calculator;
+pub mod oauth;
 pub mod server;
 pub mod server_common;
 pub mod sqlite_explorer;

--- a/cargo-pmcp/src/templates/oauth/authorizer.rs
+++ b/cargo-pmcp/src/templates/oauth/authorizer.rs
@@ -1,0 +1,259 @@
+//! JWT Authorizer Lambda template for validating tokens via JWKS.
+
+/// Returns the Rust source code for the Lambda Authorizer.
+/// This authorizer validates JWT tokens using JWKS from Cognito.
+pub fn get_authorizer_template(user_pool_id: &str, region: &str) -> String {
+    format!(
+        r#"//! JWT Authorizer Lambda for API Gateway.
+//!
+//! This Lambda validates JWT tokens using JWKS from Cognito.
+//! It returns an IAM policy allowing or denying the request.
+
+use lambda_runtime::{{service_fn, Error, LambdaEvent}};
+use serde::{{Deserialize, Serialize}};
+use serde_json::{{json, Value}};
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// JWKS URL for the Cognito User Pool.
+const JWKS_URL: &str = "https://cognito-idp.{region}.amazonaws.com/{user_pool_id}/.well-known/jwks.json";
+
+/// Expected issuer for token validation.
+const ISSUER: &str = "https://cognito-idp.{region}.amazonaws.com/{user_pool_id}";
+
+/// Cached JWKS for token validation.
+static JWKS_CACHE: OnceLock<JwksCache> = OnceLock::new();
+
+/// JWKS cache structure.
+struct JwksCache {{
+    keys: HashMap<String, jsonwebtoken::DecodingKey>,
+}}
+
+/// API Gateway authorizer request.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthorizerRequest {{
+    #[serde(rename = "type")]
+    request_type: String,
+    authorization_token: Option<String>,
+    headers: Option<HashMap<String, String>>,
+    method_arn: String,
+}}
+
+/// API Gateway authorizer response.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthorizerResponse {{
+    principal_id: String,
+    policy_document: PolicyDocument,
+    context: HashMap<String, Value>,
+}}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PolicyDocument {{
+    #[serde(rename = "Version")]
+    version: String,
+    #[serde(rename = "Statement")]
+    statement: Vec<Statement>,
+}}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Statement {{
+    #[serde(rename = "Action")]
+    action: String,
+    #[serde(rename = "Effect")]
+    effect: String,
+    #[serde(rename = "Resource")]
+    resource: String,
+}}
+
+/// JWT claims from Cognito.
+#[derive(Debug, Deserialize)]
+struct Claims {{
+    sub: String,
+    #[serde(default)]
+    scope: String,
+    #[serde(default)]
+    client_id: String,
+    iss: String,
+    token_use: String,
+    exp: u64,
+}}
+
+async fn handler(event: LambdaEvent<AuthorizerRequest>) -> Result<AuthorizerResponse, Error> {{
+    let request = event.payload;
+
+    // Extract token from Authorization header
+    let token = extract_token(&request)?;
+
+    // Validate token
+    match validate_token(&token).await {{
+        Ok(claims) => {{
+            // Build allow policy
+            let mut context = HashMap::new();
+            context.insert("sub".to_string(), json!(claims.sub));
+            context.insert("scope".to_string(), json!(claims.scope));
+            context.insert("clientId".to_string(), json!(claims.client_id));
+
+            Ok(AuthorizerResponse {{
+                principal_id: claims.sub,
+                policy_document: build_policy("Allow", &request.method_arn),
+                context,
+            }})
+        }}
+        Err(e) => {{
+            tracing::warn!("Token validation failed: {{}}", e);
+            // Return deny policy
+            Ok(AuthorizerResponse {{
+                principal_id: "unauthorized".to_string(),
+                policy_document: build_policy("Deny", &request.method_arn),
+                context: HashMap::new(),
+            }})
+        }}
+    }}
+}}
+
+fn extract_token(request: &AuthorizerRequest) -> Result<String, Error> {{
+    // Try authorization_token first (TOKEN type)
+    if let Some(token) = &request.authorization_token {{
+        return Ok(token.strip_prefix("Bearer ").unwrap_or(token).to_string());
+    }}
+
+    // Try headers (REQUEST type)
+    if let Some(headers) = &request.headers {{
+        if let Some(auth) = headers.get("authorization").or_else(|| headers.get("Authorization")) {{
+            return Ok(auth.strip_prefix("Bearer ").unwrap_or(auth).to_string());
+        }}
+    }}
+
+    Err("No authorization token found".into())
+}}
+
+async fn validate_token(token: &str) -> Result<Claims, Error> {{
+    // Get or fetch JWKS
+    let jwks = get_jwks().await?;
+
+    // Decode header to get kid
+    let header = jsonwebtoken::decode_header(token)?;
+    let kid = header.kid.ok_or("No kid in token header")?;
+
+    // Get decoding key for this kid
+    let key = jwks.keys.get(&kid).ok_or("Unknown key id")?;
+
+    // Validate token
+    let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
+    validation.set_issuer(&[ISSUER]);
+    validation.set_required_spec_claims(&["exp", "iss", "sub"]);
+
+    let token_data = jsonwebtoken::decode::<Claims>(token, key, &validation)?;
+    let claims = token_data.claims;
+
+    // Verify token_use is "access"
+    if claims.token_use != "access" {{
+        return Err("Invalid token_use".into());
+    }}
+
+    Ok(claims)
+}}
+
+async fn get_jwks() -> Result<&'static JwksCache, Error> {{
+    if let Some(cache) = JWKS_CACHE.get() {{
+        return Ok(cache);
+    }}
+
+    // Fetch JWKS
+    let client = reqwest::Client::new();
+    let response = client.get(JWKS_URL).send().await?;
+    let jwks: JwksResponse = response.json().await?;
+
+    // Parse keys
+    let mut keys = HashMap::new();
+    for key in jwks.keys {{
+        if key.kty == "RSA" && key.alg == "RS256" {{
+            if let (Some(n), Some(e)) = (&key.n, &key.e) {{
+                let decoding_key = jsonwebtoken::DecodingKey::from_rsa_components(n, e)?;
+                keys.insert(key.kid.clone(), decoding_key);
+            }}
+        }}
+    }}
+
+    let cache = JwksCache {{ keys }};
+
+    // Try to set the cache (race condition is fine, both values are equivalent)
+    let _ = JWKS_CACHE.set(cache);
+
+    Ok(JWKS_CACHE.get().unwrap())
+}}
+
+#[derive(Debug, Deserialize)]
+struct JwksResponse {{
+    keys: Vec<JwkKey>,
+}}
+
+#[derive(Debug, Deserialize)]
+struct JwkKey {{
+    kid: String,
+    kty: String,
+    alg: String,
+    n: Option<String>,
+    e: Option<String>,
+}}
+
+fn build_policy(effect: &str, resource: &str) -> PolicyDocument {{
+    // Parse resource to get the wildcard version
+    let resource_parts: Vec<&str> = resource.split('/').collect();
+    let wildcard_resource = if resource_parts.len() >= 2 {{
+        format!("{{}}/{{}}/{{}}/{{}}/{{}}", resource_parts[0], resource_parts[1], "*", "*", "*")
+    }} else {{
+        resource.to_string()
+    }};
+
+    PolicyDocument {{
+        version: "2012-10-17".to_string(),
+        statement: vec![Statement {{
+            action: "execute-api:Invoke".to_string(),
+            effect: effect.to_string(),
+            resource: wildcard_resource,
+        }}],
+    }}
+}}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {{
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    lambda_runtime::run(service_fn(handler)).await
+}}
+"#,
+        region = region,
+        user_pool_id = user_pool_id,
+    )
+}
+
+/// Returns the Cargo.toml for the authorizer Lambda.
+pub fn get_authorizer_cargo_toml(name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{name}-authorizer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lambda_runtime = "0.13"
+tokio = {{ version = "1", features = ["full"] }}
+serde = {{ version = "1.0", features = ["derive"] }}
+serde_json = "1.0"
+jsonwebtoken = "9"
+reqwest = {{ version = "0.12", default-features = false, features = ["json", "rustls-tls"] }}
+tracing = "0.1"
+tracing-subscriber = {{ version = "0.3", default-features = false, features = ["fmt"] }}
+"#,
+        name = name
+    )
+}

--- a/cargo-pmcp/src/templates/oauth/mod.rs
+++ b/cargo-pmcp/src/templates/oauth/mod.rs
@@ -1,0 +1,4 @@
+//! OAuth Lambda templates for deployment.
+
+pub mod authorizer;
+pub mod proxy;

--- a/cargo-pmcp/src/templates/oauth/proxy.rs
+++ b/cargo-pmcp/src/templates/oauth/proxy.rs
@@ -1,0 +1,468 @@
+//! OAuth Proxy Lambda template for handling OAuth flows with Cognito.
+
+/// Returns the Rust source code for the OAuth Proxy Lambda.
+/// This Lambda handles:
+/// - /.well-known/openid-configuration (OIDC discovery)
+/// - /oauth2/register (Dynamic Client Registration - RFC 7591)
+/// - /oauth2/authorize (Authorization endpoint - redirects to Cognito)
+/// - /oauth2/token (Token endpoint - proxies to Cognito)
+/// - /oauth2/revoke (Token revocation)
+///
+/// IMPORTANT: This template intentionally does NOT implement:
+/// - /.well-known/oauth-protected-resource (RFC 8707)
+///
+/// Reason: RFC 8707 can cause issues with clients like Claude Code that discover
+/// and validate the underlying Cognito provider, which may not support S256 PKCE.
+/// The OIDC discovery endpoint is sufficient for OAuth client discovery.
+pub fn get_proxy_template(user_pool_id: &str, region: &str, _server_name: &str) -> String {
+    format!(
+        r#"//! OAuth Proxy Lambda for MCP servers.
+//!
+//! Handles OAuth flows including Dynamic Client Registration (DCR).
+
+use lambda_http::{{run, service_fn, Body, Error, Request, Response}};
+use serde::{{Deserialize, Serialize}};
+use std::collections::HashMap;
+use std::env;
+
+/// Cognito User Pool configuration.
+const USER_POOL_ID: &str = "{user_pool_id}";
+const REGION: &str = "{region}";
+
+/// DynamoDB table for client registrations.
+fn get_table_name() -> String {{
+    env::var("CLIENT_TABLE_NAME").unwrap_or_else(|_| "ClientRegistrations".to_string())
+}}
+
+/// Get the deployment URL from environment.
+fn get_base_url() -> String {{
+    env::var("BASE_URL").unwrap_or_else(|_| "https://example.execute-api.{region}.amazonaws.com".to_string())
+}}
+
+/// OIDC Discovery metadata.
+#[derive(Debug, Serialize)]
+struct OidcDiscovery {{
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    registration_endpoint: String,
+    jwks_uri: String,
+    revocation_endpoint: String,
+    response_types_supported: Vec<String>,
+    grant_types_supported: Vec<String>,
+    token_endpoint_auth_methods_supported: Vec<String>,
+    code_challenge_methods_supported: Vec<String>,
+    scopes_supported: Vec<String>,
+}}
+
+/// DCR Request (RFC 7591).
+#[derive(Debug, Deserialize)]
+struct ClientRegistrationRequest {{
+    client_name: String,
+    #[serde(default)]
+    redirect_uris: Vec<String>,
+    #[serde(default)]
+    grant_types: Vec<String>,
+    #[serde(default)]
+    response_types: Vec<String>,
+    #[serde(default)]
+    scope: String,
+    #[serde(default)]
+    software_id: Option<String>,
+    #[serde(default)]
+    software_version: Option<String>,
+}}
+
+/// DCR Response (RFC 7591).
+#[derive(Debug, Serialize)]
+struct ClientRegistrationResponse {{
+    client_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_secret: Option<String>,
+    client_name: String,
+    redirect_uris: Vec<String>,
+    grant_types: Vec<String>,
+    response_types: Vec<String>,
+    scope: String,
+    client_id_issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_secret_expires_at: Option<u64>,
+}}
+
+/// Known public client patterns (no secret required).
+const PUBLIC_CLIENT_PATTERNS: &[&str] = &[
+    "claude",
+    "cursor",
+    "chatgpt",
+    "mcp-inspector",
+    "desktop",
+];
+
+fn is_public_client(client_name: &str) -> bool {{
+    let name_lower = client_name.to_lowercase();
+    PUBLIC_CLIENT_PATTERNS.iter().any(|p| name_lower.contains(p))
+}}
+
+/// Sanitize client name for Cognito compatibility.
+/// Cognito only accepts names matching [\w\s+=,.@-]+
+/// Characters like parentheses in "Claude Code (chess)" will cause registration to fail.
+fn sanitize_client_name(name: &str) -> String {{
+    name.chars()
+        .map(|c| match c {{
+            'a'..='z' | 'A'..='Z' | '0'..='9' | ' ' | '+' | '=' | ',' | '.' | '@' | '-' | '_' => c,
+            _ => '-'
+        }})
+        .collect()
+}}
+
+async fn handler(event: Request) -> Result<Response<Body>, Error> {{
+    let path = event.uri().path();
+    let method = event.method().as_str();
+
+    tracing::info!("OAuth Proxy: {{}} {{}}", method, path);
+
+    match (method, path) {{
+        // OIDC Discovery
+        ("GET", "/.well-known/openid-configuration") => {{
+            handle_oidc_discovery().await
+        }}
+
+        // Dynamic Client Registration
+        ("POST", "/oauth2/register") => {{
+            handle_client_registration(event).await
+        }}
+
+        // Authorization (redirect to Cognito)
+        ("GET", "/oauth2/authorize") => {{
+            handle_authorize(event).await
+        }}
+
+        // Token endpoint (proxy to Cognito)
+        ("POST", "/oauth2/token") => {{
+            handle_token(event).await
+        }}
+
+        // Token revocation
+        ("POST", "/oauth2/revoke") => {{
+            handle_revoke(event).await
+        }}
+
+        _ => {{
+            Ok(Response::builder()
+                .status(404)
+                .body(Body::from("Not found"))?)
+        }}
+    }}
+}}
+
+async fn handle_oidc_discovery() -> Result<Response<Body>, Error> {{
+    let base_url = get_base_url();
+    let cognito_domain = format!(
+        "https://cognito-idp.{{}}.amazonaws.com/{{}}",
+        REGION, USER_POOL_ID
+    );
+
+    let discovery = OidcDiscovery {{
+        issuer: cognito_domain.clone(),
+        authorization_endpoint: format!("{{}}/oauth2/authorize", base_url),
+        token_endpoint: format!("{{}}/oauth2/token", base_url),
+        registration_endpoint: format!("{{}}/oauth2/register", base_url),
+        jwks_uri: format!("{{}}/.well-known/jwks.json", cognito_domain),
+        revocation_endpoint: format!("{{}}/oauth2/revoke", base_url),
+        response_types_supported: vec!["code".to_string()],
+        grant_types_supported: vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ],
+        token_endpoint_auth_methods_supported: vec![
+            "client_secret_basic".to_string(),
+            "client_secret_post".to_string(),
+            "none".to_string(),
+        ],
+        code_challenge_methods_supported: vec!["S256".to_string()],
+        scopes_supported: vec![
+            "openid".to_string(),
+            "email".to_string(),
+            "profile".to_string(),
+            "mcp/read".to_string(),
+            "mcp/write".to_string(),
+        ],
+    }};
+
+    Ok(Response::builder()
+        .status(200)
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&discovery)?))?)
+}}
+
+async fn handle_client_registration(event: Request) -> Result<Response<Body>, Error> {{
+    // Parse request body
+    let body = match event.body() {{
+        Body::Text(s) => s.clone(),
+        Body::Binary(b) => String::from_utf8_lossy(b).to_string(),
+        Body::Empty => String::new(),
+    }};
+
+    let request: ClientRegistrationRequest = serde_json::from_str(&body)
+        .map_err(|e| Error::from(format!("Invalid request: {{}}", e)))?;
+
+    // Sanitize client name for Cognito compatibility
+    // Clients like "Claude Code (chess)" contain characters Cognito doesn't accept
+    let sanitized_name = sanitize_client_name(&request.client_name);
+    tracing::info!("Registering client: '{{}}' (sanitized: '{{}}')", request.client_name, sanitized_name);
+
+    // Generate client credentials
+    let client_id = uuid::Uuid::new_v4().to_string();
+    let is_public = is_public_client(&request.client_name); // Check against original name
+    let client_secret = if is_public {{
+        None
+    }} else {{
+        Some(uuid::Uuid::new_v4().to_string())
+    }};
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    // Store in DynamoDB
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let dynamodb = aws_sdk_dynamodb::Client::new(&config);
+
+    let mut item = HashMap::new();
+    item.insert(
+        "client_id".to_string(),
+        aws_sdk_dynamodb::types::AttributeValue::S(client_id.clone()),
+    );
+    item.insert(
+        "client_name".to_string(),
+        aws_sdk_dynamodb::types::AttributeValue::S(sanitized_name.clone()),
+    );
+    // Store original name for reference/debugging
+    item.insert(
+        "original_client_name".to_string(),
+        aws_sdk_dynamodb::types::AttributeValue::S(request.client_name.clone()),
+    );
+    if let Some(ref secret) = client_secret {{
+        // Hash the secret before storing
+        use sha2::{{Sha256, Digest}};
+        let mut hasher = Sha256::new();
+        hasher.update(secret.as_bytes());
+        let hash = format!("{{:x}}", hasher.finalize());
+        item.insert(
+            "client_secret_hash".to_string(),
+            aws_sdk_dynamodb::types::AttributeValue::S(hash),
+        );
+    }}
+    item.insert(
+        "redirect_uris".to_string(),
+        aws_sdk_dynamodb::types::AttributeValue::Ss(request.redirect_uris.clone()),
+    );
+    item.insert(
+        "created_at".to_string(),
+        aws_sdk_dynamodb::types::AttributeValue::N(now.to_string()),
+    );
+    item.insert(
+        "is_public".to_string(),
+        aws_sdk_dynamodb::types::AttributeValue::Bool(is_public),
+    );
+
+    dynamodb
+        .put_item()
+        .table_name(get_table_name())
+        .set_item(Some(item))
+        .send()
+        .await?;
+
+    // Build response (use sanitized name for Cognito compatibility)
+    let response = ClientRegistrationResponse {{
+        client_id,
+        client_secret,
+        client_name: sanitized_name,
+        redirect_uris: request.redirect_uris,
+        grant_types: if request.grant_types.is_empty() {{
+            vec!["authorization_code".to_string(), "refresh_token".to_string()]
+        }} else {{
+            request.grant_types
+        }},
+        response_types: if request.response_types.is_empty() {{
+            vec!["code".to_string()]
+        }} else {{
+            request.response_types
+        }},
+        scope: if request.scope.is_empty() {{
+            "openid email mcp/read".to_string()
+        }} else {{
+            request.scope
+        }},
+        client_id_issued_at: now,
+        client_secret_expires_at: None,
+    }};
+
+    Ok(Response::builder()
+        .status(201)
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&response)?))?)
+}}
+
+async fn handle_authorize(event: Request) -> Result<Response<Body>, Error> {{
+    // Get query parameters
+    let query = event.uri().query().unwrap_or("");
+    let params: HashMap<String, String> = url::form_urlencoded::parse(query.as_bytes())
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    // Validate client_id exists in DynamoDB
+    let client_id = params.get("client_id")
+        .ok_or_else(|| Error::from("Missing client_id"))?;
+
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let dynamodb = aws_sdk_dynamodb::Client::new(&config);
+
+    let result = dynamodb
+        .get_item()
+        .table_name(get_table_name())
+        .key("client_id", aws_sdk_dynamodb::types::AttributeValue::S(client_id.clone()))
+        .send()
+        .await?;
+
+    if result.item().is_none() {{
+        return Ok(Response::builder()
+            .status(400)
+            .body(Body::from("Invalid client_id"))?);
+    }}
+
+    // Build Cognito authorize URL
+    let cognito_domain = env::var("COGNITO_DOMAIN")
+        .unwrap_or_else(|_| format!("{{}}auth.{{}}.amazoncognito.com", USER_POOL_ID.split('_').next().unwrap_or(""), REGION));
+
+    let mut cognito_url = format!("https://{{}}/oauth2/authorize?", cognito_domain);
+    cognito_url.push_str(&format!("client_id={{}}", client_id));
+
+    if let Some(redirect_uri) = params.get("redirect_uri") {{
+        cognito_url.push_str(&format!("&redirect_uri={{}}", urlencoding::encode(redirect_uri)));
+    }}
+    if let Some(response_type) = params.get("response_type") {{
+        cognito_url.push_str(&format!("&response_type={{}}", response_type));
+    }}
+    if let Some(scope) = params.get("scope") {{
+        cognito_url.push_str(&format!("&scope={{}}", urlencoding::encode(scope)));
+    }}
+    if let Some(state) = params.get("state") {{
+        cognito_url.push_str(&format!("&state={{}}", urlencoding::encode(state)));
+    }}
+    if let Some(code_challenge) = params.get("code_challenge") {{
+        cognito_url.push_str(&format!("&code_challenge={{}}", code_challenge));
+    }}
+    if let Some(code_challenge_method) = params.get("code_challenge_method") {{
+        cognito_url.push_str(&format!("&code_challenge_method={{}}", code_challenge_method));
+    }}
+
+    Ok(Response::builder()
+        .status(302)
+        .header("Location", cognito_url)
+        .body(Body::Empty)?)
+}}
+
+async fn handle_token(event: Request) -> Result<Response<Body>, Error> {{
+    // Parse request body
+    let body = match event.body() {{
+        Body::Text(s) => s.clone(),
+        Body::Binary(b) => String::from_utf8_lossy(b).to_string(),
+        Body::Empty => String::new(),
+    }};
+
+    // Get Cognito token endpoint
+    let cognito_domain = env::var("COGNITO_DOMAIN")
+        .unwrap_or_else(|_| format!("{{}}auth.{{}}.amazoncognito.com", USER_POOL_ID.split('_').next().unwrap_or(""), REGION));
+    let token_url = format!("https://{{}}/oauth2/token", cognito_domain);
+
+    // Proxy to Cognito
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&token_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await?;
+
+    let status = response.status().as_u16();
+    let body = response.text().await?;
+
+    Ok(Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json")
+        .body(Body::from(body))?)
+}}
+
+async fn handle_revoke(event: Request) -> Result<Response<Body>, Error> {{
+    // Parse request body
+    let body = match event.body() {{
+        Body::Text(s) => s.clone(),
+        Body::Binary(b) => String::from_utf8_lossy(b).to_string(),
+        Body::Empty => String::new(),
+    }};
+
+    // Get Cognito revoke endpoint
+    let cognito_domain = env::var("COGNITO_DOMAIN")
+        .unwrap_or_else(|_| format!("{{}}auth.{{}}.amazoncognito.com", USER_POOL_ID.split('_').next().unwrap_or(""), REGION));
+    let revoke_url = format!("https://{{}}/oauth2/revoke", cognito_domain);
+
+    // Proxy to Cognito
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&revoke_url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await?;
+
+    let status = response.status().as_u16();
+
+    Ok(Response::builder()
+        .status(status)
+        .body(Body::Empty)?)
+}}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {{
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    run(service_fn(handler)).await
+}}
+"#,
+        user_pool_id = user_pool_id,
+        region = region,
+    )
+}
+
+/// Returns the Cargo.toml for the OAuth Proxy Lambda.
+pub fn get_proxy_cargo_toml(name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{name}-oauth-proxy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lambda_http = "0.14"
+tokio = {{ version = "1", features = ["full"] }}
+serde = {{ version = "1.0", features = ["derive"] }}
+serde_json = "1.0"
+uuid = {{ version = "1", features = ["v4"] }}
+sha2 = "0.10"
+url = "2.5"
+urlencoding = "2.1"
+aws-config = "1.5"
+aws-sdk-dynamodb = "1.56"
+reqwest = {{ version = "0.12", default-features = false, features = ["json", "rustls-tls"] }}
+tracing = "0.1"
+tracing-subscriber = {{ version = "0.3", default-features = false, features = ["fmt"] }}
+"#,
+        name = name
+    )
+}

--- a/docs/OAUTH_DEBUGGING_GUIDE.md
+++ b/docs/OAUTH_DEBUGGING_GUIDE.md
@@ -1,0 +1,273 @@
+# OAuth Debugging Guide for pmcp.run MCP Servers
+
+This guide explains how to use the `mcp-tester` tool to debug OAuth authentication issues with MCP servers deployed to pmcp.run.
+
+## Prerequisites
+
+1. **Build the mcp-tester tool:**
+   ```bash
+   cd ~/Development/mcp/sdk/rust-mcp-sdk
+   cargo build --release -p mcp-server-tester
+   ```
+
+2. **Ensure you have an OAuth client ID** from your Cognito User Pool (created during `cargo pmcp deploy --oauth`)
+
+## Quick Start
+
+### Test OAuth-Protected Server (Auto-Discovery)
+
+The mcp-tester can automatically discover OAuth endpoints from your server:
+
+```bash
+# The tool auto-discovers OAuth configuration from the server
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID
+```
+
+This will:
+1. Discover OAuth endpoints from `https://api.pmcp.run/chess/.well-known/openid-configuration`
+2. Open a browser for Cognito login
+3. Cache the token for future requests
+4. Test the server connection
+
+### Test with Explicit OAuth Issuer
+
+If auto-discovery fails, specify the issuer explicitly:
+
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --oauth-issuer https://cognito-idp.us-east-1.amazonaws.com/YOUR_USER_POOL_ID
+```
+
+## Authentication Flows
+
+### 1. Authorization Code Flow with PKCE (Default)
+
+The tool uses the Authorization Code Flow with PKCE, which:
+- Opens a browser for user login
+- Starts a local callback server on `http://localhost:8080/callback`
+- Exchanges the authorization code for tokens
+
+```bash
+# Use a different callback port if 8080 is in use
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --oauth-redirect-port 3000
+```
+
+**Important**: The redirect URI (`http://localhost:8080/callback`) must be registered in your Cognito User Pool App Client settings.
+
+### 2. Device Code Flow (Fallback)
+
+If the authorization code flow fails, the tool automatically falls back to device code flow (if supported by the server).
+
+## Common Commands
+
+### Quick Connectivity Test
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID
+```
+
+### Full Test Suite
+```bash
+./target/release/mcp-tester test https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --with-tools
+```
+
+### List Available Tools
+```bash
+./target/release/mcp-tester tools https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID
+```
+
+### Test a Specific Tool
+```bash
+./target/release/mcp-tester test https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --tool make_move \
+  --args '{"move": "e2e4"}'
+```
+
+### Health Check
+```bash
+./target/release/mcp-tester health https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID
+```
+
+### Connection Diagnostics
+```bash
+./target/release/mcp-tester diagnose https://api.pmcp.run/chess/mcp \
+  --network
+```
+
+## Token Caching
+
+By default, tokens are cached at `~/.mcp-tester/tokens.json`. To disable caching:
+
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --oauth-no-cache
+```
+
+To clear the cache manually:
+```bash
+rm ~/.mcp-tester/tokens.json
+```
+
+## Environment Variables
+
+You can set OAuth configuration via environment variables:
+
+```bash
+export MCP_OAUTH_CLIENT_ID="your-client-id"
+export MCP_OAUTH_ISSUER="https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xxxxx"
+export MCP_OAUTH_SCOPES="openid,profile,email"
+export MCP_OAUTH_REDIRECT_PORT=8080
+
+# Then run without flags
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp
+```
+
+## OAuth Scopes
+
+Default scope is `openid`. Add additional scopes if needed:
+
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --oauth-scopes openid,mcp:read,mcp:write
+```
+
+## Debugging Tips
+
+### 1. Check OAuth Discovery
+
+First verify the OAuth discovery endpoint is working:
+
+```bash
+curl https://api.pmcp.run/chess/.well-known/openid-configuration | jq
+```
+
+Expected response:
+```json
+{
+  "issuer": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xxxxx",
+  "authorization_endpoint": "https://xxx.auth.us-east-1.amazoncognito.com/oauth2/authorize",
+  "token_endpoint": "https://xxx.auth.us-east-1.amazoncognito.com/oauth2/token",
+  ...
+}
+```
+
+### 2. Verbose Mode
+
+Enable verbose logging to see detailed OAuth flow:
+
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  -v    # verbosity level 1
+```
+
+Or with maximum verbosity:
+```bash
+RUST_LOG=debug ./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID
+```
+
+### 3. Check Token Manually
+
+After authentication, inspect the cached token:
+
+```bash
+cat ~/.mcp-tester/tokens.json | jq
+```
+
+### 4. Test Token Validity
+
+Make a manual request with the token:
+
+```bash
+TOKEN=$(cat ~/.mcp-tester/tokens.json | jq -r '.access_token')
+curl -H "Authorization: Bearer $TOKEN" https://api.pmcp.run/chess/mcp
+```
+
+### 5. Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Failed to bind to localhost:8080` | Port in use | Use `--oauth-redirect-port 3000` |
+| `redirect_uri_mismatch` | Callback not registered | Add `http://localhost:8080/callback` to Cognito App Client |
+| `invalid_client` | Wrong client ID | Check Client ID in Cognito console |
+| `OAuth discovery failed` | Server not OAuth-enabled | Run `cargo pmcp oauth enable <server-id>` |
+
+## Output Formats
+
+### Pretty (Default)
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --format pretty
+```
+
+### JSON (for CI/CD)
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --format json
+```
+
+### Minimal
+```bash
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id YOUR_CLIENT_ID \
+  --format minimal
+```
+
+## Finding Your OAuth Client ID
+
+After deploying with OAuth, the client ID is stored in the deployment outputs:
+
+```bash
+# From deployment output
+cargo pmcp deploy --target pmcp-run --oauth
+
+# Or check the Cognito console:
+# AWS Console > Cognito > User Pools > [Your Pool] > App clients
+```
+
+## Example: Full Debugging Session
+
+```bash
+# 1. Build the tester
+cd ~/Development/mcp/sdk/rust-mcp-sdk
+cargo build --release -p mcp-server-tester
+
+# 2. Check if server is deployed
+curl -I https://api.pmcp.run/chess/health
+
+# 3. Check OAuth discovery
+curl https://api.pmcp.run/chess/.well-known/openid-configuration | jq
+
+# 4. Run quick test (this will prompt for login)
+./target/release/mcp-tester quick https://api.pmcp.run/chess/mcp \
+  --oauth-client-id 1abc2def3ghi4jkl5mno6pqr7s
+
+# 5. If successful, run full test suite
+./target/release/mcp-tester test https://api.pmcp.run/chess/mcp \
+  --oauth-client-id 1abc2def3ghi4jkl5mno6pqr7s \
+  --with-tools
+
+# 6. Test specific tool
+./target/release/mcp-tester test https://api.pmcp.run/chess/mcp \
+  --oauth-client-id 1abc2def3ghi4jkl5mno6pqr7s \
+  --tool get_board
+```
+
+## See Also
+
+- [pmcp.run OAuth Documentation](../pmcp-run/docs/OAUTH_SDK_INTEGRATION_ANSWERS.md)
+- [cargo-pmcp OAuth Commands](../cargo-pmcp/docs/COMMANDS.md)


### PR DESCRIPTION
## Summary

- Add comprehensive OAuth support for MCP servers deployed to pmcp.run
- OAuth proxy Lambda template with Dynamic Client Registration (RFC 7591)
- Client name sanitization for Cognito compatibility (fixes Claude Code "(project)" name issue)
- Integration with pmcp.run shared API Gateway architecture
- New `cargo pmcp oauth` commands for managing OAuth settings
- Complete deployment cleanup with `destroyDeployment` mutation
- Stable serverId-based URLs from server response

## Key Fixes for Claude Code Compatibility

- **P0**: Intentionally omit RFC 8707 `oauth-protected-resource` endpoint that caused validation issues
- **P1**: Sanitize client names containing special characters (parentheses, brackets, etc.) for Cognito

## Test plan

- [ ] Deploy MCP server with OAuth enabled via `cargo pmcp deploy --target pmcp-run`
- [ ] Verify OAuth discovery at `/.well-known/openid-configuration`
- [ ] Test Dynamic Client Registration from Claude Code
- [ ] Verify token exchange and MCP server access
- [ ] Test destroy with `cargo pmcp deploy destroy --target pmcp-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)