### PR TITLE
fix: crates.io publish + bump to v1.11.2/v0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,15 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: |
         echo "Publishing pmcp..."
-        cargo publish -p pmcp || echo "pmcp already published or unchanged, continuing..."
+        OUTPUT=$(cargo publish -p pmcp 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp"
+            exit 1
+          fi
+        }
 
     - name: Wait for crates.io to index pmcp
       run: sleep 30
@@ -90,14 +98,30 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: |
         echo "Publishing mcp-tester..."
-        cargo publish -p mcp-tester || echo "mcp-tester already published or unchanged, continuing..."
+        OUTPUT=$(cargo publish -p mcp-tester 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "mcp-tester already published, continuing..."
+          else
+            echo "::error::Failed to publish mcp-tester"
+            exit 1
+          fi
+        }
 
     - name: Publish pmcp-widget-utils
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: |
         echo "Publishing pmcp-widget-utils..."
-        cargo publish -p pmcp-widget-utils || echo "pmcp-widget-utils already published or unchanged, continuing..."
+        OUTPUT=$(cargo publish -p pmcp-widget-utils 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-widget-utils already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-widget-utils"
+            exit 1
+          fi
+        }
 
     - name: Wait for crates.io to index pmcp-widget-utils
       run: sleep 30
@@ -107,7 +131,15 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: |
         echo "Publishing mcp-preview..."
-        cargo publish -p mcp-preview || echo "mcp-preview already published or unchanged, continuing..."
+        OUTPUT=$(cargo publish -p mcp-preview 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "mcp-preview already published, continuing..."
+          else
+            echo "::error::Failed to publish mcp-preview"
+            exit 1
+          fi
+        }
 
     - name: Wait for crates.io to index mcp-tester and mcp-preview
       run: sleep 30
@@ -117,7 +149,15 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       run: |
         echo "Publishing cargo-pmcp..."
-        cargo publish -p cargo-pmcp || echo "cargo-pmcp already published or unchanged, continuing..."
+        OUTPUT=$(cargo publish -p cargo-pmcp 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "cargo-pmcp already published, continuing..."
+          else
+            echo "::error::Failed to publish cargo-pmcp"
+            exit 1
+          fi
+        }
 
   publish-mcp:
     name: Publish to MCP Registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.11.1"
+version = "1.11.2"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"
@@ -59,7 +59,7 @@ parking_lot = "0.12"
 dashmap = "6.1"
 bytes = { version = "1.10", optional = true }
 futures = "0.3"
-pmcp-widget-utils = { path = "crates/pmcp-widget-utils" }
+pmcp-widget-utils = { path = "crates/pmcp-widget-utils", version = "0.1.0" }
 futures-util = { version = "0.3", optional = true }
 futures-channel = { version = "0.3", optional = true }
 futures-locks = { version = "0.7", optional = true, default-features = false }

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"
@@ -33,7 +33,7 @@ glob = "0.3"
 hdrhistogram = "7.5"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-pmcp = { version = "1.11.1", path = "..", features = ["streamable-http", "oauth"] }
+pmcp = { version = "1.11.2", path = "..", features = ["streamable-http", "oauth"] }
 mcp-tester = { version = "0.2.0", path = "../crates/mcp-tester" }
 mcp-preview = { version = "0.1.1", path = "../crates/mcp-preview" }
 urlencoding = "2"


### PR DESCRIPTION
## Summary
- **Root cause**: `pmcp-widget-utils` dependency in `Cargo.toml` had `path` only, no `version` — `cargo publish` requires both for path dependencies
- **Impact**: v1.11.1 and cargo-pmcp v0.3.0 never published to crates.io (the `|| echo "already published..."` pattern in the release workflow silently swallowed the error)
- **Fix**: Add `version = "0.1.0"` to the dependency, bump to v1.11.2/v0.3.1, and fix the release workflow to only skip actual "already exists" errors

## Changes
1. `Cargo.toml`: Add version to `pmcp-widget-utils` dep, bump pmcp to v1.11.2
2. `cargo-pmcp/Cargo.toml`: Bump to v0.3.1, update pmcp dep to v1.11.2
3. `.github/workflows/release.yml`: Replace `|| echo` with proper error handling that only skips "already exists" errors

## Test plan
- [x] `cargo check -p pmcp -p cargo-pmcp` passes
- [ ] After merge, tag v1.11.2 and verify Release workflow publishes successfully to crates.io
- [ ] Verify `cargo install cargo-pmcp` installs v0.3.1 with `loadtest upload` subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)