### PR TITLE
fix: resolve circular publish dependency for pmcp-macros

### DIFF
--- a/pmcp-macros/Cargo.toml
+++ b/pmcp-macros/Cargo.toml
@@ -24,7 +24,7 @@ darling = "0.23"
 heck = "0.5"
 
 [dev-dependencies]
-pmcp = { version = "2.0.0", path = "..", features = ["full"] }
+pmcp = { version = ">=1.20.0", path = "..", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = "1.0"


### PR DESCRIPTION
## Summary

The v2.0.1 release failed to publish `pmcp-macros` because it has `pmcp = "2.0.0"` as a dev-dependency, but `pmcp 2.0.x` isn't on crates.io yet (it depends on `pmcp-macros`, creating a circular publish dependency).

**Fix:** Change the dev-dependency version to `>=1.20.0` so the existing `pmcp 1.20.0` on crates.io satisfies the requirement during `cargo publish`. Locally, the `path = ".."` override ensures the workspace version is used for development and testing.

## Test plan

- [x] `cargo check -p pmcp-macros` passes
- [x] One-line change to Cargo.toml dev-dependencies only

🤖 Generated with [Claude Code](https://claude.com/claude-code)