### PR TITLE
feat: standardize --server flag and add code_mode loadtest scenario

### DIFF
--- a/cargo-pmcp/src/commands/landing/deploy.rs
+++ b/cargo-pmcp/src/commands/landing/deploy.rs
@@ -76,7 +76,7 @@ pub async fn deploy_landing_page(
                     cargo pmcp deploy --target pmcp-run\n\
                  \n\
                  2. Or manually specify server ID:\n\
-                    cargo pmcp landing deploy --target pmcp-run --server-id YOUR_SERVER_ID\n\
+                    cargo pmcp landing deploy --target pmcp-run --server YOUR_SERVER_ID\n\
                  \n\
                  3. Or add to pmcp-landing.toml:\n\
                     [deployment]\n\

--- a/cargo-pmcp/src/commands/loadtest/mod.rs
+++ b/cargo-pmcp/src/commands/loadtest/mod.rs
@@ -89,9 +89,9 @@ pub enum LoadtestCommand {
     /// Validates the TOML config locally (parses it and checks that scenarios
     /// exist), then uploads it to pmcp.run for cloud-based load test execution.
     Upload {
-        /// Server ID (deployment ID) on pmcp.run
+        /// Server name (deployment ID) on pmcp.run
         #[arg(long)]
-        server_id: String,
+        server: String,
 
         /// Path to the loadtest TOML config file
         #[arg(required = true)]
@@ -147,14 +147,14 @@ impl LoadtestCommand {
                 runtime.block_on(init::execute_init(url, force, global_flags))
             },
             LoadtestCommand::Upload {
-                server_id,
+                server,
                 path,
                 name,
                 description,
             } => {
                 let runtime = tokio::runtime::Runtime::new()?;
                 runtime.block_on(upload::execute(
-                    server_id,
+                    server,
                     path,
                     name,
                     description,

--- a/cargo-pmcp/src/commands/test/download.rs
+++ b/cargo-pmcp/src/commands/test/download.rs
@@ -85,7 +85,7 @@ pub async fn execute(
             output_path.display()
         );
         println!(
-            "  - Upload changes: cargo pmcp test upload --server-id <id> {}",
+            "  - Upload changes: cargo pmcp test upload --server <id> {}",
             output_path.display()
         );
     }

--- a/cargo-pmcp/src/commands/test/generate.rs
+++ b/cargo-pmcp/src/commands/test/generate.rs
@@ -90,7 +90,7 @@ pub fn execute(
                 println!("{}", "Tip:".bright_cyan().bold());
                 println!("  Upload scenarios to pmcp.run for scheduled testing:");
                 println!(
-                    "    cargo pmcp test upload --server-id <id> {}",
+                    "    cargo pmcp test upload --server <id> {}",
                     output_path.display()
                 );
             }

--- a/cargo-pmcp/src/commands/test/list.rs
+++ b/cargo-pmcp/src/commands/test/list.rs
@@ -36,7 +36,7 @@ pub async fn execute(server_id: String, show_all: bool, global_flags: &GlobalFla
             println!();
             println!("  2. Upload to pmcp.run:");
             println!(
-                "     cargo pmcp test upload --server-id {} scenarios/",
+                "     cargo pmcp test upload --server {} scenarios/",
                 server_id
             );
         }
@@ -133,7 +133,7 @@ pub async fn execute(server_id: String, show_all: bool, global_flags: &GlobalFla
         println!("{}", "Commands:".bright_white().bold());
         println!("  Download a scenario:  cargo pmcp test download --scenario-id <id>");
         println!(
-            "  Upload scenarios:     cargo pmcp test upload --server-id {} <path>",
+            "  Upload scenarios:     cargo pmcp test upload --server {} <path>",
             server_id
         );
 

--- a/cargo-pmcp/src/commands/test/mod.rs
+++ b/cargo-pmcp/src/commands/test/mod.rs
@@ -124,9 +124,9 @@ pub enum TestCommand {
     /// Upload local scenario files to pmcp.run for scheduled testing
     /// and cloud-based test execution.
     Upload {
-        /// Server ID (deployment ID) on pmcp.run
+        /// Server name (deployment ID) on pmcp.run
         #[arg(long)]
-        server_id: String,
+        server: String,
 
         /// Path(s) to scenario files or directories
         #[arg(required = true)]
@@ -162,9 +162,9 @@ pub enum TestCommand {
     ///
     /// Show all scenarios configured for an MCP server on pmcp.run.
     List {
-        /// Server ID (deployment ID) on pmcp.run
+        /// Server name (deployment ID) on pmcp.run
         #[arg(long)]
-        server_id: String,
+        server: String,
 
         /// Show all scenarios including disabled ones
         #[arg(long)]
@@ -230,14 +230,14 @@ impl TestCommand {
             ),
 
             TestCommand::Upload {
-                server_id,
+                server,
                 paths,
                 name,
                 description,
             } => {
                 let runtime = tokio::runtime::Runtime::new()?;
                 runtime.block_on(upload::execute(
-                    server_id,
+                    server,
                     paths,
                     name,
                     description,
@@ -254,9 +254,9 @@ impl TestCommand {
                 runtime.block_on(download::execute(scenario_id, output, format, global_flags))
             },
 
-            TestCommand::List { server_id, all } => {
+            TestCommand::List { server, all } => {
                 let runtime = tokio::runtime::Runtime::new()?;
-                runtime.block_on(list::execute(server_id, all, global_flags))
+                runtime.block_on(list::execute(server, all, global_flags))
             },
         }
     }

--- a/cargo-pmcp/src/commands/test/upload.rs
+++ b/cargo-pmcp/src/commands/test/upload.rs
@@ -140,7 +140,7 @@ pub async fn execute(
             );
             println!("  - Configure scheduled testing in the dashboard");
             println!(
-                "  - Or run tests manually: cargo pmcp test remote --server-id {}",
+                "  - Or run tests manually: cargo pmcp test remote --server {}",
                 server_id
             );
         } else {

--- a/cargo-pmcp/src/loadtest/README.md
+++ b/cargo-pmcp/src/loadtest/README.md
@@ -74,7 +74,7 @@ Uploads a validated config to [pmcp.run](https://pmcp.run) for cloud-based load 
 
 ```bash
 cargo pmcp loadtest upload \
-  --server-id your-deployment-id \
+  --server your-deployment-id \
   .pmcp/loadtest.toml \
   --name "baseline" \
   --description "10 VU steady-state baseline"
@@ -84,7 +84,7 @@ cargo pmcp loadtest upload \
 
 | Flag | Description |
 |------|-------------|
-| `--server-id <id>` | **(required)** Deployment ID on pmcp.run |
+| `--server <id>` | **(required)** Deployment ID on pmcp.run |
 | `<path>` | **(required)** Path to the TOML config file |
 | `--name <name>` | Config name (defaults to filename stem) |
 | `--description <text>` | Description for the config |

--- a/cargo-pmcp/src/loadtest/client.rs
+++ b/cargo-pmcp/src/loadtest/client.rs
@@ -246,6 +246,44 @@ impl McpClient {
         Self::parse_response(&response_bytes)
     }
 
+    /// Executes a code_mode two-step flow: `validate_code` then `execute_code`.
+    ///
+    /// Step 1: Calls `validate_code` tool with the code and format.
+    /// Step 2: Extracts the `approval_token` from the response and calls
+    /// `execute_code` with the same code and the token.
+    pub async fn execute_code_mode(&mut self, code: &str, format: &str) -> Result<Value, McpError> {
+        // Step 1: validate_code
+        let validate_args = json!({
+            "code": code,
+            "format": format
+        });
+        let validate_result = self.call_tool("validate_code", &validate_args).await?;
+
+        // Extract approval_token from the validate_code response
+        let approval_token = validate_result
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|arr| {
+                arr.iter()
+                    .find(|item| item.get("type") == Some(&json!("text")))
+            })
+            .and_then(|item| item.get("text"))
+            .and_then(|text| serde_json::from_str::<Value>(text.as_str().unwrap_or("")).ok())
+            .and_then(|parsed| parsed.get("approval_token").cloned())
+            .and_then(|t| t.as_str().map(|s| s.to_string()))
+            .ok_or_else(|| McpError::JsonRpc {
+                code: -1,
+                message: "validate_code response missing approval_token".to_string(),
+            })?;
+
+        // Step 2: execute_code
+        let execute_args = json!({
+            "code": code,
+            "approval_token": approval_token
+        });
+        self.call_tool("execute_code", &execute_args).await
+    }
+
     /// Sends an HTTP POST request with the given JSON-RPC body.
     ///
     /// Attaches the `mcp-session-id` header if a session has been established.

--- a/cargo-pmcp/src/loadtest/config.rs
+++ b/cargo-pmcp/src/loadtest/config.rs
@@ -133,7 +133,8 @@ fn default_expected_interval() -> u64 {
 /// A single scenario step representing an MCP operation with a scheduling weight.
 ///
 /// The `type` field in TOML determines the variant via serde's internally tagged
-/// enum support. Supported types: `"tools/call"`, `"resources/read"`, `"prompts/get"`.
+/// enum support. Supported types: `"tools/call"`, `"resources/read"`, `"prompts/get"`,
+/// `"code_mode"`.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type")]
 pub enum ScenarioStep {
@@ -167,6 +168,24 @@ pub enum ScenarioStep {
         #[serde(default)]
         arguments: HashMap<String, String>,
     },
+    /// A `code_mode` two-step flow: `validate_code` then `execute_code`.
+    ///
+    /// Used for servers that support Code Mode (e.g., GraphQL, SQL).
+    /// The code is first validated, then executed if approved.
+    #[serde(rename = "code_mode")]
+    CodeMode {
+        /// Scheduling weight relative to other steps.
+        weight: u32,
+        /// The code to validate and execute.
+        code: String,
+        /// Code format (e.g., "graphql", "sql", "javascript").
+        #[serde(default = "default_code_format")]
+        format: String,
+    },
+}
+
+fn default_code_format() -> String {
+    "graphql".to_string()
 }
 
 impl LoadTestConfig {
@@ -275,6 +294,7 @@ impl ScenarioStep {
             Self::ToolCall { weight, .. } => *weight,
             Self::ResourceRead { weight, .. } => *weight,
             Self::PromptGet { weight, .. } => *weight,
+            Self::CodeMode { weight, .. } => *weight,
         }
     }
 }
@@ -359,6 +379,64 @@ arguments = { text = "Hello world" }
         assert!(matches!(
             &config.scenario[2],
             ScenarioStep::PromptGet { weight: 10, .. }
+        ));
+    }
+
+    #[test]
+    fn test_parse_code_mode_scenario() {
+        let toml_str = r#"
+[settings]
+virtual_users = 5
+duration_secs = 30
+timeout_ms = 5000
+
+[[scenario]]
+type = "tools/call"
+weight = 50
+tool = "list-agents"
+
+[[scenario]]
+type = "code_mode"
+weight = 10
+code = """
+query ListAgents {
+  listAgentsFromRegistry { id name }
+}
+"""
+format = "graphql"
+"#;
+        let config = LoadTestConfig::from_toml(toml_str).unwrap();
+        assert_eq!(config.scenario.len(), 2);
+        assert!(matches!(
+            &config.scenario[1],
+            ScenarioStep::CodeMode {
+                weight: 10,
+                format,
+                ..
+            } if format == "graphql"
+        ));
+    }
+
+    #[test]
+    fn test_parse_code_mode_default_format() {
+        let toml_str = r#"
+[settings]
+virtual_users = 5
+duration_secs = 30
+timeout_ms = 5000
+
+[[scenario]]
+type = "code_mode"
+weight = 5
+code = "SELECT 1"
+"#;
+        let config = LoadTestConfig::from_toml(toml_str).unwrap();
+        assert!(matches!(
+            &config.scenario[0],
+            ScenarioStep::CodeMode {
+                format,
+                ..
+            } if format == "graphql"
         ));
     }
 

--- a/cargo-pmcp/src/loadtest/metrics.rs
+++ b/cargo-pmcp/src/loadtest/metrics.rs
@@ -44,6 +44,8 @@ pub enum OperationType {
     ResourcesList,
     /// prompts/list discovery request.
     PromptsList,
+    /// code_mode two-step flow (validate_code + execute_code).
+    CodeMode,
 }
 
 impl fmt::Display for OperationType {
@@ -56,6 +58,7 @@ impl fmt::Display for OperationType {
             Self::ToolsList => "tools/list",
             Self::ResourcesList => "resources/list",
             Self::PromptsList => "prompts/list",
+            Self::CodeMode => "code_mode",
         };
         f.write_str(s)
     }

--- a/cargo-pmcp/src/loadtest/vu.rs
+++ b/cargo-pmcp/src/loadtest/vu.rs
@@ -69,6 +69,7 @@ pub fn step_to_operation_type(step: &ScenarioStep) -> OperationType {
         ScenarioStep::ToolCall { .. } => OperationType::ToolsCall,
         ScenarioStep::ResourceRead { .. } => OperationType::ResourcesRead,
         ScenarioStep::PromptGet { .. } => OperationType::PromptsGet,
+        ScenarioStep::CodeMode { .. } => OperationType::CodeMode,
     }
 }
 
@@ -95,6 +96,10 @@ async fn execute_step(
         } => {
             let result = client.get_prompt(prompt, arguments).await;
             (OperationType::PromptsGet, result.map(|_| ()))
+        },
+        ScenarioStep::CodeMode { code, format, .. } => {
+            let result = client.execute_code_mode(code, format).await;
+            (OperationType::CodeMode, result.map(|_| ()))
         },
     }
 }
@@ -297,6 +302,7 @@ async fn vu_loop_inner(
             ScenarioStep::ToolCall { tool, .. } => Some(tool.clone()),
             ScenarioStep::ResourceRead { uri, .. } => Some(uri.clone()),
             ScenarioStep::PromptGet { prompt, .. } => Some(prompt.clone()),
+            ScenarioStep::CodeMode { format, .. } => Some(format!("code_mode/{format}")),
         };
 
         // Build and send the metrics sample


### PR DESCRIPTION
## Summary
- **Standardize --server flag**: Rename `--server-id` to `--server` across `loadtest upload`, `test upload`, and `test list` commands for consistency with the rest of the CLI (`dev --server`, `deploy --server`, etc.)
- **Add code_mode scenario type**: Support the `validate_code` + `execute_code` two-step flow used by Code Mode servers (GraphQL, SQL, JavaScript)

## Changes
1. `commands/loadtest/mod.rs`, `commands/test/mod.rs`: Rename `server_id` field to `server`
2. Help text strings updated across 6 files
3. `loadtest/config.rs`: Add `CodeMode` variant to `ScenarioStep` enum with `code`, `format` fields
4. `loadtest/client.rs`: Add `execute_code_mode()` method (validate → extract token → execute)
5. `loadtest/metrics.rs`: Add `CodeMode` operation type
6. `loadtest/vu.rs`: Wire up CodeMode in step dispatch and metrics labeling

## Usage after this change
```bash
# Before (broken)
cargo pmcp loadtest upload --server-id true-agent scenarios/loadtest.toml

# After (consistent)
cargo pmcp loadtest upload --server true-agent scenarios/loadtest.toml
```

## Test plan
- [x] All 115 loadtest tests pass
- [x] New tests for code_mode TOML parsing (with and without format)
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)