### PR TITLE
fix: binary release pipeline — ring ARM fix, remove mcp-preview builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,10 +301,13 @@ jobs:
     if: always()
     steps:
       - name: Evaluate required checks
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          QG_RESULT: ${{ needs.quality-gate.result }}
         run: |
-          if [[ "${{ needs.test.result }}" != "success" ]] || \
-             [[ "${{ needs.quality-gate.result }}" != "success" ]]; then
-            echo "Required checks failed: test=${{ needs.test.result }}, quality-gate=${{ needs.quality-gate.result }}"
+          if [[ "$TEST_RESULT" != "success" ]] || \
+             [[ "$QG_RESULT" != "success" ]]; then
+            echo "Required checks failed: test=$TEST_RESULT, quality-gate=$QG_RESULT"
             exit 1
           fi
           echo "All required checks passed."

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,9 +1,7 @@
 name: Publish to MCP Registry
 
 on:
-  workflow_dispatch:  # Allow manual triggering
-  push:
-    tags: ["v*"]  # Also trigger on version tags
+  workflow_dispatch:  # Manual re-publish only; release.yml handles tag-triggered publish
 
 jobs:
   publish-mcp:

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,5 +1,5 @@
 # Reusable workflow: build a single binary package for all platforms.
-# Called from release.yml for mcp-tester and mcp-preview.
+# Called from release.yml for mcp-tester.
 name: Release Binary
 
 on:
@@ -11,7 +11,7 @@ on:
       package_name:
         required: true
         type: string
-        description: 'Cargo package name (mcp-tester or mcp-preview)'
+        description: 'Cargo package name (e.g. mcp-tester)'
   workflow_dispatch:
     inputs:
       tag_name:
@@ -24,7 +24,13 @@ on:
         type: choice
         options:
           - mcp-tester
-          - mcp-preview
+
+env:
+  CARGO_TERM_COLOR: never
+  # Override .cargo/config.toml target-cpu=native which causes ring compilation
+  # failure on macOS ARM64 CI runners where LLVM misidentifies the native CPU,
+  # stripping aes/sha2 target features that ring requires for aarch64-apple-darwin.
+  RUSTFLAGS: ""
 
 jobs:
   build-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,11 +202,3 @@ jobs:
       package_name: mcp-tester
     secrets: inherit
 
-  build-preview:
-    name: Build Preview Binaries
-    needs: create-release
-    uses: ./.github/workflows/release-binary.yml
-    with:
-      tag_name: ${{ needs.create-release.outputs.version }}
-      package_name: mcp-preview
-    secrets: inherit


### PR DESCRIPTION
## Summary

- **Fix ring compilation on aarch64-apple-darwin** — add `RUSTFLAGS=""` to override `.cargo/config.toml` `target-cpu=native` which causes LLVM to misidentify CPU features on macOS ARM CI runners
- **Remove mcp-preview binary builds** — mcp-preview is a library crate (no `[[bin]]` target), so the binary build job always failed
- **Fix duplicate MCP Registry publish** — `publish-mcp.yml` and `release.yml` both triggered on `v*` tags; removed the tag trigger from `publish-mcp.yml`
- **Fix expression injection in gate job** — move `${{ }}` interpolations to env vars, consistent with `release-binary.yml` hardening
- **Align CARGO_TERM_COLOR** to `never` in release-binary.yml

## Test plan

- [ ] CI passes (gate job, quality gate, tests)
- [ ] After merge: re-run release workflow via `workflow_dispatch` or push patch tag to verify all 5 mcp-tester binaries build (including aarch64-apple-darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)