### PR TITLE
chore: bump to v1.11.3/v0.3.2 for crates.io release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.11.2"
+version = "1.11.3"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"
@@ -33,7 +33,7 @@ glob = "0.3"
 hdrhistogram = "7.5"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-pmcp = { version = "1.11.2", path = "..", features = ["streamable-http", "oauth"] }
+pmcp = { version = "1.11.3", path = "..", features = ["streamable-http", "oauth"] }
 mcp-tester = { version = "0.2.1", path = "../crates/mcp-tester" }
 mcp-preview = { version = "0.1.1", path = "../crates/mcp-preview" }
 urlencoding = "2"

--- a/crates/mcp-tester/Cargo.toml
+++ b/crates/mcp-tester/Cargo.toml
@@ -18,7 +18,7 @@ name = "mcp-tester"
 path = "src/main.rs"
 
 [dependencies]
-pmcp = { version = "1.11.2", path = "../../", features = ["streamable-http", "oauth"] }
+pmcp = { version = "1.11.3", path = "../../", features = ["streamable-http", "oauth"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
Version bump to trigger a clean release after fixing the publish chain in PR #183.

- pmcp: v1.11.2 → v1.11.3
- cargo-pmcp: v0.3.1 → v0.3.2
- mcp-tester pmcp dep: v1.11.2 → v1.11.3

## After merge
Tag `v1.11.3` on the merge commit to trigger the release workflow. The corrected publish order and error handling from PR #183 should result in all crates publishing successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)