### PR TITLE
chore: release v1.10.2 - CI/CD client credentials support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/crates/mcp-tester/Cargo.toml
+++ b/crates/mcp-tester/Cargo.toml
@@ -18,7 +18,7 @@ name = "mcp-tester"
 path = "src/main.rs"
 
 [dependencies]
-pmcp = { version = "1.10.1", path = "../../", features = ["streamable-http"] }
+pmcp = { version = "1.10.2", path = "../../", features = ["streamable-http"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }

--- a/pmcp-macros/Cargo.toml
+++ b/pmcp-macros/Cargo.toml
@@ -24,7 +24,7 @@ darling = "0.23"
 heck = "0.5"
 
 [dev-dependencies]
-pmcp = { version = "1.10.1", path = "..", features = ["full"] }
+pmcp = { version = "1.10.2", path = "..", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = "1.0"


### PR DESCRIPTION
## Summary

Version bump for v1.10.2 release with CI/CD client credentials support.

## Version Changes

| Crate | Old | New |
|-------|-----|-----|
| pmcp | 1.10.1 | 1.10.2 |
| cargo-pmcp | 0.1.0 | 0.1.1 |

## Highlights

**cargo-pmcp 0.1.1** adds OAuth 2.0 client credentials flow for CI/CD deployments:
- `PMCP_CLIENT_ID` + `PMCP_CLIENT_SECRET` environment variables
- Works with GitHub Actions, GitLab CI, AWS CodeBuild
- No interactive login required for automated deployments

## Test plan
- [x] `make test` - 1105 tests passed
- [x] `make quality-gate` - all checks passed (except pre-existing atty advisory)

## After merge
Tag `v1.10.2` will trigger the release workflow to publish to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)