### PR TITLE
chore: bump cargo-pmcp to v0.3.3

### DIFF
--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"


### PR DESCRIPTION
## Summary
Version bump for cargo-pmcp release with:
- `--server` flag (replaces `--server-id`)
- `code_mode` loadtest scenario type

## After merge
Tag `v1.11.4` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)