### PR TITLE
fix(release): add pmcp-code-mode to publish order before pmcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,42 @@ jobs:
     - name: Wait for crates.io to index pmcp-macros
       run: sleep 30
 
+    - name: Publish pmcp-code-mode
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-code-mode..."
+        OUTPUT=$(cargo publish -p pmcp-code-mode 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-code-mode already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-code-mode"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index pmcp-code-mode
+      run: sleep 30
+
+    - name: Publish pmcp-code-mode-derive
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-code-mode-derive..."
+        OUTPUT=$(cargo publish -p pmcp-code-mode-derive 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-code-mode-derive already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-code-mode-derive"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index pmcp-code-mode-derive
+      run: sleep 30
+
     - name: Publish pmcp (core SDK)
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `pmcp-code-mode` and `pmcp-code-mode-derive` publish steps to the release workflow **before** `pmcp`
- `pmcp` has a dev-dependency on `pmcp-code-mode = "^0.2.0"` (for examples), so crates.io requires it to be published first
- Publish order: `pmcp-widget-utils` -> `pmcp-macros` -> **`pmcp-code-mode`** -> **`pmcp-code-mode-derive`** -> `pmcp` -> `mcp-tester` -> ...

This fixes the v2.3.0 release failure:
```
failed to select a version for the requirement `pmcp-code-mode = "^0.2.0"`
candidate versions found which didn't match: 0.1.0
```

## Test plan

- [x] Workflow YAML is valid
- [ ] After merge: delete v2.3.0 tag, re-tag, push to trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)