### PR TITLE
chore: bump pmcp-code-mode 0.1.0 -> 0.2.0 for release v2.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11"
 dashmap = "6.1"  # Already in main deps but needed for examples
 pmcp-macros = { version = "0.5.0", path = "pmcp-macros" }  # For macro examples (s23_mcp_tool_macro)
-pmcp-code-mode = { version = "0.1.0", path = "crates/pmcp-code-mode" }  # For code mode example (s41)
+pmcp-code-mode = { version = "0.2.0", path = "crates/pmcp-code-mode" }  # For code mode example (s41)
 pmcp-code-mode-derive = { version = "0.1.0", path = "crates/pmcp-code-mode-derive" }  # For code mode example (s41)
 
 [features]

--- a/crates/pmcp-code-mode-derive/Cargo.toml
+++ b/crates/pmcp-code-mode-derive/Cargo.toml
@@ -24,7 +24,7 @@ darling = "0.23"
 
 [dev-dependencies]
 pmcp = { version = "2.3.0", path = "../../" }
-pmcp-code-mode = { version = "0.1.0", path = "../pmcp-code-mode" }
+pmcp-code-mode = { version = "0.2.0", path = "../pmcp-code-mode" }
 tokio = { version = "1", features = ["full"] }
 trybuild = "1.0"
 serde = { version = "1", features = ["derive"] }

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-code-mode"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/rust-mcp-sdk"


### PR DESCRIPTION
## Summary

Version bump for release. `pmcp-code-mode` 0.1.0 is already published on crates.io, and this release has breaking changes, so bump to 0.2.0.

- `pmcp` remains at 2.3.0
- `pmcp-code-mode` 0.1.0 -> 0.2.0 (breaking: Result-returning constructors, Arc policy evaluator, language dispatch)
- `pmcp-code-mode-derive` stays at 0.1.0 (first publish)
- Root Cargo.toml and derive dev-dependency updated to match

## Test plan

- [x] `cargo test -p pmcp-code-mode -p pmcp-code-mode-derive` — all pass
- [x] Version references consistent across all 3 Cargo.toml files

After merge: tag `v2.3.0` and push to trigger release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)