### PR TITLE
fix(deps): add version specifiers to remaining path deps (closes #215)

### DIFF
--- a/crates/pmcp-server/pmcp-server-lambda/Cargo.toml
+++ b/crates/pmcp-server/pmcp-server-lambda/Cargo.toml
@@ -13,8 +13,8 @@ name = "bootstrap"
 path = "src/main.rs"
 
 [dependencies]
-pmcp-server = { path = ".." }
-pmcp = { path = "../../..", features = ["streamable-http"] }
+pmcp-server = { version = "0.2.2", path = ".." }
+pmcp = { version = "2.2.0", path = "../../..", features = ["streamable-http"] }
 lambda_http = "1.1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 tokio = { version = "1", features = ["full"] }

--- a/examples/25-oauth-basic/Cargo.toml
+++ b/examples/25-oauth-basic/Cargo.toml
@@ -21,7 +21,7 @@ name = "stdio-minimal"
 path = "stdio-minimal.rs"
 
 [dependencies]
-pmcp = { path = "../../", features = ["streamable-http"] }
+pmcp = { version = "2.2.0", path = "../../", features = ["streamable-http"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 anyhow = "1"

--- a/examples/test-basic/Cargo.toml
+++ b/examples/test-basic/Cargo.toml
@@ -10,5 +10,5 @@ keywords = ["mcp", "example", "test"]
 categories = ["development-tools::testing"]
 
 [dependencies]
-pmcp = { path = "../../", features = ["http"] }
+pmcp = { version = "2.2.0", path = "../../", features = ["http"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary

Closes #215.

`cargo deny check bans` was rejecting the workspace because three path dependencies lacked version specifiers. Wildcard path deps bypass crates.io resolution and can silently break downstream crates when a dep's API changes without a version bump.

### Before

```toml
# crates/pmcp-server/pmcp-server-lambda/Cargo.toml
pmcp-server = { path = ".." }
pmcp        = { path = "../../..", features = ["streamable-http"] }

# examples/25-oauth-basic/Cargo.toml
pmcp        = { path = "../../", features = ["streamable-http"] }

# examples/test-basic/Cargo.toml
pmcp        = { path = "../../", features = ["http"] }
```

### After

```toml
# crates/pmcp-server/pmcp-server-lambda/Cargo.toml
pmcp-server = { version = "0.2.2", path = ".." }
pmcp        = { version = "2.2.0", path = "../../..", features = ["streamable-http"] }

# examples/25-oauth-basic/Cargo.toml
pmcp        = { version = "2.2.0", path = "../../", features = ["streamable-http"] }

# examples/test-basic/Cargo.toml
pmcp        = { version = "2.2.0", path = "../../", features = ["http"] }
```

Versions match each dep's `Cargo.toml` version field (pmcp 2.2.0 root, pmcp-server 0.2.2 from `crates/pmcp-server/`).

### Scope

All **other** workspace-member path deps already had version specifiers (added/verified during the v2.2.0 version bump work in #223). These three were the only remaining offenders in members scanned by `cargo deny`.

Non-workspace paths under `deploy/cloudflare/`, `fuzz/`, and excluded examples (`mcp-apps-chess`, `wasm-*`, etc.) are **not** workspace members (per the root `Cargo.toml` `[workspace] exclude` list) and are therefore not scanned by `cargo deny check bans`.

## Test plan

- [x] `cargo package` sanity check — all three crates package fine (via `make quality-gate`'s build step)
- [x] `make quality-gate` PASSED (fmt, clippy pedantic+nursery, build, tests, doctests, examples, fuzz, property)
- [ ] CI green on this PR
- [ ] After merge: `cargo deny check bans` should no longer report wildcard path dep violations for these three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)