### PR TITLE
chore: bump versions for v1.10.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.10.2"
+version = "1.10.3"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/crates/mcp-tester/Cargo.toml
+++ b/crates/mcp-tester/Cargo.toml
@@ -18,7 +18,7 @@ name = "mcp-tester"
 path = "src/main.rs"
 
 [dependencies]
-pmcp = { version = "1.10.2", path = "../../", features = ["streamable-http"] }
+pmcp = { version = "1.10.3", path = "../../", features = ["streamable-http"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }

--- a/pmcp-macros/Cargo.toml
+++ b/pmcp-macros/Cargo.toml
@@ -24,7 +24,7 @@ darling = "0.23"
 heck = "0.5"
 
 [dev-dependencies]
-pmcp = { version = "1.10.2", path = "..", features = ["full"] }
+pmcp = { version = "1.10.3", path = "..", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = "1.0"

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/paiml/rust-mcp-sdk",
     "source": "github"
   },
-  "version": "1.10.2",
+  "version": "1.10.3",
   "installInstructions": "Install via Cargo: cargo install pmcp",
   "homepage": "https://github.com/paiml/rust-mcp-sdk",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump `pmcp` crate version from 1.10.2 to 1.10.3
- Update dependency references in `pmcp-macros` and `mcp-tester`
- Update `server.json` registry metadata

## Changes in v1.10.3
- fix: parse proxy header groups as JSON array instead of string (#170)
- fix: update MCP Registry schema to 2025-12-11

## Test plan
- [x] `cargo check` passes with new version
- [x] All tests and quality gates verified in #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)