### PR TITLE
fix: Add HTTPS support to StreamableHttpTransport (v1.9.3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.9.2"
+version = "1.9.3"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"
@@ -56,6 +56,8 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tokio-tungstenite = { version = "0.28", optional = true }
 hyper = { version = "1.6", features = ["full"], optional = true }
 hyper-util = { version = "0.1", features = ["full"], optional = true }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "tls12", "ring", "native-tokio"], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 axum = { version = "0.8.5", optional = true }
 
 # File watching dependencies (optional, feature-gated)
@@ -113,7 +115,7 @@ jwt-auth = ["dep:jsonwebtoken"]
 sse = ["dep:bytes"]
 websocket = ["dep:tokio-tungstenite"]
 http = ["dep:hyper", "dep:hyper-util", "dep:bytes"]
-streamable-http = ["dep:hyper", "dep:hyper-util", "dep:futures-util", "dep:bytes", "dep:axum"]
+streamable-http = ["dep:hyper", "dep:hyper-util", "dep:hyper-rustls", "dep:rustls", "dep:futures-util", "dep:bytes", "dep:axum"]
 validation = ["dep:jsonschema", "dep:garde"]
 resource-watcher = ["dep:notify", "dep:glob-match"]
 schema-generation = ["dep:schemars"]


### PR DESCRIPTION
## Summary
- Fixes HTTPS connectivity for `StreamableHttpTransport` which was broken after hyper migration
- Bumps version to 1.9.3
- Adds `hyper-rustls` and `rustls` dependencies with ring crypto provider
- Uses `default-features = false` on hyper-rustls to avoid aws-lc-rs (OpenSSL license issue)

## Problem
The migration to hyper in commit 9eda4dc used `HttpConnector` which only supports HTTP, not HTTPS. This broke HTTPS connectivity for MCP clients using `StreamableHttpTransport`.

## Solution
- Add hyper-rustls and rustls dependencies with ring crypto provider
- Replace `HttpConnector` with `HttpsConnector` via `HttpsConnectorBuilder`
- Install ring crypto provider explicitly for AWS Lambda compatibility
- Support both HTTP and HTTPS URLs (`https_or_http`)
- Enable HTTP/1.1 and HTTP/2

## Note: Observability Module
This PR is based on `upstream/main` which includes the observability module from PR #151. The observability code is intact.

## Test plan
- [x] `make test` - 1074 tests passed (including observability tests)
- [x] `make quality-gate` - All checks passed (including `61_observability_middleware` example)
- [x] Verified `aws-lc-rs` is NOT in dependency tree (license compliance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)