### PR TITLE
fix(release): break circular publish dependency for pmcp-code-mode

### DIFF
--- a/crates/pmcp-code-mode-derive/Cargo.toml
+++ b/crates/pmcp-code-mode-derive/Cargo.toml
@@ -23,7 +23,7 @@ proc-macro2 = "1.0"
 darling = "0.23"
 
 [dev-dependencies]
-pmcp = { version = "2.3.0", path = "../../" }
+pmcp = { version = ">=2.2.0", path = "../../" }
 pmcp-code-mode = { version = "0.2.0", path = "../pmcp-code-mode" }
 tokio = { version = "1", features = ["full"] }
 trybuild = "1.0"

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-pmcp = { version = "2.3.0", path = "../../" }
+pmcp = { version = ">=2.2.0", path = "../../" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

`pmcp-code-mode` depends on `pmcp` for types (`ServerBuilder`, `ToolHandler`, `Error`), and `pmcp` has a dev-dependency on `pmcp-code-mode`. This creates a circular publish dependency — neither can publish first.

Fix: `pmcp-code-mode` now uses `pmcp = ">=2.2.0"` instead of `"2.3.0"`. The types it uses haven't changed since 2.2.0, so this is safe. This allows publishing `pmcp-code-mode` 0.2.0 before `pmcp` 2.3.0 exists on crates.io.

## Test plan

- [x] `cargo test -p pmcp-code-mode -p pmcp-code-mode-derive` — all pass
- [ ] After merge: delete v2.3.0 tag, re-tag, push to trigger release

🤖 Generated with [Claude Code](https://claude.com/claude-code)