### PR TITLE
chore: bump pmcp to v1.11.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "1.11.3"
+version = "1.11.4"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -33,7 +33,7 @@ glob = "0.3"
 hdrhistogram = "7.5"
 tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-pmcp = { version = "1.11.3", path = "..", features = ["streamable-http", "oauth"] }
+pmcp = { version = "1.11.4", path = "..", features = ["streamable-http", "oauth"] }
 mcp-tester = { version = "0.2.1", path = "../crates/mcp-tester" }
 mcp-preview = { version = "0.1.1", path = "../crates/mcp-preview" }
 urlencoding = "2"

--- a/crates/mcp-tester/Cargo.toml
+++ b/crates/mcp-tester/Cargo.toml
@@ -18,7 +18,7 @@ name = "mcp-tester"
 path = "src/main.rs"
 
 [dependencies]
-pmcp = { version = "1.11.3", path = "../../", features = ["streamable-http", "oauth"] }
+pmcp = { version = "1.11.4", path = "../../", features = ["streamable-http", "oauth"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bump pmcp from v1.11.3 to v1.11.4 to trigger release workflow for cargo-pmcp v0.3.3

## Test plan
- [ ] CI passes
- [ ] Tag v1.11.4 after merge triggers release workflow
- [ ] cargo-pmcp v0.3.3 published to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)