### PR TITLE
fix: downgrade cargo_metadata for Rust 1.82+ cargo install compatibility

### DIFF
--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -27,7 +27,7 @@ mcp-preview = { version = "0.1.0", path = "../crates/mcp-preview" }
 urlencoding = "2"
 async-trait = "0.1.89"
 pathdiff = "0.2.3"
-cargo_metadata = "0.23"
+cargo_metadata = "0.19"
 
 # For pmcp-run target and landing pages
 oauth2 = "5.0"                          # OAuth 2.0 authentication

--- a/crates/mcp-tester/src/main.rs
+++ b/crates/mcp-tester/src/main.rs
@@ -726,6 +726,7 @@ async fn run_prompts_test(
     tester.run_prompts_discovery().await
 }
 
+#[allow(dead_code)]
 async fn run_diagnostics(
     url: &str,
     network: bool,

--- a/crates/mcp-tester/src/tester.rs
+++ b/crates/mcp-tester/src/tester.rs
@@ -21,6 +21,7 @@ use crate::validators::Validator;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ToolUIInfo {
     pub tool_name: String,
     pub ui_resource_uri: String,
@@ -73,6 +74,7 @@ pub struct ServerTester {
     http_middleware_chain:
         Option<std::sync::Arc<pmcp::client::http_middleware::HttpMiddlewareChain>>,
     // UI information for tools with associated UIs
+    #[allow(dead_code)]
     tool_uis: HashMap<String, ToolUIInfo>,
 }
 
@@ -469,6 +471,7 @@ impl ServerTester {
         self.run_tools_discovery_with_verbose(test_all, false).await
     }
 
+    #[allow(dead_code)]
     pub async fn run_resources_discovery(&mut self) -> Result<TestReport> {
         self.run_resources_discovery_with_verbose(false).await
     }
@@ -2809,6 +2812,7 @@ impl ServerTester {
     }
 
     /// Detect tools with UI metadata and extract UI resource URIs
+    #[allow(dead_code)]
     pub async fn discover_tool_uis(&mut self) -> Result<Vec<ToolUIInfo>> {
         let mut ui_tools = Vec::new();
 
@@ -2831,6 +2835,7 @@ impl ServerTester {
     }
 
     /// Fetch UI resource content for a given URI
+    #[allow(dead_code)]
     pub async fn fetch_ui_resource(&mut self, uri: &str) -> Result<String> {
         use pmcp::types::Content;
 
@@ -2859,6 +2864,7 @@ impl ServerTester {
     }
 
     /// Discover and fetch all tool UIs
+    #[allow(dead_code)]
     pub async fn load_all_tool_uis(&mut self) -> Result<()> {
         let ui_tools = self.discover_tool_uis().await?;
 
@@ -2881,11 +2887,13 @@ impl ServerTester {
     }
 
     /// Get UI information for all tools
+    #[allow(dead_code)]
     pub fn get_tool_uis(&self) -> &HashMap<String, ToolUIInfo> {
         &self.tool_uis
     }
 
     /// Render a tool's UI to an HTML file
+    #[allow(dead_code)]
     pub fn render_tool_ui(&self, tool_name: &str, output_path: &str) -> Result<()> {
         let ui_info = self
             .tool_uis
@@ -2915,6 +2923,7 @@ impl ServerTester {
     }
 
     /// Wrap HTML with postMessage bridge for MCP communication
+    #[allow(dead_code)]
     fn wrap_with_postmessage_bridge(&self, original_html: &str) -> String {
         let html_base64 = base64::Engine::encode(
             &base64::engine::general_purpose::STANDARD,


### PR DESCRIPTION
## Summary
- Downgrade `cargo_metadata` from 0.23 to 0.19 in cargo-pmcp to fix `cargo install cargo-pmcp` failing on Rust < 1.88
- Suppress dead_code warnings in mcp-tester for UI methods not yet wired up

## Problem
`cargo install cargo-pmcp` fails on Rust 1.83 (and anything below 1.88) because `cargo_metadata 0.23` transitively depends on `cargo-platform v0.3.2` which requires `edition2024` (Rust 1.88+):

```
error: feature `edition2024` is required
The package requires the Cargo feature called `edition2024`, but that feature is
not stabilized in this version of Cargo (1.83.0)
```

## Fix
`cargo_metadata 0.19` (MSRV 1.78) provides the same `MetadataCommand` and `TargetKind::Bin` API we use, with no edition2024 dependency.

## Test plan
- [x] `make test` - 1105 tests passed
- [x] `make quality-gate` - all checks passed (except pre-existing atty advisory)
- [x] `cargo build -p cargo-pmcp` - compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)