### PR TITLE
feat: Code Mode config deploy, AVP schema sync, category-based action routing

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,6 +12,14 @@ ignore = [
     # Path: aws-smithy-http-client -> rustls 0.21 -> rustls-webpki 0.101
     "RUSTSEC-2026-0049",
 
+    # rustls-webpki 0.101.7: Name constraints for URI names incorrectly accepted
+    # Path: aws-smithy-http-client -> rustls 0.21 -> rustls-webpki 0.101
+    "RUSTSEC-2026-0098",
+
+    # rustls-webpki 0.101.7: Name constraints accepted for wildcard certificates
+    # Path: aws-smithy-http-client -> rustls 0.21 -> rustls-webpki 0.101
+    "RUSTSEC-2026-0099",
+
     # aws-lc-sys: Timing side-channel in AES-CCM tag verification
     "RUSTSEC-2026-0045",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11"
 dashmap = "6.1"  # Already in main deps but needed for examples
 pmcp-macros = { version = "0.5.0", path = "pmcp-macros" }  # For macro examples (s23_mcp_tool_macro)
-pmcp-code-mode = { version = "0.3.0", path = "crates/pmcp-code-mode" }  # For code mode example (s41)
+pmcp-code-mode = { version = "0.4.0", path = "crates/pmcp-code-mode" }  # For code mode example (s41)
 pmcp-code-mode-derive = { version = "0.2.0", path = "crates/pmcp-code-mode-derive" }  # For code mode example (s41)
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,8 +145,8 @@ clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11"
 dashmap = "6.1"  # Already in main deps but needed for examples
 pmcp-macros = { version = "0.5.0", path = "pmcp-macros" }  # For macro examples (s23_mcp_tool_macro)
-pmcp-code-mode = { version = "0.2.0", path = "crates/pmcp-code-mode" }  # For code mode example (s41)
-pmcp-code-mode-derive = { version = "0.1.0", path = "crates/pmcp-code-mode-derive" }  # For code mode example (s41)
+pmcp-code-mode = { version = "0.3.0", path = "crates/pmcp-code-mode" }  # For code mode example (s41)
+pmcp-code-mode-derive = { version = "0.2.0", path = "crates/pmcp-code-mode-derive" }  # For code mode example (s41)
 
 [features]
 default = ["logging"]

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/cargo-pmcp/src/deployment/builder.rs
+++ b/cargo-pmcp/src/deployment/builder.rs
@@ -469,12 +469,11 @@ impl BinaryBuilder {
             Vec::new()
         };
 
-        // Check if config.toml exists (for Code Mode operation extraction)
-        let has_config_toml = self.project_root.join("config.toml").exists()
-            || self.find_single_instance_toml().is_some();
+        // Resolve config.toml once (for Code Mode operation extraction)
+        let config_toml_path = self.resolve_config_toml();
 
         // Only create ZIP if there's something to bundle beyond bootstrap
-        if asset_files.is_empty() && !has_config_toml {
+        if asset_files.is_empty() && config_toml_path.is_none() {
             return Ok(None);
         }
 
@@ -515,7 +514,7 @@ impl BinaryBuilder {
             .unix_permissions(0o644);
 
         // Add config.toml if found (for Code Mode operation extraction by pmcp.run)
-        let config_toml_included = self.add_config_toml_to_zip(&mut zip, file_options)?;
+        let config_toml_included = self.add_config_toml_to_zip(&mut zip, file_options, config_toml_path.as_deref())?;
 
         // Add assets to assets/ subdirectory in the zip
         // Lambda will extract to $LAMBDA_TASK_ROOT/assets/
@@ -563,16 +562,17 @@ impl BinaryBuilder {
         Ok(Some(zip_path))
     }
 
-    /// Find and add config.toml to the deploy ZIP for Code Mode operation extraction.
+    /// Add config.toml to the deploy ZIP for Code Mode operation extraction.
     ///
-    /// Uses `resolve_config_toml` to find the config file, then writes it to the ZIP
-    /// root as `config.toml`. Returns true if a config file was found and added.
+    /// Takes a pre-resolved config path (from `resolve_config_toml`) to avoid
+    /// redundant filesystem scanning. Returns true if a config file was added.
     fn add_config_toml_to_zip<W: std::io::Write + std::io::Seek>(
         &self,
         zip: &mut ZipWriter<W>,
         options: SimpleFileOptions,
+        config_path: Option<&Path>,
     ) -> Result<bool> {
-        let config_path = match self.resolve_config_toml() {
+        let config_path = match config_path {
             Some(path) => path,
             None => return Ok(false),
         };
@@ -581,7 +581,7 @@ impl BinaryBuilder {
         std::io::Write::flush(&mut std::io::stdout())?;
 
         let config_data =
-            std::fs::read(&config_path).context("Failed to read config.toml")?;
+            std::fs::read(config_path).context("Failed to read config.toml")?;
         zip.start_file("config.toml", options)
             .context("Failed to add config.toml to zip")?;
         zip.write_all(&config_data)

--- a/cargo-pmcp/src/deployment/builder.rs
+++ b/cargo-pmcp/src/deployment/builder.rs
@@ -514,7 +514,8 @@ impl BinaryBuilder {
             .unix_permissions(0o644);
 
         // Add config.toml if found (for Code Mode operation extraction by pmcp.run)
-        let config_toml_included = self.add_config_toml_to_zip(&mut zip, file_options, config_toml_path.as_deref())?;
+        let config_toml_included =
+            self.add_config_toml_to_zip(&mut zip, file_options, config_toml_path.as_deref())?;
 
         // Add assets to assets/ subdirectory in the zip
         // Lambda will extract to $LAMBDA_TASK_ROOT/assets/
@@ -580,8 +581,7 @@ impl BinaryBuilder {
         print!("   Adding config.toml...");
         std::io::Write::flush(&mut std::io::stdout())?;
 
-        let config_data =
-            std::fs::read(config_path).context("Failed to read config.toml")?;
+        let config_data = std::fs::read(config_path).context("Failed to read config.toml")?;
         zip.start_file("config.toml", options)
             .context("Failed to add config.toml to zip")?;
         zip.write_all(&config_data)

--- a/cargo-pmcp/src/deployment/builder.rs
+++ b/cargo-pmcp/src/deployment/builder.rs
@@ -462,22 +462,26 @@ impl BinaryBuilder {
     fn bundle_assets_if_configured(&self, binary_path: &Path) -> Result<Option<PathBuf>> {
         let config = crate::deployment::config::DeployConfig::load(&self.project_root)?;
 
-        // Check if any assets are configured
-        if !config.assets.has_assets() {
+        // Resolve asset files (empty vec if no assets configured)
+        let asset_files = if config.assets.has_assets() {
+            config.assets.resolve_files(&self.project_root)?
+        } else {
+            Vec::new()
+        };
+
+        // Check if config.toml exists (for Code Mode operation extraction)
+        let has_config_toml = self.project_root.join("config.toml").exists()
+            || self.find_single_instance_toml().is_some();
+
+        // Only create ZIP if there's something to bundle beyond bootstrap
+        if asset_files.is_empty() && !has_config_toml {
             return Ok(None);
         }
 
-        println!("📦 Bundling assets...");
-
-        // Resolve asset files
-        let asset_files = config.assets.resolve_files(&self.project_root)?;
-
-        if asset_files.is_empty() {
-            println!("   No asset files found matching patterns");
-            return Ok(None);
+        println!("📦 Bundling deployment package...");
+        if !asset_files.is_empty() {
+            println!("   Found {} asset file(s)", asset_files.len());
         }
-
-        println!("   Found {} asset file(s)", asset_files.len());
 
         // Create deployment package directory
         let package_dir = self.project_root.join("deploy/.build");
@@ -506,6 +510,13 @@ impl BinaryBuilder {
             .context("Failed to write bootstrap to zip")?;
         println!(" ✅");
 
+        let file_options = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated)
+            .unix_permissions(0o644);
+
+        // Add config.toml if found (for Code Mode operation extraction by pmcp.run)
+        let config_toml_included = self.add_config_toml_to_zip(&mut zip, file_options)?;
+
         // Add assets to assets/ subdirectory in the zip
         // Lambda will extract to $LAMBDA_TASK_ROOT/assets/
         let base_dir = config
@@ -514,10 +525,6 @@ impl BinaryBuilder {
             .as_ref()
             .map(|d| self.project_root.join(d))
             .unwrap_or_else(|| self.project_root.clone());
-
-        let asset_options = SimpleFileOptions::default()
-            .compression_method(zip::CompressionMethod::Deflated)
-            .unix_permissions(0o644);
 
         for asset_path in &asset_files {
             // Get relative path from base directory
@@ -532,7 +539,7 @@ impl BinaryBuilder {
 
             let asset_data = std::fs::read(asset_path)
                 .context(format!("Failed to read {}", asset_path.display()))?;
-            zip.start_file(&zip_path, asset_options)
+            zip.start_file(&zip_path, file_options)
                 .context(format!("Failed to add {} to zip", zip_path))?;
             zip.write_all(&asset_data)
                 .context(format!("Failed to write {} to zip", zip_path))?;
@@ -546,12 +553,76 @@ impl BinaryBuilder {
             .context("Failed to get zip size")?
             .len();
 
+        let extra_files = 1 + if config_toml_included { 1 } else { 0 }; // bootstrap + optional config.toml
         println!(
             "✅ Deployment package created: {:.2} MB ({} files)",
             zip_size as f64 / 1_048_576.0,
-            asset_files.len() + 1 // +1 for bootstrap
+            asset_files.len() + extra_files
         );
 
         Ok(Some(zip_path))
+    }
+
+    /// Find and add config.toml to the deploy ZIP for Code Mode operation extraction.
+    ///
+    /// Uses `resolve_config_toml` to find the config file, then writes it to the ZIP
+    /// root as `config.toml`. Returns true if a config file was found and added.
+    fn add_config_toml_to_zip<W: std::io::Write + std::io::Seek>(
+        &self,
+        zip: &mut ZipWriter<W>,
+        options: SimpleFileOptions,
+    ) -> Result<bool> {
+        let config_path = match self.resolve_config_toml() {
+            Some(path) => path,
+            None => return Ok(false),
+        };
+
+        print!("   Adding config.toml...");
+        std::io::Write::flush(&mut std::io::stdout())?;
+
+        let config_data =
+            std::fs::read(&config_path).context("Failed to read config.toml")?;
+        zip.start_file("config.toml", options)
+            .context("Failed to add config.toml to zip")?;
+        zip.write_all(&config_data)
+            .context("Failed to write config.toml to zip")?;
+        println!(" ✅ ({})", config_path.display());
+        Ok(true)
+    }
+
+    /// Resolve the server's config.toml path.
+    ///
+    /// Resolution order (same as Rust servers using `include_str!()`):
+    /// 1. `config.toml` in the server crate root
+    /// 2. Single file in `instances/*.toml`
+    fn resolve_config_toml(&self) -> Option<PathBuf> {
+        let direct = self.project_root.join("config.toml");
+        if direct.exists() {
+            return Some(direct);
+        }
+        self.find_single_instance_toml()
+    }
+
+    /// Find a single .toml file in the `instances/` directory.
+    fn find_single_instance_toml(&self) -> Option<PathBuf> {
+        let instances_dir = self.project_root.join("instances");
+        if !instances_dir.is_dir() {
+            return None;
+        }
+        let toml_files: Vec<_> = std::fs::read_dir(&instances_dir)
+            .ok()?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|ext| ext == "toml")
+                    .unwrap_or(false)
+            })
+            .collect();
+        if toml_files.len() == 1 {
+            Some(toml_files[0].path())
+        } else {
+            None
+        }
     }
 }

--- a/cargo-pmcp/src/deployment/metadata.rs
+++ b/cargo-pmcp/src/deployment/metadata.rs
@@ -70,6 +70,11 @@ pub struct McpMetadata {
 
     /// Server capabilities (tools, resources, prompts)
     pub capabilities: ServerCapabilities,
+
+    /// Available operations for Code Mode policy enforcement.
+    /// Extracted from config.toml or set directly in CloudFormation Metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_operations: Option<AvailableOperations>,
 }
 
 /// Resource requirements for the server.
@@ -166,6 +171,101 @@ pub struct ServerCapabilities {
     /// Whether server supports composition (server-to-server calls)
     #[serde(default)]
     pub composition: bool,
+}
+
+/// Available operations for Code Mode policy enforcement.
+///
+/// Operations are categorized by access level (read/write/delete/admin) based
+/// on the server type. The pmcp.run admin UI uses this to populate the Code Mode
+/// settings page, allowing administrators to adjust policies per operation.
+///
+/// This is extracted from `config.toml` in the deploy ZIP, or set directly
+/// in CloudFormation Metadata as `mcp:availableOperations`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailableOperations {
+    /// Read operations (GET, query, SELECT)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reads: Vec<OperationEntry>,
+
+    /// Write operations (POST/PUT/PATCH, mutation, INSERT/UPDATE)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub writes: Vec<OperationEntry>,
+
+    /// Delete operations (DELETE, destructive mutations, DELETE SQL)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deletes: Vec<OperationEntry>,
+
+    /// Admin operations (schema changes, user management, etc.)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub admin: Vec<OperationEntry>,
+
+    /// ISO 8601 timestamp of when operations were last extracted
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_updated: Option<String>,
+}
+
+/// A single operation available in Code Mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationEntry {
+    /// Operation identifier (tool name, query name, endpoint path, table name)
+    pub id: String,
+
+    /// Human-readable description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Server-type-specific metadata
+    #[serde(default, skip_serializing_if = "OperationMetadata::is_empty")]
+    pub metadata: OperationMetadata,
+}
+
+/// Server-type-specific metadata for an operation.
+///
+/// Different server types populate different fields:
+/// - **OpenAPI:** `path`, `method`
+/// - **GraphQL:** `operation_type`, `destructive_hint`
+/// - **SQL:** `table`, `access_type`
+/// - **MCP-API:** `read_only_hint`, `destructive_hint`, `operation_category`
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationMetadata {
+    // OpenAPI fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+
+    // GraphQL fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_type: Option<String>,
+
+    // SQL fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub access_type: Option<String>,
+
+    // MCP-API / shared fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_only_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destructive_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_category: Option<String>,
+}
+
+impl OperationMetadata {
+    fn is_empty(&self) -> bool {
+        self.path.is_none()
+            && self.method.is_none()
+            && self.operation_type.is_none()
+            && self.table.is_none()
+            && self.access_type.is_none()
+            && self.read_only_hint.is_none()
+            && self.destructive_hint.is_none()
+            && self.operation_category.is_none()
+    }
 }
 
 // ============================================================================
@@ -282,6 +382,81 @@ pub(crate) struct InstanceConfig {
 
     #[serde(default)]
     pub observability: Option<ObservabilitySection>,
+
+    /// Code Mode configuration with operation declarations for policy enforcement
+    #[serde(default)]
+    pub code_mode: Option<CodeModeSection>,
+
+    /// Database tables (SQL servers)
+    #[serde(default)]
+    pub database: Option<DatabaseSection>,
+}
+
+/// Code Mode section in config.toml — declares available operations
+/// and policy settings. The pmcp.run handler reads this to populate
+/// the admin UI's Code Mode policy page.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct CodeModeSection {
+    /// Whether write operations are allowed
+    #[serde(default)]
+    pub allow_writes: bool,
+
+    /// Whether delete operations are allowed
+    #[serde(default)]
+    pub allow_deletes: bool,
+
+    /// Tables blocked from Code Mode access (SQL servers)
+    #[serde(default)]
+    pub blocked_tables: Vec<String>,
+
+    /// Explicit operation declarations (preferred over [[tools]] when present)
+    #[serde(default)]
+    pub operations: Vec<CodeModeOperation>,
+}
+
+/// An operation declared in config.toml for Code Mode policy enforcement.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct CodeModeOperation {
+    /// Operation name/identifier
+    pub name: String,
+
+    /// Human-readable description
+    pub description: Option<String>,
+
+    /// HTTP path (OpenAPI servers)
+    pub path: Option<String>,
+
+    /// HTTP method (OpenAPI servers)
+    pub method: Option<String>,
+
+    /// GraphQL operation type: "query" or "mutation"
+    pub operation_type: Option<String>,
+
+    /// Whether this is a destructive operation
+    #[serde(default)]
+    pub destructive_hint: bool,
+
+    /// Explicit category override: "read", "write", "delete", "admin"
+    pub operation_category: Option<String>,
+}
+
+/// Database section in config.toml (SQL servers).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct DatabaseSection {
+    /// Available tables
+    #[serde(default)]
+    pub tables: Vec<DatabaseTable>,
+}
+
+/// A database table declaration.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct DatabaseTable {
+    pub name: String,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -539,6 +714,7 @@ impl McpMetadata {
                 prompts: vec![],
                 composition: manifest.features.composition_enabled,
             },
+            available_operations: None,
         })
     }
 
@@ -597,6 +773,7 @@ impl McpMetadata {
                     prompts: vec![],
                     composition: false,
                 },
+                available_operations: None,
             });
         }
 
@@ -616,6 +793,7 @@ impl McpMetadata {
             template_version: None,
             resources: ResourceRequirements::default(),
             capabilities: ServerCapabilities::default(),
+            available_operations: None,
         })
     }
 
@@ -647,6 +825,7 @@ impl McpMetadata {
             template_version: None,
             resources: ResourceRequirements::default(),
             capabilities: ServerCapabilities::default(),
+            available_operations: None,
         })
     }
 
@@ -702,6 +881,10 @@ impl McpMetadata {
 
         if let Some(ref template_version) = self.template_version {
             metadata["mcp:templateVersion"] = serde_json::json!(template_version);
+        }
+
+        if let Some(ref ops) = self.available_operations {
+            metadata["mcp:availableOperations"] = serde_json::json!(ops);
         }
 
         metadata

--- a/cargo-pmcp/src/deployment/metadata.rs
+++ b/cargo-pmcp/src/deployment/metadata.rs
@@ -227,7 +227,7 @@ pub struct OperationEntry {
 /// - **GraphQL:** `operation_type`, `destructive_hint`
 /// - **SQL:** `table`, `access_type`
 /// - **MCP-API:** `read_only_hint`, `destructive_hint`, `operation_category`
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OperationMetadata {
     // OpenAPI fields
@@ -257,14 +257,7 @@ pub struct OperationMetadata {
 
 impl OperationMetadata {
     fn is_empty(&self) -> bool {
-        self.path.is_none()
-            && self.method.is_none()
-            && self.operation_type.is_none()
-            && self.table.is_none()
-            && self.access_type.is_none()
-            && self.read_only_hint.is_none()
-            && self.destructive_hint.is_none()
-            && self.operation_category.is_none()
+        *self == Self::default()
     }
 }
 

--- a/crates/pmcp-code-mode-derive/CHANGELOG.md
+++ b/crates/pmcp-code-mode-derive/CHANGELOG.md
@@ -2,7 +2,30 @@
 
 All notable changes to `pmcp-code-mode-derive` will be documented in this file.
 
-## [0.1.0] - Unreleased
+## [0.2.0] - 2026-04-14
+
+### Breaking Changes
+
+- `language = "javascript"` now calls `validate_javascript_code_async` (async with policy
+  evaluation) instead of `validate_javascript_code` (sync, no policy). This means Cedar
+  and AVP policies are now enforced for JavaScript/OpenAPI servers using the derive macro.
+
+  No code changes needed if you use `NoopPolicyEvaluator` — it allows all scripts.
+  Custom evaluators must override `evaluate_script` (the trait default denies all scripts).
+
+### Added
+
+- `"sql"` and `"mcp"` language support — compile-time dispatch to `validate_sql_query` and
+  `validate_mcp_composition` respectively.
+- `"js"` accepted as alias for `"javascript"`.
+- `CodeLanguage` sync test — CI enforces that derive macro's language dispatch stays aligned
+  with the runtime `CodeLanguage` enum.
+- `gen_validation_call` helper — centralized language-to-validation-method mapping with shared
+  error handling. Adding a new language is a single match arm.
+- Unknown language values produce a compile error listing all supported values.
+- Invalid `context_from` values produce a compile error instead of panicking.
+
+## [0.1.0] - 2026-04-13
 
 ### Breaking Changes
 
@@ -18,13 +41,12 @@ All notable changes to `pmcp-code-mode-derive` will be documented in this file.
 
   // After (v0.1.0):
   let builder = server.register_code_mode_tools(builder)?;
-  // or: let builder = server.register_code_mode_tools(builder).unwrap();
   ```
 
 ### Added
 
 - `#[code_mode(context_from = "method_name")]` attribute for real `ValidationContext` binding.
-- `#[code_mode(language = "...")]` attribute to parameterize tool metadata language.
+- `#[code_mode(language = "...")]` attribute to parameterize validation path and tool metadata.
 - Compile-fail trybuild tests for missing `token_secret` and `code_executor` fields.
 - Improved error messages: missing field errors now explicitly mention `#[derive(CodeMode)]` as
   the source of the requirement and include type hints.

--- a/crates/pmcp-code-mode-derive/Cargo.toml
+++ b/crates/pmcp-code-mode-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-code-mode-derive"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/rust-mcp-sdk"
@@ -24,7 +24,7 @@ darling = "0.23"
 
 [dev-dependencies]
 pmcp = { version = ">=2.2.0", path = "../../" }
-pmcp-code-mode = { version = "0.2.0", path = "../pmcp-code-mode" }
+pmcp-code-mode = { version = "0.3.0", path = "../pmcp-code-mode" }
 tokio = { version = "1", features = ["full"] }
 trybuild = "1.0"
 serde = { version = "1", features = ["derive"] }

--- a/crates/pmcp-code-mode-derive/Cargo.toml
+++ b/crates/pmcp-code-mode-derive/Cargo.toml
@@ -24,7 +24,7 @@ darling = "0.23"
 
 [dev-dependencies]
 pmcp = { version = ">=2.2.0", path = "../../" }
-pmcp-code-mode = { version = "0.3.0", path = "../pmcp-code-mode" }
+pmcp-code-mode = { version = "0.4.0", path = "../pmcp-code-mode" }
 tokio = { version = "1", features = ["full"] }
 trybuild = "1.0"
 serde = { version = "1", features = ["derive"] }

--- a/crates/pmcp-code-mode-derive/README.md
+++ b/crates/pmcp-code-mode-derive/README.md
@@ -71,7 +71,9 @@ let config = ExecutionConfig::default()
 let code_executor = Arc::new(JsCodeExecutor::new(http, config));
 ```
 
-The generated handler calls `validate_javascript_code` (sync) instead of `validate_graphql_query_async`. `JsCodeExecutor` compiles the JS code, executes it against your `HttpExecutor`, and logs execution metadata automatically.
+The generated handler calls `validate_javascript_code_async` — this runs config-level checks, then **async policy evaluation** via `PolicyEvaluator::evaluate_script` (Cedar/AVP), then token generation. This is the same security model as GraphQL servers. `JsCodeExecutor` compiles the JS code, executes it against your `HttpExecutor`, and logs execution metadata automatically.
+
+**Policy enforcement:** When deployed with `POLICY_STORE_ID` on pmcp.run, admin-configured operation blocklists are enforced at `validate_code` time. Locally, Cedar policies work the same way. `NoopPolicyEvaluator` allows everything (for testing only).
 
 For SDK-backed servers (no HTTP), use `SdkCodeExecutor` instead:
 
@@ -274,7 +276,17 @@ let builder = server.register_code_mode_tools(builder);
 let builder = server.register_code_mode_tools(builder)?;
 ```
 
-`language` attribute now selects the validation path, not just metadata. Servers that previously used `language = "javascript"` as a documentation hint will now get their code routed through `validate_javascript_code` instead of the GraphQL parser (which is the correct behavior).
+`language` attribute now selects the validation path, not just metadata. Servers that previously used `language = "javascript"` as a documentation hint will now get their code routed through the JavaScript validator instead of the GraphQL parser (which is the correct behavior).
+
+## Breaking Changes in v0.2.0
+
+`language = "javascript"` now calls `validate_javascript_code_async` (with policy evaluation) instead of the sync `validate_javascript_code`. This means:
+
+- **Cedar policies are enforced** for JavaScript servers using the derive macro
+- **AVP policies are enforced** when deployed with `POLICY_STORE_ID` on pmcp.run
+- Policy evaluation failures are **fail-closed** — same security model as GraphQL
+
+No code changes needed if you use `NoopPolicyEvaluator`. Custom evaluators must override `evaluate_script` (the trait default denies all scripts).
 
 See [CHANGELOG.md](./CHANGELOG.md) for the full list of changes.
 

--- a/crates/pmcp-code-mode-derive/src/lib.rs
+++ b/crates/pmcp-code-mode-derive/src/lib.rs
@@ -340,18 +340,14 @@ fn expand_with_context_from(
 
                     let result = #validation_call;
 
-                    let response = pmcp_code_mode::ValidationResponse::success(
-                        result.explanation.clone(),
-                        result.risk_level,
+                    let mut response = pmcp_code_mode::ValidationResponse::from_result(result);
+                    if response.result.is_valid {
                         if dry_run {
-                            String::new()
-                        } else {
-                            result.approval_token.clone().unwrap_or_default()
-                        },
-                        result.metadata.clone(),
-                    )
-                    .with_warnings(result.warnings.clone())
-                    .with_auto_approved(self.config.should_auto_approve(result.risk_level));
+                            response.result.approval_token = None;
+                        }
+                        let risk = response.result.risk_level;
+                        response = response.with_auto_approved(self.config.should_auto_approve(risk));
+                    }
 
                     let (json, _is_error) = response.to_json_response();
                     Ok(json)
@@ -528,18 +524,14 @@ fn expand_without_context_from(
 
                     let result = #validation_call;
 
-                    let response = pmcp_code_mode::ValidationResponse::success(
-                        result.explanation.clone(),
-                        result.risk_level,
+                    let mut response = pmcp_code_mode::ValidationResponse::from_result(result);
+                    if response.result.is_valid {
                         if dry_run {
-                            String::new()
-                        } else {
-                            result.approval_token.clone().unwrap_or_default()
-                        },
-                        result.metadata.clone(),
-                    )
-                    .with_warnings(result.warnings.clone())
-                    .with_auto_approved(self.config.should_auto_approve(result.risk_level));
+                            response.result.approval_token = None;
+                        }
+                        let risk = response.result.risk_level;
+                        response = response.with_auto_approved(self.config.should_auto_approve(risk));
+                    }
 
                     let (json, _is_error) = response.to_json_response();
                     Ok(json)

--- a/crates/pmcp-code-mode-derive/src/lib.rs
+++ b/crates/pmcp-code-mode-derive/src/lib.rs
@@ -268,7 +268,7 @@ fn gen_validation_call(
             self.pipeline.validate_graphql_query_async(code, &context).await #map_err
         }),
         "javascript" | "js" => Ok(quote! {
-            self.pipeline.validate_javascript_code(code, &context) #map_err
+            self.pipeline.validate_javascript_code_async(code, &context).await #map_err
         }),
         "sql" => Ok(quote! {
             self.pipeline.validate_sql_query(code, &context) #map_err

--- a/crates/pmcp-code-mode/CHANGELOG.md
+++ b/crates/pmcp-code-mode/CHANGELOG.md
@@ -2,7 +2,35 @@
 
 All notable changes to `pmcp-code-mode` will be documented in this file.
 
-## [0.1.0] - Unreleased
+## [0.3.0] - 2026-04-14
+
+### Breaking Changes
+
+- `validate_javascript_code_async` added — the derive macro now calls this instead of the sync
+  `validate_javascript_code`. This means **policy evaluation (Cedar/AVP) is now enforced** for
+  JavaScript/OpenAPI servers using `#[derive(CodeMode)]`.
+
+  The default `PolicyEvaluator::evaluate_script` implementation **denies all scripts**. If you
+  have a custom evaluator that only implements `evaluate_operation`, override `evaluate_script`
+  to allow scripts. `NoopPolicyEvaluator` already allows all scripts.
+
+- Policy evaluation errors are **fail-closed** (matching the GraphQL path). A policy backend
+  outage blocks JavaScript validation requests instead of silently allowing them.
+
+### Added
+
+- `validate_javascript_code_async` — async JavaScript validation with `PolicyEvaluator::evaluate_script`
+  policy enforcement. Mirrors `validate_graphql_query_async` pattern.
+- `validate_js_preamble` and `check_js_config_authorization` — shared helpers extracted from
+  sync/async JavaScript validation (eliminates 55 lines of duplication).
+- `CodeLanguage` enum — extensible runtime representation of supported languages with `from_attr`,
+  `as_str`, `required_feature` methods.
+- `JsCodeExecutor<H>` — standard adapter bridging `HttpExecutor` to `CodeExecutor` (Pattern B: JS+HTTP).
+- `SdkCodeExecutor<S>` — standard adapter bridging `SdkExecutor` to `CodeExecutor` (Pattern C: JS+SDK).
+- `McpCodeExecutor<M>` — standard adapter bridging `McpExecutor` to `CodeExecutor` (Pattern D: JS+MCP).
+- `SdkExecutor` now exported from lib.rs (was previously missing).
+
+## [0.2.0] - 2026-04-13
 
 ### Breaking Changes
 
@@ -16,19 +44,24 @@ All notable changes to `pmcp-code-mode` will be documented in this file.
   **Migration:** Add `?` or `.unwrap()` to your constructor calls:
 
   ```rust
-  // Before (v0.0.x):
+  // Before (v0.1.0):
   let pipeline = ValidationPipeline::new(config, secret);
 
-  // After (v0.1.0):
+  // After (v0.2.0):
   let pipeline = ValidationPipeline::new(config, secret)?;
-  // or: let pipeline = ValidationPipeline::new(config, secret).unwrap();
   ```
+
+- `ValidationPipeline::policy_evaluator` field changed from `Option<Box<dyn PolicyEvaluator>>`
+  to `Option<Arc<dyn PolicyEvaluator>>`. `with_policy_evaluator` and `set_policy_evaluator`
+  accept `Arc<dyn PolicyEvaluator>`.
+
+- `language` attribute now selects the validation path at compile time, not just tool metadata.
 
 ### Added
 
 - `TokenError` enum for token generator construction errors (`TokenError::SecretTooShort`).
 - `#[code_mode(context_from = "method_name")]` attribute for real `ValidationContext` binding.
-- `#[code_mode(language = "...")]` attribute to parameterize tool metadata language.
+- `#[code_mode(language = "...")]` attribute — selects validation method and tool metadata.
 - `PolicyEvaluator` trait wiring through `Arc<dyn PolicyEvaluator>` in `ValidationPipeline`.
 - `from_token_secret_with_policy` constructor for derive macro use.
 - Compile-fail trybuild tests for missing `token_secret` and `code_executor` fields.

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-code-mode"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/rust-mcp-sdk"
@@ -40,12 +40,17 @@ swc_common = { version = "18", optional = true }
 # Local Cedar policy evaluation (optional)
 cedar-policy = { version = "4.9", optional = true }
 
+# AWS Verified Permissions (optional)
+aws-config = { version = "1", optional = true }
+aws-sdk-verifiedpermissions = { version = "1", optional = true }
+
 [features]
 default = []
 openapi-code-mode = ["dep:swc_ecma_parser", "dep:swc_ecma_ast", "dep:swc_ecma_visit", "dep:swc_common"]
 js-runtime = ["openapi-code-mode"]
 mcp-code-mode = ["js-runtime"]
 cedar = ["dep:cedar-policy"]
+avp = ["dep:aws-config", "dep:aws-sdk-verifiedpermissions"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -30,7 +30,7 @@ uuid = { version = "1", features = ["v4"] }
 hex = "0.4"
 chrono = "0.4"
 graphql-parser = "0.4"
-toml = "0.8"
+toml = "1.0"
 
 # JavaScript parsing (optional, for OpenAPI Code Mode)
 swc_ecma_parser = { version = "32", optional = true }
@@ -57,4 +57,3 @@ avp = ["dep:aws-config", "dep:aws-sdk-verifiedpermissions"]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 cedar-policy = "4.9"
 proptest = "1.7"
-toml = "0.8"

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -56,3 +56,4 @@ avp = ["dep:aws-config", "dep:aws-sdk-verifiedpermissions"]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 cedar-policy = "4.9"
 proptest = "1.7"
+toml = "0.8"

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -30,6 +30,7 @@ uuid = { version = "1", features = ["v4"] }
 hex = "0.4"
 chrono = "0.4"
 graphql-parser = "0.4"
+toml = "0.8"
 
 # JavaScript parsing (optional, for OpenAPI Code Mode)
 swc_ecma_parser = { version = "32", optional = true }

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-code-mode"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/paiml/rust-mcp-sdk"

--- a/crates/pmcp-code-mode/README.md
+++ b/crates/pmcp-code-mode/README.md
@@ -4,7 +4,7 @@ Code Mode validation and execution framework for MCP servers built on the PMCP S
 
 Enables LLM-generated code (GraphQL, JavaScript, SQL, MCP compositions) to be **validated, explained, and executed** with HMAC-signed approval tokens that cryptographically bind code to its validation result.
 
-> **Status:** v0.1.0 — migrated from `pmcp-run/built-in/shared/pmcp-code-mode` into the SDK workspace in Phase 67.1. The public API is stabilizing; feedback is welcome before the 1.0 contract is locked.
+> **Status:** v0.3.0 — multi-language validation with policy enforcement, standard adapters, deploy-time config. The public API is stabilizing; feedback is welcome before the 1.0 contract is locked.
 
 ## How It Works
 
@@ -468,7 +468,9 @@ See [SECURITY.md](./SECURITY.md) for the full threat model.
 **Policy evaluation:**
 - Default-deny: without a configured `PolicyEvaluator`, only basic config checks run
 - Policy evaluator stored as `Arc<dyn PolicyEvaluator>` — shared safely across async handlers
+- **Both GraphQL and JavaScript** validation call their respective policy evaluation methods (`evaluate_operation` / `evaluate_script`) — fail-closed on policy errors
 - Cedar support via `cedar` feature flag (local evaluation, no network)
+- AVP (AWS Verified Permissions) support via external evaluator — policies configured in pmcp.run admin UI
 - `NoopPolicyEvaluator` for tests only — prominently documented with warnings
 
 ## Schema Exposure Architecture
@@ -515,6 +517,26 @@ pipeline.set_policy_evaluator(Arc::new(my_evaluator));
 
 `#[code_mode(language = "...")]` now dispatches to the correct language-specific validation method at compile time, not just tool metadata. Servers using JavaScript, SQL, or MCP can now use `#[derive(CodeMode)]` instead of manual handler structs.
 
+## Breaking Changes in v0.3.0
+
+### JavaScript derive macro now calls async validation with policy enforcement
+
+`#[derive(CodeMode)]` with `language = "javascript"` now calls `validate_javascript_code_async` instead of the sync `validate_javascript_code`. This means:
+
+- **Cedar policies are now enforced** for JavaScript servers using the derive macro
+- **AVP policies are now enforced** when deployed with `POLICY_STORE_ID` on pmcp.run
+- Policy evaluation failures are **fail-closed** (same as GraphQL) — a policy backend outage blocks requests rather than silently allowing them
+
+If your JavaScript server was relying on the absence of policy enforcement (e.g., using a custom `PolicyEvaluator` that only implemented `evaluate_operation` but not `evaluate_script`), the default `evaluate_script` implementation **denies all scripts**. Override `evaluate_script` in your evaluator to allow scripts, or use `NoopPolicyEvaluator` for testing.
+
+### Standard adapters added
+
+`JsCodeExecutor`, `SdkCodeExecutor`, and `McpCodeExecutor` are new. They don't break existing code, but if you were manually implementing `CodeExecutor` for JS plan execution, you can now replace ~75 lines of boilerplate with:
+
+```rust
+let code_executor = Arc::new(JsCodeExecutor::new(http_client, ExecutionConfig::default()));
+```
+
 See [CHANGELOG.md](./CHANGELOG.md) for the full list of changes.
 
 ## Known Limitations (v0.1.0)
@@ -525,9 +547,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for the full list of changes.
 
 3. **No server-side token revocation.** Tokens are stateless (verified by HMAC). Once issued, a token is valid until it expires. Short TTL (5 min default) mitigates this.
 
-4. **JavaScript validation is sync only.** `validate_javascript_code` is synchronous (no async variant). The derive macro handles this transparently — the generated async handler calls the sync method without `.await`.
-
-5. **SQL and MCP validators are stub.** The `validate_sql_query` and `validate_mcp_composition` methods require their respective feature flags. These validators are being implemented — the derive macro dispatch is ready.
+4. **SQL and MCP validators are stub.** The `validate_sql_query` and `validate_mcp_composition` methods require their respective feature flags. These validators are being implemented — the derive macro dispatch is ready.
 
 ## Crate Dependencies
 

--- a/crates/pmcp-code-mode/README.md
+++ b/crates/pmcp-code-mode/README.md
@@ -308,6 +308,134 @@ The pipeline enforces config-level authorization checks before policy evaluation
 - **Query control:** `blocked_queries` (blocklist), `allowed_queries` (allowlist). Same allowlist-takes-precedence semantics as mutations.
 - **Policy evaluation:** After config checks pass, `PolicyEvaluator::evaluate_operation()` runs (if configured) for fine-grained authorization.
 
+## Deployment Configuration (`config.toml`)
+
+When deploying with `cargo pmcp deploy`, the server's `config.toml` is automatically included in the deploy ZIP. The pmcp.run platform extracts operation metadata from this file to populate the Code Mode policy page in the admin UI — administrators can then enable/disable individual operations by category.
+
+### config.toml Schema
+
+The `[[code_mode.operations]]` section declares available operations. When present, it takes priority over `[[tools]]` for policy categorization.
+
+**OpenAPI server:**
+
+```toml
+[server]
+name = "cost-coach"
+type = "openapi-api"
+
+[code_mode]
+allow_writes = false
+allow_deletes = false
+
+[[code_mode.operations]]
+name = "getCostAndUsage"
+description = "Retrieve AWS cost and usage data"
+path = "/ce/GetCostAndUsage"
+method = "POST"
+
+[[code_mode.operations]]
+name = "getRecommendations"
+description = "Get cost optimization recommendations"
+path = "/ce/GetRightsizingRecommendation"
+method = "POST"
+
+[[code_mode.operations]]
+name = "deleteBudget"
+description = "Delete a budget"
+path = "/budgets/DeleteBudget"
+method = "POST"
+destructive_hint = true
+```
+
+**GraphQL server:**
+
+```toml
+[server]
+name = "open-images"
+type = "graphql-api"
+
+[code_mode]
+allow_writes = false
+
+[[code_mode.operations]]
+name = "searchImages"
+operation_type = "query"
+description = "Search the image catalog"
+
+[[code_mode.operations]]
+name = "createCollection"
+operation_type = "mutation"
+description = "Create a new image collection"
+
+[[code_mode.operations]]
+name = "deleteImage"
+operation_type = "mutation"
+description = "Permanently delete an image"
+destructive_hint = true
+```
+
+**SQL server:**
+
+```toml
+[server]
+name = "analytics"
+type = "sql"
+
+[code_mode]
+allow_writes = true
+allow_deletes = false
+blocked_tables = ["audit_log", "credentials"]
+
+[database]
+[[database.tables]]
+name = "orders"
+description = "Customer order history"
+
+[[database.tables]]
+name = "products"
+description = "Product catalog"
+```
+
+**MCP composition server:**
+
+```toml
+[server]
+name = "orchestrator"
+type = "mcp-api"
+
+[[code_mode.operations]]
+name = "analyze_costs"
+description = "Multi-step cost analysis workflow"
+operation_category = "read"
+
+[[code_mode.operations]]
+name = "provision_resources"
+description = "Provision cloud resources"
+operation_category = "admin"
+```
+
+### Categorization Rules
+
+Operations are automatically categorized based on server type:
+
+| Server Type | Read | Write | Delete | Admin |
+|-------------|------|-------|--------|-------|
+| **OpenAPI** | GET, HEAD, OPTIONS | POST, PUT, PATCH | DELETE | `operation_category = "admin"` |
+| **GraphQL** | query | mutation | mutation with `destructive_hint` or delete/remove/destroy prefix | `operation_category = "admin"` |
+| **SQL** | SELECT on non-blocked tables | INSERT, UPDATE (if `allow_writes`) | DELETE (if `allow_deletes`) | — |
+| **MCP-API** | `read_only_hint` / default | create/add/update/set name patterns | delete/remove/destroy patterns | `operation_category = "admin"` |
+
+The `operation_category` field overrides automatic categorization when set explicitly.
+
+### Config File Resolution
+
+`cargo pmcp deploy` finds the config file using this resolution order:
+
+1. `config.toml` in the server crate root
+2. Single `.toml` file in `instances/` directory
+
+The same file the server embeds via `include_str!()` in `main.rs`.
+
 ## Feature Flags
 
 | Feature | Default | What It Adds |

--- a/crates/pmcp-code-mode/src/avp.rs
+++ b/crates/pmcp-code-mode/src/avp.rs
@@ -172,7 +172,10 @@ impl AvpClient {
             .entities(entities)
             .send()
             .await
-            .map_err(|e| AvpError::SdkError(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(error = ?e, "AVP is_authorized failed");
+                AvpError::SdkError(e.to_string())
+            })?;
 
         Ok(self.parse_response(&response))
     }
@@ -219,7 +222,10 @@ impl AvpClient {
             .entities(EntitiesDefinition::EntityList(entities))
             .send()
             .await
-            .map_err(|e| AvpError::SdkError(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(error = ?e, "AVP is_authorized failed");
+                AvpError::SdkError(e.to_string())
+            })?;
 
         Ok(self.parse_response(&response))
     }
@@ -277,7 +283,10 @@ impl AvpClient {
                 .entities(EntitiesDefinition::EntityList(all_entities))
                 .send()
                 .await
-                .map_err(|e| AvpError::SdkError(e.to_string()))?;
+                .map_err(|e| {
+                    tracing::error!(error = ?e, "AVP is_authorized failed");
+                    AvpError::SdkError(e.to_string())
+                })?;
 
             for result in response.results() {
                 let allowed =
@@ -527,7 +536,10 @@ impl AvpClient {
             .entities(entities)
             .send()
             .await
-            .map_err(|e| AvpError::SdkError(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(error = ?e, "AVP is_authorized failed");
+                AvpError::SdkError(e.to_string())
+            })?;
 
         Ok(self.parse_response(&response))
     }

--- a/crates/pmcp-code-mode/src/avp.rs
+++ b/crates/pmcp-code-mode/src/avp.rs
@@ -1,0 +1,816 @@
+//! Amazon Verified Permissions (AVP) policy evaluator for Code Mode.
+//!
+//! Provides [`AvpPolicyEvaluator`] — an implementation of [`PolicyEvaluator`] backed by
+//! AWS Verified Permissions. Supports both GraphQL (`evaluate_operation`) and JavaScript
+//! (`evaluate_script`) policy evaluation.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use pmcp_code_mode::{AvpClient, AvpConfig, AvpPolicyEvaluator};
+//! use std::sync::Arc;
+//!
+//! // Construct from POLICY_STORE_ID env var (injected by pmcp.run platform)
+//! let config = AvpConfig {
+//!     policy_store_id: std::env::var("POLICY_STORE_ID").unwrap(),
+//!     region: None, // uses default AWS region
+//! };
+//! let client = AvpClient::new(config).await?;
+//! let evaluator = Arc::new(AvpPolicyEvaluator::new(client));
+//! ```
+//!
+//! # Feature Gate
+//!
+//! This module requires the `avp` feature:
+//! ```toml
+//! pmcp-code-mode = { version = "0.4.0", features = ["avp"] }
+//! ```
+
+use aws_config::BehaviorVersion;
+use aws_sdk_verifiedpermissions::{
+    types::{ActionIdentifier, AttributeValue, EntitiesDefinition, EntityIdentifier, EntityItem},
+    Client,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+
+use crate::policy::{
+    AuthorizationDecision, OperationEntity, PolicyEvaluationError, PolicyEvaluator,
+    ServerConfigEntity,
+};
+
+#[cfg(feature = "openapi-code-mode")]
+use crate::policy::{normalize_operation_format, OpenAPIServerEntity, ScriptEntity};
+
+/// Configuration for the AVP client.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AvpConfig {
+    /// The AVP Policy Store ID for this server.
+    pub policy_store_id: String,
+
+    /// AWS region (optional, uses default if not set).
+    #[serde(default)]
+    pub region: Option<String>,
+}
+
+impl Default for AvpConfig {
+    fn default() -> Self {
+        Self {
+            policy_store_id: String::new(),
+            region: None,
+        }
+    }
+}
+
+/// Error type for AVP operations.
+#[derive(Debug, thiserror::Error)]
+pub enum AvpError {
+    #[error("AVP configuration error: {0}")]
+    ConfigError(String),
+
+    #[error("AVP SDK error: {0}")]
+    SdkError(String),
+
+    #[error("Authorization denied: {0}")]
+    Denied(String),
+}
+
+/// AVP client for Code Mode policy evaluation.
+///
+/// Wraps the AWS SDK `verifiedpermissions::Client` and provides typed methods
+/// for authorizing GraphQL operations and JavaScript scripts against Cedar
+/// policies managed in AWS Verified Permissions.
+#[derive(Clone)]
+pub struct AvpClient {
+    client: Client,
+    policy_store_id: String,
+}
+
+impl AvpClient {
+    /// Create a new AVP client.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AvpError::ConfigError`] if the policy store ID is empty.
+    pub async fn new(config: AvpConfig) -> Result<Self, AvpError> {
+        if config.policy_store_id.is_empty() {
+            return Err(AvpError::ConfigError(
+                "Policy store ID is required".to_string(),
+            ));
+        }
+
+        let aws_config = if let Some(region) = &config.region {
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(aws_config::Region::new(region.clone()))
+                .load()
+                .await
+        } else {
+            aws_config::load_defaults(BehaviorVersion::latest()).await
+        };
+
+        let client = Client::new(&aws_config);
+
+        Ok(Self {
+            client,
+            policy_store_id: config.policy_store_id,
+        })
+    }
+
+    /// Check if a GraphQL operation is authorized.
+    pub async fn is_authorized(
+        &self,
+        operation: &OperationEntity,
+        server_config: &ServerConfigEntity,
+    ) -> Result<AuthorizationDecision, AvpError> {
+        let entities = self.build_entities(operation, server_config);
+
+        let action_id = if operation.has_introspection {
+            "Admin"
+        } else {
+            match operation.operation_type.as_str() {
+                "mutation" => {
+                    let op_name = operation.operation_name.to_lowercase();
+                    if op_name.starts_with("delete")
+                        || op_name.starts_with("remove")
+                        || op_name.starts_with("purge")
+                    {
+                        "Delete"
+                    } else {
+                        "Write"
+                    }
+                },
+                "subscription" => "Write",
+                _ => "Read",
+            }
+        };
+
+        let response = self
+            .client
+            .is_authorized()
+            .policy_store_id(&self.policy_store_id)
+            .principal(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Operation")
+                    .entity_id(&operation.id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .action(
+                ActionIdentifier::builder()
+                    .action_type("CodeMode::Action")
+                    .action_id(action_id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .resource(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Server")
+                    .entity_id(&server_config.server_id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .entities(entities)
+            .send()
+            .await
+            .map_err(|e| AvpError::SdkError(e.to_string()))?;
+
+        Ok(self.parse_response(&response))
+    }
+
+    /// Generic authorization check using raw entity types and attributes.
+    ///
+    /// Use this when your server type has a unique Cedar schema that doesn't
+    /// match the typed entity structs (`OperationEntity`, `ScriptEntity`, etc.).
+    pub async fn is_authorized_raw(
+        &self,
+        principal_type: &str,
+        principal_id: &str,
+        action_type: &str,
+        action_id: &str,
+        resource_type: &str,
+        resource_id: &str,
+        entities: Vec<EntityItem>,
+    ) -> Result<AuthorizationDecision, AvpError> {
+        let response = self
+            .client
+            .is_authorized()
+            .policy_store_id(&self.policy_store_id)
+            .principal(
+                EntityIdentifier::builder()
+                    .entity_type(principal_type)
+                    .entity_id(principal_id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .action(
+                ActionIdentifier::builder()
+                    .action_type(action_type)
+                    .action_id(action_id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .resource(
+                EntityIdentifier::builder()
+                    .entity_type(resource_type)
+                    .entity_id(resource_id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .entities(EntitiesDefinition::EntityList(entities))
+            .send()
+            .await
+            .map_err(|e| AvpError::SdkError(e.to_string()))?;
+
+        Ok(self.parse_response(&response))
+    }
+
+    /// Batch authorization for multiple operations (chunks of 30 per API limit).
+    pub async fn batch_is_authorized(
+        &self,
+        requests: Vec<(OperationEntity, ServerConfigEntity)>,
+    ) -> Result<Vec<AuthorizationDecision>, AvpError> {
+        let mut results = Vec::new();
+
+        for chunk in requests.chunks(30) {
+            let batch_items: Vec<_> = chunk
+                .iter()
+                .map(|(op, config)| {
+                    let action_id = Self::determine_action_id(op);
+
+                    aws_sdk_verifiedpermissions::types::BatchIsAuthorizedInputItem::builder()
+                        .principal(
+                            EntityIdentifier::builder()
+                                .entity_type("CodeMode::Operation")
+                                .entity_id(&op.id)
+                                .build()
+                                .expect("valid entity identifier"),
+                        )
+                        .action(
+                            ActionIdentifier::builder()
+                                .action_type("CodeMode::Action")
+                                .action_id(action_id)
+                                .build()
+                                .expect("valid action identifier"),
+                        )
+                        .resource(
+                            EntityIdentifier::builder()
+                                .entity_type("CodeMode::Server")
+                                .entity_id(&config.server_id)
+                                .build()
+                                .expect("valid entity identifier"),
+                        )
+                        .build()
+                })
+                .collect();
+
+            let mut all_entities = Vec::new();
+            for (op, config) in chunk {
+                all_entities.push(self.build_operation_entity(op));
+                all_entities.push(self.build_server_config_entity(config));
+            }
+
+            let response = self
+                .client
+                .batch_is_authorized()
+                .policy_store_id(&self.policy_store_id)
+                .set_requests(Some(batch_items))
+                .entities(EntitiesDefinition::EntityList(all_entities))
+                .send()
+                .await
+                .map_err(|e| AvpError::SdkError(e.to_string()))?;
+
+            for result in response.results() {
+                let allowed =
+                    result.decision() == &aws_sdk_verifiedpermissions::types::Decision::Allow;
+                results.push(AuthorizationDecision {
+                    allowed,
+                    determining_policies: result
+                        .determining_policies()
+                        .iter()
+                        .map(|p| p.policy_id().to_string())
+                        .collect(),
+                    errors: result
+                        .errors()
+                        .iter()
+                        .map(|e| e.error_description().to_string())
+                        .collect(),
+                });
+            }
+        }
+
+        Ok(results)
+    }
+
+    fn determine_action_id(op: &OperationEntity) -> &'static str {
+        if op.has_introspection {
+            "Admin"
+        } else {
+            match op.operation_type.as_str() {
+                "mutation" => {
+                    let op_name = op.operation_name.to_lowercase();
+                    if op_name.starts_with("delete")
+                        || op_name.starts_with("remove")
+                        || op_name.starts_with("purge")
+                    {
+                        "Delete"
+                    } else {
+                        "Write"
+                    }
+                },
+                "subscription" => "Write",
+                _ => "Read",
+            }
+        }
+    }
+
+    fn parse_response(
+        &self,
+        response: &aws_sdk_verifiedpermissions::operation::is_authorized::IsAuthorizedOutput,
+    ) -> AuthorizationDecision {
+        let allowed = response.decision() == &aws_sdk_verifiedpermissions::types::Decision::Allow;
+        AuthorizationDecision {
+            allowed,
+            determining_policies: response
+                .determining_policies()
+                .iter()
+                .map(|p| p.policy_id().to_string())
+                .collect(),
+            errors: response
+                .errors()
+                .iter()
+                .map(|e| e.error_description().to_string())
+                .collect(),
+        }
+    }
+
+    fn build_entities(
+        &self,
+        operation: &OperationEntity,
+        server_config: &ServerConfigEntity,
+    ) -> EntitiesDefinition {
+        EntitiesDefinition::EntityList(vec![
+            self.build_operation_entity(operation),
+            self.build_server_config_entity(server_config),
+        ])
+    }
+
+    fn build_operation_entity(&self, operation: &OperationEntity) -> EntityItem {
+        let mut attrs: HashMap<String, AttributeValue> = HashMap::new();
+        attrs.insert(
+            "operationType".into(),
+            AttributeValue::String(operation.operation_type.clone()),
+        );
+        attrs.insert(
+            "operationName".into(),
+            AttributeValue::String(operation.operation_name.clone()),
+        );
+        attrs.insert("depth".into(), AttributeValue::Long(operation.depth as i64));
+        attrs.insert(
+            "fieldCount".into(),
+            AttributeValue::Long(operation.field_count as i64),
+        );
+        attrs.insert(
+            "estimatedCost".into(),
+            AttributeValue::Long(operation.estimated_cost as i64),
+        );
+        attrs.insert(
+            "hasIntrospection".into(),
+            AttributeValue::Boolean(operation.has_introspection),
+        );
+        attrs.insert(
+            "accessesSensitiveData".into(),
+            AttributeValue::Boolean(operation.accesses_sensitive_data),
+        );
+        attrs.insert(
+            "rootFields".into(),
+            Self::string_set(&operation.root_fields),
+        );
+        attrs.insert(
+            "accessedTypes".into(),
+            Self::string_set(&operation.accessed_types),
+        );
+        attrs.insert(
+            "accessedFields".into(),
+            Self::string_set(&operation.accessed_fields),
+        );
+        attrs.insert(
+            "sensitiveCategories".into(),
+            Self::string_set(&operation.sensitive_categories),
+        );
+
+        EntityItem::builder()
+            .identifier(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Operation")
+                    .entity_id(&operation.id)
+                    .build()
+                    .expect("valid entity identifier"),
+            )
+            .set_attributes(Some(attrs))
+            .build()
+    }
+
+    fn build_server_config_entity(&self, config: &ServerConfigEntity) -> EntityItem {
+        let mut attrs: HashMap<String, AttributeValue> = HashMap::new();
+        attrs.insert(
+            "serverId".into(),
+            AttributeValue::String(config.server_id.clone()),
+        );
+        attrs.insert(
+            "serverType".into(),
+            AttributeValue::String(config.server_type.clone()),
+        );
+        attrs.insert(
+            "allowWrite".into(),
+            AttributeValue::Boolean(config.allow_write),
+        );
+        attrs.insert(
+            "allowDelete".into(),
+            AttributeValue::Boolean(config.allow_delete),
+        );
+        attrs.insert(
+            "allowAdmin".into(),
+            AttributeValue::Boolean(config.allow_admin),
+        );
+        attrs.insert(
+            "maxDepth".into(),
+            AttributeValue::Long(config.max_depth as i64),
+        );
+        attrs.insert(
+            "maxFieldCount".into(),
+            AttributeValue::Long(config.max_field_count as i64),
+        );
+        attrs.insert(
+            "maxCost".into(),
+            AttributeValue::Long(config.max_cost as i64),
+        );
+        attrs.insert(
+            "maxApiCalls".into(),
+            AttributeValue::Long(config.max_api_calls as i64),
+        );
+        attrs.insert(
+            "allowedOperations".into(),
+            Self::string_set(&config.allowed_operations),
+        );
+        attrs.insert(
+            "blockedOperations".into(),
+            Self::string_set(&config.blocked_operations),
+        );
+        attrs.insert(
+            "blockedFields".into(),
+            Self::string_set(&config.blocked_fields),
+        );
+
+        EntityItem::builder()
+            .identifier(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Server")
+                    .entity_id(&config.server_id)
+                    .build()
+                    .expect("valid entity identifier"),
+            )
+            .set_attributes(Some(attrs))
+            .build()
+    }
+
+    fn string_set(set: &HashSet<String>) -> AttributeValue {
+        AttributeValue::Set(
+            set.iter()
+                .map(|s| AttributeValue::String(s.clone()))
+                .collect(),
+        )
+    }
+}
+
+// ============================================================================
+// OpenAPI Code Mode Support (Script-based validation)
+// ============================================================================
+
+#[cfg(feature = "openapi-code-mode")]
+impl AvpClient {
+    /// Check if a JavaScript script is authorized (OpenAPI Code Mode).
+    pub async fn is_script_authorized(
+        &self,
+        script: &ScriptEntity,
+        server: &OpenAPIServerEntity,
+    ) -> Result<AuthorizationDecision, AvpError> {
+        let entities = EntitiesDefinition::EntityList(vec![
+            self.build_script_entity(script),
+            self.build_openapi_server_entity(server),
+        ]);
+
+        let response = self
+            .client
+            .is_authorized()
+            .policy_store_id(&self.policy_store_id)
+            .principal(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Script")
+                    .entity_id(&script.id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .action(
+                ActionIdentifier::builder()
+                    .action_type("CodeMode::Action")
+                    .action_id(script.action())
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .resource(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Server")
+                    .entity_id(&server.server_id)
+                    .build()
+                    .map_err(|e| AvpError::SdkError(e.to_string()))?,
+            )
+            .entities(entities)
+            .send()
+            .await
+            .map_err(|e| AvpError::SdkError(e.to_string()))?;
+
+        Ok(self.parse_response(&response))
+    }
+
+    fn build_script_entity(&self, script: &ScriptEntity) -> EntityItem {
+        let mut attrs: HashMap<String, AttributeValue> = HashMap::new();
+        attrs.insert(
+            "scriptType".into(),
+            AttributeValue::String(script.script_type.clone()),
+        );
+        attrs.insert(
+            "hasWrites".into(),
+            AttributeValue::Boolean(script.has_writes),
+        );
+        attrs.insert(
+            "hasDeletes".into(),
+            AttributeValue::Boolean(script.has_deletes),
+        );
+        attrs.insert(
+            "accessesSensitivePath".into(),
+            AttributeValue::Boolean(script.accesses_sensitive_path),
+        );
+        attrs.insert(
+            "hasUnboundedLoop".into(),
+            AttributeValue::Boolean(script.has_unbounded_loop),
+        );
+        attrs.insert(
+            "hasDynamicPath".into(),
+            AttributeValue::Boolean(script.has_dynamic_path),
+        );
+        attrs.insert(
+            "totalApiCalls".into(),
+            AttributeValue::Long(script.total_api_calls as i64),
+        );
+        attrs.insert(
+            "readCalls".into(),
+            AttributeValue::Long(script.read_calls as i64),
+        );
+        attrs.insert(
+            "writeCalls".into(),
+            AttributeValue::Long(script.write_calls as i64),
+        );
+        attrs.insert(
+            "deleteCalls".into(),
+            AttributeValue::Long(script.delete_calls as i64),
+        );
+        attrs.insert(
+            "loopIterations".into(),
+            AttributeValue::Long(script.loop_iterations as i64),
+        );
+        attrs.insert(
+            "nestingDepth".into(),
+            AttributeValue::Long(script.nesting_depth as i64),
+        );
+        attrs.insert(
+            "scriptLength".into(),
+            AttributeValue::Long(script.script_length as i64),
+        );
+        attrs.insert(
+            "accessedPaths".into(),
+            Self::string_set(&script.accessed_paths),
+        );
+        attrs.insert(
+            "accessedMethods".into(),
+            Self::string_set(&script.accessed_methods),
+        );
+        attrs.insert(
+            "pathPatterns".into(),
+            Self::string_set(&script.path_patterns),
+        );
+        attrs.insert(
+            "calledOperations".into(),
+            Self::string_set(&script.called_operations),
+        );
+        attrs.insert(
+            "hasOutputDeclaration".into(),
+            AttributeValue::Boolean(script.has_output_declaration),
+        );
+        attrs.insert(
+            "outputFields".into(),
+            Self::string_set(&script.output_fields),
+        );
+        attrs.insert(
+            "hasSpreadInOutput".into(),
+            AttributeValue::Boolean(script.has_spread_in_output),
+        );
+
+        EntityItem::builder()
+            .identifier(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Script")
+                    .entity_id(&script.id)
+                    .build()
+                    .expect("valid entity identifier"),
+            )
+            .set_attributes(Some(attrs))
+            .build()
+    }
+
+    fn build_openapi_server_entity(&self, server: &OpenAPIServerEntity) -> EntityItem {
+        let mut attrs: HashMap<String, AttributeValue> = HashMap::new();
+        attrs.insert(
+            "serverId".into(),
+            AttributeValue::String(server.server_id.clone()),
+        );
+        attrs.insert(
+            "serverType".into(),
+            AttributeValue::String(server.server_type.clone()),
+        );
+        attrs.insert(
+            "allowWrite".into(),
+            AttributeValue::Boolean(server.allow_write),
+        );
+        attrs.insert(
+            "allowDelete".into(),
+            AttributeValue::Boolean(server.allow_delete),
+        );
+        attrs.insert(
+            "allowAdmin".into(),
+            AttributeValue::Boolean(server.allow_admin),
+        );
+        attrs.insert(
+            "writeMode".into(),
+            AttributeValue::String(server.write_mode.clone()),
+        );
+        attrs.insert(
+            "maxDepth".into(),
+            AttributeValue::Long(server.max_depth as i64),
+        );
+        attrs.insert(
+            "maxCost".into(),
+            AttributeValue::Long(server.max_cost as i64),
+        );
+        attrs.insert(
+            "maxApiCalls".into(),
+            AttributeValue::Long(server.max_api_calls as i64),
+        );
+        attrs.insert(
+            "maxLoopIterations".into(),
+            AttributeValue::Long(server.max_loop_iterations as i64),
+        );
+        attrs.insert(
+            "maxScriptLength".into(),
+            AttributeValue::Long(server.max_script_length as i64),
+        );
+        attrs.insert(
+            "maxNestingDepth".into(),
+            AttributeValue::Long(server.max_nesting_depth as i64),
+        );
+        attrs.insert(
+            "executionTimeoutSeconds".into(),
+            AttributeValue::Long(server.execution_timeout_seconds as i64),
+        );
+        attrs.insert(
+            "allowedOperations".into(),
+            AttributeValue::Set(
+                server
+                    .allowed_operations
+                    .iter()
+                    .map(|s| AttributeValue::String(normalize_operation_format(s)))
+                    .collect(),
+            ),
+        );
+        attrs.insert(
+            "blockedOperations".into(),
+            AttributeValue::Set(
+                server
+                    .blocked_operations
+                    .iter()
+                    .map(|s| AttributeValue::String(normalize_operation_format(s)))
+                    .collect(),
+            ),
+        );
+        attrs.insert(
+            "allowedMethods".into(),
+            Self::string_set(&server.allowed_methods),
+        );
+        attrs.insert(
+            "blockedMethods".into(),
+            Self::string_set(&server.blocked_methods),
+        );
+        attrs.insert(
+            "allowedPathPatterns".into(),
+            Self::string_set(&server.allowed_path_patterns),
+        );
+        attrs.insert(
+            "blockedPathPatterns".into(),
+            Self::string_set(&server.blocked_path_patterns),
+        );
+        attrs.insert(
+            "sensitivePathPatterns".into(),
+            Self::string_set(&server.sensitive_path_patterns),
+        );
+        attrs.insert(
+            "autoApproveReadOnly".into(),
+            AttributeValue::Boolean(server.auto_approve_read_only),
+        );
+        attrs.insert(
+            "maxApiCallsForAutoApprove".into(),
+            AttributeValue::Long(server.max_api_calls_for_auto_approve as i64),
+        );
+        attrs.insert(
+            "internalBlockedFields".into(),
+            Self::string_set(&server.internal_blocked_fields),
+        );
+        attrs.insert(
+            "outputBlockedFields".into(),
+            Self::string_set(&server.output_blocked_fields),
+        );
+        attrs.insert(
+            "requireOutputDeclaration".into(),
+            AttributeValue::Boolean(server.require_output_declaration),
+        );
+
+        EntityItem::builder()
+            .identifier(
+                EntityIdentifier::builder()
+                    .entity_type("CodeMode::Server")
+                    .entity_id(&server.server_id)
+                    .build()
+                    .expect("valid entity identifier"),
+            )
+            .set_attributes(Some(attrs))
+            .build()
+    }
+}
+
+/// AVP-based policy evaluator implementing the [`PolicyEvaluator`] trait.
+///
+/// This wraps [`AvpClient`] and provides the standard `PolicyEvaluator` interface
+/// for use with `ValidationPipeline` and `#[derive(CodeMode)]`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use pmcp_code_mode::{AvpClient, AvpConfig, AvpPolicyEvaluator, NoopPolicyEvaluator};
+/// use std::sync::Arc;
+///
+/// // Runtime selection based on environment
+/// let evaluator: Arc<dyn PolicyEvaluator> = match std::env::var("POLICY_STORE_ID") {
+///     Ok(store_id) => Arc::new(AvpPolicyEvaluator::new(
+///         AvpClient::new(AvpConfig { policy_store_id: store_id, region: None }).await?
+///     )),
+///     Err(_) => Arc::new(NoopPolicyEvaluator::new()),
+/// };
+/// ```
+pub struct AvpPolicyEvaluator {
+    client: AvpClient,
+}
+
+impl AvpPolicyEvaluator {
+    /// Create a new AVP policy evaluator.
+    pub fn new(client: AvpClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl PolicyEvaluator for AvpPolicyEvaluator {
+    async fn evaluate_operation(
+        &self,
+        operation: &OperationEntity,
+        server_config: &ServerConfigEntity,
+    ) -> Result<AuthorizationDecision, PolicyEvaluationError> {
+        self.client
+            .is_authorized(operation, server_config)
+            .await
+            .map_err(|e| PolicyEvaluationError::EvaluationError(e.to_string()))
+    }
+
+    #[cfg(feature = "openapi-code-mode")]
+    async fn evaluate_script(
+        &self,
+        script: &ScriptEntity,
+        server: &OpenAPIServerEntity,
+    ) -> Result<AuthorizationDecision, PolicyEvaluationError> {
+        self.client
+            .is_script_authorized(script, server)
+            .await
+            .map_err(|e| PolicyEvaluationError::EvaluationError(e.to_string()))
+    }
+
+    fn name(&self) -> &str {
+        "avp"
+    }
+}

--- a/crates/pmcp-code-mode/src/cedar_validation.rs
+++ b/crates/pmcp-code-mode/src/cedar_validation.rs
@@ -56,6 +56,7 @@ pub const GRAPHQL_CEDAR_SCHEMA: &str = r#"{
                         "maxDepth": { "type": "Long", "required": true },
                         "maxFieldCount": { "type": "Long", "required": true },
                         "maxCost": { "type": "Long", "required": true },
+                        "maxApiCalls": { "type": "Long", "required": true },
                         "allowWrite": { "type": "Boolean", "required": true },
                         "allowDelete": { "type": "Boolean", "required": true },
                         "allowAdmin": { "type": "Boolean", "required": true },
@@ -116,6 +117,7 @@ pub const OPENAPI_CEDAR_SCHEMA: &str = r#"{
                         "accessedPaths": { "type": "Set", "element": { "type": "String" } },
                         "accessedMethods": { "type": "Set", "element": { "type": "String" } },
                         "pathPatterns": { "type": "Set", "element": { "type": "String" } },
+                        "calledOperations": { "type": "Set", "element": { "type": "String" } },
                         "loopIterations": { "type": "Long", "required": true },
                         "nestingDepth": { "type": "Long", "required": true },
                         "scriptLength": { "type": "Long", "required": true },
@@ -134,6 +136,9 @@ pub const OPENAPI_CEDAR_SCHEMA: &str = r#"{
                     "attributes": {
                         "serverId": { "type": "String", "required": true },
                         "serverType": { "type": "String", "required": true },
+                        "writeMode": { "type": "String", "required": true },
+                        "maxDepth": { "type": "Long", "required": true },
+                        "maxCost": { "type": "Long", "required": true },
                         "maxApiCalls": { "type": "Long", "required": true },
                         "maxLoopIterations": { "type": "Long", "required": true },
                         "maxScriptLength": { "type": "Long", "required": true },
@@ -144,6 +149,7 @@ pub const OPENAPI_CEDAR_SCHEMA: &str = r#"{
                         "allowAdmin": { "type": "Boolean", "required": true },
                         "blockedOperations": { "type": "Set", "element": { "type": "String" } },
                         "allowedOperations": { "type": "Set", "element": { "type": "String" } },
+                        "blockedFields": { "type": "Set", "element": { "type": "String" } },
                         "allowedMethods": { "type": "Set", "element": { "type": "String" } },
                         "blockedMethods": { "type": "Set", "element": { "type": "String" } },
                         "allowedPathPatterns": { "type": "Set", "element": { "type": "String" } },
@@ -845,5 +851,115 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ==========================================================================
+    // SCHEMA SYNC TESTS (cedar_validation.rs ↔ types.rs must agree)
+    // ==========================================================================
+
+    /// Extract sorted attribute names from a Cedar JSON schema entity type.
+    fn extract_attrs(schema_json: &serde_json::Value, entity_type: &str) -> Vec<String> {
+        let attrs = &schema_json["CodeMode"]["entityTypes"][entity_type]["shape"]["attributes"];
+        let mut names: Vec<String> = attrs
+            .as_object()
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default();
+        names.sort();
+        names
+    }
+
+    #[cfg(feature = "openapi-code-mode")]
+    #[test]
+    fn test_openapi_schema_sources_in_sync() {
+        // cedar_validation.rs (test const — also used by platform for AVP schema provisioning)
+        let const_schema: serde_json::Value =
+            serde_json::from_str(OPENAPI_CEDAR_SCHEMA).expect("const schema should parse");
+
+        // types.rs (runtime JSON export)
+        let runtime_schema = get_openapi_code_mode_schema_json();
+
+        // Server entity attributes must match
+        let const_server = extract_attrs(&const_schema, "Server");
+        let runtime_server = extract_attrs(&runtime_schema, "Server");
+        assert_eq!(
+            const_server, runtime_server,
+            "OPENAPI_CEDAR_SCHEMA Server attrs != get_openapi_code_mode_schema_json() Server attrs\n\
+             const only: {:?}\n\
+             runtime only: {:?}",
+            const_server
+                .iter()
+                .filter(|a| !runtime_server.contains(a))
+                .collect::<Vec<_>>(),
+            runtime_server
+                .iter()
+                .filter(|a| !const_server.contains(a))
+                .collect::<Vec<_>>(),
+        );
+
+        // Script entity attributes must match
+        let const_script = extract_attrs(&const_schema, "Script");
+        let runtime_script = extract_attrs(&runtime_schema, "Script");
+        assert_eq!(
+            const_script, runtime_script,
+            "OPENAPI_CEDAR_SCHEMA Script attrs != get_openapi_code_mode_schema_json() Script attrs\n\
+             const only: {:?}\n\
+             runtime only: {:?}",
+            const_script
+                .iter()
+                .filter(|a| !runtime_script.contains(a))
+                .collect::<Vec<_>>(),
+            runtime_script
+                .iter()
+                .filter(|a| !const_script.contains(a))
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_graphql_schema_sources_in_sync() {
+        // cedar_validation.rs
+        let const_schema: serde_json::Value =
+            serde_json::from_str(GRAPHQL_CEDAR_SCHEMA).expect("const schema should parse");
+
+        // types.rs
+        let runtime_schema = get_code_mode_schema_json();
+
+        // Server entity attributes must match
+        let const_server = extract_attrs(&const_schema, "Server");
+        let runtime_server = extract_attrs(&runtime_schema, "Server");
+        assert_eq!(
+            const_server,
+            runtime_server,
+            "GRAPHQL_CEDAR_SCHEMA Server attrs != get_code_mode_schema_json() Server attrs\n\
+             const only: {:?}\n\
+             runtime only: {:?}",
+            const_server
+                .iter()
+                .filter(|a| !runtime_server.contains(a))
+                .collect::<Vec<_>>(),
+            runtime_server
+                .iter()
+                .filter(|a| !const_server.contains(a))
+                .collect::<Vec<_>>(),
+        );
+
+        // Operation entity attributes must match
+        let const_op = extract_attrs(&const_schema, "Operation");
+        let runtime_op = extract_attrs(&runtime_schema, "Operation");
+        assert_eq!(
+            const_op,
+            runtime_op,
+            "GRAPHQL_CEDAR_SCHEMA Operation attrs != get_code_mode_schema_json() Operation attrs\n\
+             const only: {:?}\n\
+             runtime only: {:?}",
+            const_op
+                .iter()
+                .filter(|a| !runtime_op.contains(a))
+                .collect::<Vec<_>>(),
+            runtime_op
+                .iter()
+                .filter(|a| !const_op.contains(a))
+                .collect::<Vec<_>>(),
+        );
     }
 }

--- a/crates/pmcp-code-mode/src/config.rs
+++ b/crates/pmcp-code-mode/src/config.rs
@@ -28,25 +28,39 @@ pub struct OperationEntry {
 }
 
 /// Registry built from [[code_mode.operations]] config entries.
-/// Maps raw paths to canonical operation IDs.
+/// Maps raw paths to canonical operation IDs and categories.
 #[derive(Debug, Clone, Default)]
 pub struct OperationRegistry {
     path_to_id: HashMap<String, String>,
+    path_to_category: HashMap<String, String>,
 }
 
 impl OperationRegistry {
     pub fn from_entries(entries: &[OperationEntry]) -> Self {
         let mut path_to_id = HashMap::with_capacity(entries.len());
+        let mut path_to_category = HashMap::with_capacity(entries.len());
         for entry in entries {
             if let Some(ref path) = entry.path {
                 path_to_id.insert(path.clone(), entry.id.clone());
+                if !entry.category.is_empty() {
+                    path_to_category.insert(path.clone(), entry.category.clone());
+                }
             }
         }
-        Self { path_to_id }
+        Self {
+            path_to_id,
+            path_to_category,
+        }
     }
 
     pub fn lookup(&self, path: &str) -> Option<&str> {
         self.path_to_id.get(path).map(|s| s.as_str())
+    }
+
+    /// Look up the declared category for a path (e.g., "read", "write", "delete", "admin").
+    /// Returns `None` if the path has no registry entry or no category declared.
+    pub fn lookup_category(&self, path: &str) -> Option<&str> {
+        self.path_to_category.get(path).map(|s| s.as_str())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -456,6 +470,53 @@ mod tests {
         let registry = OperationRegistry::from_entries(&entries);
         assert_eq!(registry.lookup("/unknownPath"), None);
         assert_eq!(registry.lookup(""), None);
+    }
+
+    #[test]
+    fn test_operation_registry_lookup_category() {
+        let entries = vec![
+            OperationEntry {
+                id: "getCostAnomalies".to_string(),
+                category: "read".to_string(),
+                description: String::new(),
+                path: Some("/getCostAnomalies".to_string()),
+            },
+            OperationEntry {
+                id: "deleteReservation".to_string(),
+                category: "delete".to_string(),
+                description: String::new(),
+                path: Some("/deleteReservation".to_string()),
+            },
+            OperationEntry {
+                id: "updateBudget".to_string(),
+                category: "write".to_string(),
+                description: String::new(),
+                path: Some("/updateBudget".to_string()),
+            },
+        ];
+        let registry = OperationRegistry::from_entries(&entries);
+        assert_eq!(registry.lookup_category("/getCostAnomalies"), Some("read"));
+        assert_eq!(
+            registry.lookup_category("/deleteReservation"),
+            Some("delete")
+        );
+        assert_eq!(registry.lookup_category("/updateBudget"), Some("write"));
+        assert_eq!(registry.lookup_category("/unknownPath"), None);
+    }
+
+    #[test]
+    fn test_operation_registry_empty_category_excluded() {
+        let entries = vec![OperationEntry {
+            id: "legacyOp".to_string(),
+            category: String::new(), // empty = not declared
+            description: String::new(),
+            path: Some("/legacyOp".to_string()),
+        }];
+        let registry = OperationRegistry::from_entries(&entries);
+        // ID lookup still works
+        assert_eq!(registry.lookup("/legacyOp"), Some("legacyOp"));
+        // Category lookup returns None for empty category
+        assert_eq!(registry.lookup_category("/legacyOp"), None);
     }
 
     #[test]

--- a/crates/pmcp-code-mode/src/config.rs
+++ b/crates/pmcp-code-mode/src/config.rs
@@ -241,7 +241,34 @@ impl Default for CodeModeConfig {
     }
 }
 
+/// Wrapper for deserializing the `[code_mode]` section from a full TOML config file.
+/// The file may contain other sections (`[server]`, `[[tools]]`, etc.) which are ignored.
+#[derive(Deserialize)]
+struct TomlWrapper {
+    #[serde(default)]
+    code_mode: CodeModeConfig,
+}
+
 impl CodeModeConfig {
+    /// Parse `CodeModeConfig` from a full TOML config string.
+    ///
+    /// Extracts the `[code_mode]` section (including `[[code_mode.operations]]`)
+    /// and ignores all other sections. This is the recommended way for external
+    /// servers to build their config from `config.toml`:
+    ///
+    /// ```rust,ignore
+    /// const CONFIG_TOML: &str = include_str!("../../config.toml");
+    ///
+    /// let config = CodeModeConfig::from_toml(CONFIG_TOML)
+    ///     .expect("Invalid code_mode section in config.toml");
+    /// ```
+    ///
+    /// If the TOML has no `[code_mode]` section, returns `CodeModeConfig::default()`.
+    pub fn from_toml(toml_str: &str) -> Result<Self, toml::de::Error> {
+        let wrapper: TomlWrapper = toml::from_str(toml_str)?;
+        Ok(wrapper.code_mode)
+    }
+
     /// Create a new config with Code Mode enabled.
     pub fn enabled() -> Self {
         Self {
@@ -493,5 +520,57 @@ enabled = true
         let config: CodeModeConfig = toml::from_str(toml_str).expect("Failed to deserialize");
         assert!(config.enabled);
         assert!(config.operations.is_empty());
+    }
+
+    #[test]
+    fn test_from_toml_extracts_code_mode_section() {
+        let toml_str = r#"
+[server]
+name = "cost-coach"
+type = "openapi-api"
+
+[code_mode]
+enabled = true
+token_ttl_seconds = 600
+server_id = "cost-coach"
+
+[[code_mode.operations]]
+id = "getCostAndUsage"
+category = "read"
+description = "Historical cost and usage data"
+path = "/getCostAndUsage"
+
+[[code_mode.operations]]
+id = "getCostAnomalies"
+category = "read"
+description = "Cost anomalies detected by AWS"
+path = "/getCostAnomalies"
+
+[[tools]]
+name = "some_tool"
+"#;
+        let config = CodeModeConfig::from_toml(toml_str).expect("Failed to parse");
+        assert!(config.enabled);
+        assert_eq!(config.token_ttl_seconds, 600);
+        assert_eq!(config.server_id, Some("cost-coach".to_string()));
+        assert_eq!(config.operations.len(), 2);
+        assert_eq!(config.operations[0].id, "getCostAndUsage");
+        assert_eq!(config.operations[1].id, "getCostAnomalies");
+        assert_eq!(
+            config.operations[0].path,
+            Some("/getCostAndUsage".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_toml_missing_code_mode_returns_default() {
+        let toml_str = r#"
+[server]
+name = "some-server"
+"#;
+        let config = CodeModeConfig::from_toml(toml_str).expect("Failed to parse");
+        assert!(!config.enabled);
+        assert!(config.operations.is_empty());
+        assert_eq!(config.token_ttl_seconds, 300); // default
     }
 }

--- a/crates/pmcp-code-mode/src/config.rs
+++ b/crates/pmcp-code-mode/src/config.rs
@@ -5,6 +5,55 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
 
+/// A single declared operation in Code Mode configuration.
+/// Maps a raw API path to a canonical plain-name ID for Cedar policies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationEntry {
+    /// Canonical operation ID (plain name, no method prefix).
+    /// This is what appears in Cedar policy calledOperations.
+    pub id: String,
+
+    /// Action category for AVP action routing.
+    /// Values: "read", "write", "delete", "admin"
+    pub category: String,
+
+    /// Human-readable description for admin UI and LLM context.
+    #[serde(default)]
+    pub description: String,
+
+    /// Raw API path this ID maps to (e.g., "/getCostAnomalies").
+    /// Used to match against api_call.path from JavaScript analysis.
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+/// Registry built from [[code_mode.operations]] config entries.
+/// Maps raw paths to canonical operation IDs.
+#[derive(Debug, Clone, Default)]
+pub struct OperationRegistry {
+    path_to_id: HashMap<String, String>,
+}
+
+impl OperationRegistry {
+    pub fn from_entries(entries: &[OperationEntry]) -> Self {
+        let mut path_to_id = HashMap::new();
+        for entry in entries {
+            if let Some(ref path) = entry.path {
+                path_to_id.insert(path.clone(), entry.id.clone());
+            }
+        }
+        Self { path_to_id }
+    }
+
+    pub fn lookup(&self, path: &str) -> Option<&str> {
+        self.path_to_id.get(path).map(|s| s.as_str())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.path_to_id.is_empty()
+    }
+}
+
 /// Configuration for Code Mode.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodeModeConfig {
@@ -141,6 +190,13 @@ pub struct CodeModeConfig {
     /// Operations are validated at compile time — unlisted names are rejected.
     #[serde(default)]
     pub sdk_operations: HashSet<String>,
+
+    /// Declared operations for plain-name ID mapping in Cedar entities.
+    /// Parsed from [[code_mode.operations]] TOML sections.
+    /// When non-empty, ScriptEntity calledOperations uses IDs from the registry
+    /// built from these entries. Unregistered paths fall back to METHOD:/path.
+    #[serde(default)]
+    pub operations: Vec<OperationEntry>,
 }
 
 impl Default for CodeModeConfig {
@@ -180,6 +236,7 @@ impl Default for CodeModeConfig {
             server_id: None,
             // SDK
             sdk_operations: HashSet::new(),
+            operations: Vec::new(),
         }
     }
 }
@@ -335,5 +392,102 @@ mod tests {
         assert!(!config.should_auto_approve(RiskLevel::Medium));
         assert!(!config.should_auto_approve(RiskLevel::High));
         assert!(!config.should_auto_approve(RiskLevel::Critical));
+    }
+
+    #[test]
+    fn test_operation_registry_from_entries() {
+        let entries = vec![
+            OperationEntry {
+                id: "getCostAnomalies".to_string(),
+                category: "read".to_string(),
+                description: "Get cost anomalies".to_string(),
+                path: Some("/getCostAnomalies".to_string()),
+            },
+            OperationEntry {
+                id: "listInstances".to_string(),
+                category: "read".to_string(),
+                description: "List EC2 instances".to_string(),
+                path: Some("/listInstances".to_string()),
+            },
+        ];
+        let registry = OperationRegistry::from_entries(&entries);
+        assert_eq!(registry.lookup("/getCostAnomalies"), Some("getCostAnomalies"));
+        assert_eq!(registry.lookup("/listInstances"), Some("listInstances"));
+    }
+
+    #[test]
+    fn test_operation_registry_lookup_unregistered() {
+        let entries = vec![OperationEntry {
+            id: "getCostAnomalies".to_string(),
+            category: "read".to_string(),
+            description: String::new(),
+            path: Some("/getCostAnomalies".to_string()),
+        }];
+        let registry = OperationRegistry::from_entries(&entries);
+        assert_eq!(registry.lookup("/unknownPath"), None);
+        assert_eq!(registry.lookup(""), None);
+    }
+
+    #[test]
+    fn test_operation_registry_is_empty() {
+        let empty_registry = OperationRegistry::from_entries(&[]);
+        assert!(empty_registry.is_empty());
+
+        let entries = vec![OperationEntry {
+            id: "op1".to_string(),
+            category: "read".to_string(),
+            description: String::new(),
+            path: Some("/op1".to_string()),
+        }];
+        let registry = OperationRegistry::from_entries(&entries);
+        assert!(!registry.is_empty());
+    }
+
+    #[test]
+    fn test_operation_entry_deserialization() {
+        let toml_str = r#"
+id = "getCostAnomalies"
+category = "read"
+description = "Get cost anomalies"
+path = "/getCostAnomalies"
+"#;
+        let entry: OperationEntry = toml::from_str(toml_str).expect("Failed to deserialize OperationEntry");
+        assert_eq!(entry.id, "getCostAnomalies");
+        assert_eq!(entry.category, "read");
+        assert_eq!(entry.description, "Get cost anomalies");
+        assert_eq!(entry.path, Some("/getCostAnomalies".to_string()));
+    }
+
+    #[test]
+    fn test_code_mode_config_with_operations() {
+        let toml_str = r#"
+enabled = true
+
+[[operations]]
+id = "getCostAnomalies"
+category = "read"
+description = "Get cost anomalies"
+path = "/getCostAnomalies"
+
+[[operations]]
+id = "listInstances"
+category = "read"
+path = "/listInstances"
+"#;
+        let config: CodeModeConfig = toml::from_str(toml_str).expect("Failed to deserialize");
+        assert!(config.enabled);
+        assert_eq!(config.operations.len(), 2);
+        assert_eq!(config.operations[0].id, "getCostAnomalies");
+        assert_eq!(config.operations[1].id, "listInstances");
+    }
+
+    #[test]
+    fn test_code_mode_config_without_operations_defaults_to_empty() {
+        let toml_str = r#"
+enabled = true
+"#;
+        let config: CodeModeConfig = toml::from_str(toml_str).expect("Failed to deserialize");
+        assert!(config.enabled);
+        assert!(config.operations.is_empty());
     }
 }

--- a/crates/pmcp-code-mode/src/config.rs
+++ b/crates/pmcp-code-mode/src/config.rs
@@ -36,7 +36,7 @@ pub struct OperationRegistry {
 
 impl OperationRegistry {
     pub fn from_entries(entries: &[OperationEntry]) -> Self {
-        let mut path_to_id = HashMap::new();
+        let mut path_to_id = HashMap::with_capacity(entries.len());
         for entry in entries {
             if let Some(ref path) = entry.path {
                 path_to_id.insert(path.clone(), entry.id.clone());
@@ -411,7 +411,10 @@ mod tests {
             },
         ];
         let registry = OperationRegistry::from_entries(&entries);
-        assert_eq!(registry.lookup("/getCostAnomalies"), Some("getCostAnomalies"));
+        assert_eq!(
+            registry.lookup("/getCostAnomalies"),
+            Some("getCostAnomalies")
+        );
         assert_eq!(registry.lookup("/listInstances"), Some("listInstances"));
     }
 
@@ -451,7 +454,8 @@ category = "read"
 description = "Get cost anomalies"
 path = "/getCostAnomalies"
 "#;
-        let entry: OperationEntry = toml::from_str(toml_str).expect("Failed to deserialize OperationEntry");
+        let entry: OperationEntry =
+            toml::from_str(toml_str).expect("Failed to deserialize OperationEntry");
         assert_eq!(entry.id, "getCostAnomalies");
         assert_eq!(entry.category, "read");
         assert_eq!(entry.description, "Get cost anomalies");

--- a/crates/pmcp-code-mode/src/lib.rs
+++ b/crates/pmcp-code-mode/src/lib.rs
@@ -85,6 +85,10 @@ pub mod cedar_validation;
 #[cfg(feature = "openapi-code-mode")]
 mod javascript;
 
+// AWS Verified Permissions policy evaluator
+#[cfg(feature = "avp")]
+pub mod avp;
+
 // JavaScript execution runtime (AST-based execution in pure Rust)
 #[cfg(feature = "js-runtime")]
 pub mod executor;
@@ -171,6 +175,10 @@ pub use policy::{
 // Cedar policy evaluator
 #[cfg(feature = "cedar")]
 pub use policy::cedar::CedarPolicyEvaluator;
+
+// AVP (AWS Verified Permissions) policy evaluator
+#[cfg(feature = "avp")]
+pub use avp::{AvpClient, AvpConfig, AvpError, AvpPolicyEvaluator};
 
 // Schema Exposure Architecture types
 pub use schema_exposure::{

--- a/crates/pmcp-code-mode/src/policy/cedar.rs
+++ b/crates/pmcp-code-mode/src/policy/cedar.rs
@@ -145,7 +145,7 @@ impl CedarPolicyEvaluator {
         );
 
         let mut attrs: HashMap<String, cedar_policy::RestrictedExpression> =
-            HashMap::with_capacity(10);
+            HashMap::with_capacity(12);
 
         attrs.insert(
             "serverId".to_string(),
@@ -170,6 +170,10 @@ impl CedarPolicyEvaluator {
         attrs.insert(
             "maxDepth".to_string(),
             cedar_policy::RestrictedExpression::new_long(config.max_depth as i64),
+        );
+        attrs.insert(
+            "maxFieldCount".to_string(),
+            cedar_policy::RestrictedExpression::new_long(config.max_field_count as i64),
         );
         attrs.insert(
             "maxCost".to_string(),

--- a/crates/pmcp-code-mode/src/policy/types.rs
+++ b/crates/pmcp-code-mode/src/policy/types.rs
@@ -3,6 +3,7 @@
 //! These types represent the entities used in Cedar policy evaluation.
 //! They are pure domain types with no AWS SDK dependency.
 
+use crate::config::OperationRegistry;
 use crate::graphql::GraphQLQueryInfo;
 use std::collections::HashSet;
 
@@ -234,6 +235,7 @@ impl ScriptEntity {
     pub fn from_javascript_info(
         info: &crate::javascript::JavaScriptCodeInfo,
         sensitive_patterns: &[String],
+        registry: Option<&OperationRegistry>,
     ) -> Self {
         use crate::javascript::HttpMethod;
 
@@ -256,8 +258,13 @@ impl ScriptEntity {
             let pattern = normalize_path_to_pattern(&api_call.path);
             path_patterns.insert(pattern.clone());
 
-            // Build called operation string
-            called_operations.insert(format!("{}:{}", method_str, pattern));
+            // Build called operation string: use canonical ID from registry if available,
+            // fall back to METHOD:/path format when no registry entry matches.
+            let op_id = registry
+                .and_then(|r| r.lookup(&api_call.path))
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| format!("{}:{}", method_str, pattern));
+            called_operations.insert(op_id);
 
             // Count by method type
             match api_call.method {

--- a/crates/pmcp-code-mode/src/policy/types.rs
+++ b/crates/pmcp-code-mode/src/policy/types.rs
@@ -3,6 +3,7 @@
 //! These types represent the entities used in Cedar policy evaluation.
 //! They are pure domain types with no AWS SDK dependency.
 
+#[cfg(feature = "openapi-code-mode")]
 use crate::config::OperationRegistry;
 use crate::graphql::GraphQLQueryInfo;
 use std::collections::HashSet;

--- a/crates/pmcp-code-mode/src/policy/types.rs
+++ b/crates/pmcp-code-mode/src/policy/types.rs
@@ -267,11 +267,19 @@ impl ScriptEntity {
                 .unwrap_or_else(|| format!("{}:{}", method_str, pattern));
             called_operations.insert(op_id);
 
-            // Count by method type
-            match api_call.method {
-                HttpMethod::Get | HttpMethod::Head | HttpMethod::Options => read_calls += 1,
-                HttpMethod::Delete => delete_calls += 1,
-                _ => write_calls += 1,
+            // Count by declared category (from [[code_mode.operations]]) when available,
+            // fall back to HTTP method when no registry entry or no category declared.
+            let call_category = registry.and_then(|r| r.lookup_category(&api_call.path));
+            match call_category {
+                Some("read") => read_calls += 1,
+                Some("delete") => delete_calls += 1,
+                Some("write" | "admin") => write_calls += 1,
+                Some(_) => write_calls += 1,
+                None => match api_call.method {
+                    HttpMethod::Get | HttpMethod::Head | HttpMethod::Options => read_calls += 1,
+                    HttpMethod::Delete => delete_calls += 1,
+                    _ => write_calls += 1,
+                },
             }
 
             // Track dynamic paths
@@ -545,6 +553,7 @@ pub fn get_code_mode_schema_json() -> serde_json::Value {
                             "serverId": { "type": "String", "required": true },
                             "serverType": { "type": "String", "required": true },
                             "maxDepth": { "type": "Long", "required": true },
+                            "maxFieldCount": { "type": "Long", "required": true },
                             "maxCost": { "type": "Long", "required": true },
                             "maxApiCalls": { "type": "Long", "required": true },
                             "allowWrite": { "type": "Boolean", "required": true },
@@ -620,6 +629,7 @@ pub fn get_openapi_code_mode_schema_json() -> serde_json::Value {
                         "attributes": {
                             "serverId": { "type": "String", "required": true },
                             "serverType": { "type": "String", "required": true },
+                            "writeMode": { "type": "String", "required": true },
                             "maxDepth": { "type": "Long", "required": true },
                             "maxCost": { "type": "Long", "required": true },
                             "maxApiCalls": { "type": "Long", "required": true },
@@ -758,4 +768,139 @@ pub fn get_baseline_policies() -> Vec<(&'static str, &'static str, &'static str)
             r#"forbid(principal, action, resource) when { principal.estimatedCost > resource.maxCost };"#,
         ),
     ]
+}
+
+#[cfg(all(test, feature = "openapi-code-mode"))]
+mod tests {
+    use super::*;
+    use crate::config::{OperationEntry, OperationRegistry};
+    use crate::javascript::{ApiCall, HttpMethod, JavaScriptCodeInfo};
+
+    fn make_api_call(method: HttpMethod, path: &str) -> ApiCall {
+        ApiCall {
+            method,
+            path: path.to_string(),
+            is_dynamic_path: false,
+            line: 1,
+            column: 0,
+        }
+    }
+
+    fn make_info(calls: Vec<ApiCall>) -> JavaScriptCodeInfo {
+        JavaScriptCodeInfo {
+            api_calls: calls,
+            ..Default::default()
+        }
+    }
+
+    fn make_registry(entries: &[(&str, &str, &str)]) -> OperationRegistry {
+        let entries: Vec<OperationEntry> = entries
+            .iter()
+            .map(|(id, category, path)| OperationEntry {
+                id: id.to_string(),
+                category: category.to_string(),
+                description: String::new(),
+                path: Some(path.to_string()),
+            })
+            .collect();
+        OperationRegistry::from_entries(&entries)
+    }
+
+    #[test]
+    fn test_category_read_overrides_post_method() {
+        let registry = make_registry(&[("getCostAnomalies", "read", "/getCostAnomalies")]);
+        let info = make_info(vec![make_api_call(HttpMethod::Post, "/getCostAnomalies")]);
+
+        let entity = ScriptEntity::from_javascript_info(&info, &[], Some(&registry));
+
+        assert_eq!(entity.read_calls, 1);
+        assert_eq!(entity.write_calls, 0);
+        assert_eq!(entity.script_type, "read_only");
+        assert_eq!(entity.action(), "Read");
+    }
+
+    #[test]
+    fn test_category_write_overrides_get_method() {
+        let registry = make_registry(&[("triggerExport", "write", "/triggerExport")]);
+        let info = make_info(vec![make_api_call(HttpMethod::Get, "/triggerExport")]);
+
+        let entity = ScriptEntity::from_javascript_info(&info, &[], Some(&registry));
+
+        assert_eq!(entity.write_calls, 1);
+        assert_eq!(entity.read_calls, 0);
+        assert_eq!(entity.script_type, "write_only");
+        assert_eq!(entity.action(), "Write");
+    }
+
+    #[test]
+    fn test_category_delete_routes_correctly() {
+        let registry = make_registry(&[("deleteReservation", "delete", "/deleteReservation")]);
+        let info = make_info(vec![make_api_call(HttpMethod::Post, "/deleteReservation")]);
+
+        let entity = ScriptEntity::from_javascript_info(&info, &[], Some(&registry));
+
+        assert_eq!(entity.delete_calls, 1);
+        assert_eq!(entity.has_deletes, true);
+        assert_eq!(entity.action(), "Delete");
+    }
+
+    #[test]
+    fn test_no_registry_falls_back_to_http_method() {
+        let info = make_info(vec![
+            make_api_call(HttpMethod::Get, "/getCostAnomalies"),
+            make_api_call(HttpMethod::Post, "/updateBudget"),
+        ]);
+
+        let entity = ScriptEntity::from_javascript_info(&info, &[], None);
+
+        assert_eq!(entity.read_calls, 1);
+        assert_eq!(entity.write_calls, 1);
+        assert_eq!(entity.script_type, "mixed");
+        assert_eq!(entity.action(), "Write");
+    }
+
+    #[test]
+    fn test_unregistered_path_falls_back_to_http_method() {
+        let registry = make_registry(&[("getCostAnomalies", "read", "/getCostAnomalies")]);
+        let info = make_info(vec![make_api_call(HttpMethod::Post, "/unknownEndpoint")]);
+
+        let entity = ScriptEntity::from_javascript_info(&info, &[], Some(&registry));
+
+        // POST with no category → write (HTTP method fallback)
+        assert_eq!(entity.write_calls, 1);
+        assert_eq!(entity.read_calls, 0);
+        assert_eq!(entity.script_type, "write_only");
+    }
+
+    #[test]
+    fn test_mixed_categories_produce_mixed_script() {
+        let registry = make_registry(&[
+            ("getCostAnomalies", "read", "/getCostAnomalies"),
+            ("updateBudget", "write", "/updateBudget"),
+        ]);
+        let info = make_info(vec![
+            make_api_call(HttpMethod::Post, "/getCostAnomalies"),
+            make_api_call(HttpMethod::Post, "/updateBudget"),
+        ]);
+
+        let entity = ScriptEntity::from_javascript_info(&info, &[], Some(&registry));
+
+        assert_eq!(entity.read_calls, 1);
+        assert_eq!(entity.write_calls, 1);
+        assert_eq!(entity.script_type, "mixed");
+        assert_eq!(entity.action(), "Write");
+    }
+
+    #[test]
+    fn test_empty_category_falls_back_to_http_method() {
+        // category = "" (from #[serde(default)]) → no category → HTTP method fallback
+        let registry = make_registry(&[("legacyOp", "", "/legacyOp")]);
+        let info = make_info(vec![make_api_call(HttpMethod::Post, "/legacyOp")]);
+
+        let entity = ScriptEntity::from_javascript_info(&info, &[], Some(&registry));
+
+        // POST with empty category → write (HTTP method fallback)
+        assert_eq!(entity.write_calls, 1);
+        assert_eq!(entity.script_type, "write_only");
+    }
 }

--- a/crates/pmcp-code-mode/src/validation.rs
+++ b/crates/pmcp-code-mode/src/validation.rs
@@ -7,7 +7,7 @@
 //! 4. Explanation generation
 //! 5. Token generation
 
-use crate::config::CodeModeConfig;
+use crate::config::{CodeModeConfig, OperationRegistry};
 use crate::explanation::{ExplanationGenerator, TemplateExplanationGenerator};
 use crate::graphql::{GraphQLQueryInfo, GraphQLValidator};
 use crate::policy::{OperationEntity, PolicyEvaluator};
@@ -86,6 +86,8 @@ pub struct ValidationPipeline<
     graphql_validator: GraphQLValidator,
     #[cfg(feature = "openapi-code-mode")]
     javascript_validator: JavaScriptValidator,
+    #[cfg(feature = "openapi-code-mode")]
+    operation_registry: OperationRegistry,
     token_generator: T,
     explanation_generator: E,
     policy_evaluator: Option<Arc<dyn PolicyEvaluator>>,
@@ -109,11 +111,16 @@ impl ValidationPipeline<HmacTokenGenerator, TemplateExplanationGenerator> {
             warn_no_policy_configured();
         }
 
+        #[cfg(feature = "openapi-code-mode")]
+        let operation_registry = OperationRegistry::from_entries(&config.operations);
+
         Ok(Self {
             graphql_validator: GraphQLValidator::default(),
             #[cfg(feature = "openapi-code-mode")]
             javascript_validator: JavaScriptValidator::default()
                 .with_sdk_operations(config.sdk_operations.clone()),
+            #[cfg(feature = "openapi-code-mode")]
+            operation_registry,
             token_generator: HmacTokenGenerator::new_from_bytes(token_secret)?,
             explanation_generator: TemplateExplanationGenerator::new(),
             policy_evaluator: None,
@@ -157,11 +164,16 @@ impl ValidationPipeline<HmacTokenGenerator, TemplateExplanationGenerator> {
         token_secret: impl Into<Vec<u8>>,
         evaluator: Arc<dyn PolicyEvaluator>,
     ) -> Result<Self, TokenError> {
+        #[cfg(feature = "openapi-code-mode")]
+        let operation_registry = OperationRegistry::from_entries(&config.operations);
+
         Ok(Self {
             graphql_validator: GraphQLValidator::default(),
             #[cfg(feature = "openapi-code-mode")]
             javascript_validator: JavaScriptValidator::default()
                 .with_sdk_operations(config.sdk_operations.clone()),
+            #[cfg(feature = "openapi-code-mode")]
+            operation_registry,
             token_generator: HmacTokenGenerator::new_from_bytes(token_secret)?,
             explanation_generator: TemplateExplanationGenerator::new(),
             policy_evaluator: Some(evaluator),
@@ -194,11 +206,16 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
         token_generator: T,
         explanation_generator: E,
     ) -> Self {
+        #[cfg(feature = "openapi-code-mode")]
+        let operation_registry = OperationRegistry::from_entries(&config.operations);
+
         Self {
             graphql_validator: GraphQLValidator::default(),
             #[cfg(feature = "openapi-code-mode")]
             javascript_validator: JavaScriptValidator::default()
                 .with_sdk_operations(config.sdk_operations.clone()),
+            #[cfg(feature = "openapi-code-mode")]
+            operation_registry,
             token_generator,
             explanation_generator,
             policy_evaluator: None,
@@ -580,7 +597,12 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
         if let Some(ref evaluator) = self.policy_evaluator {
             let sensitive_patterns: Vec<String> =
                 self.config.openapi_blocked_paths.iter().cloned().collect();
-            let script_entity = ScriptEntity::from_javascript_info(&code_info, &sensitive_patterns);
+            let registry_ref = if self.operation_registry.is_empty() {
+                None
+            } else {
+                Some(&self.operation_registry)
+            };
+            let script_entity = ScriptEntity::from_javascript_info(&code_info, &sensitive_patterns, registry_ref);
             let server_entity = self.config.to_openapi_server_entity();
 
             let decision = evaluator

--- a/crates/pmcp-code-mode/src/validation.rs
+++ b/crates/pmcp-code-mode/src/validation.rs
@@ -535,7 +535,11 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
         }
     }
 
-    /// Validate JavaScript code for OpenAPI Code Mode.
+    /// Validate JavaScript code for OpenAPI Code Mode (sync, no policy evaluation).
+    ///
+    /// Runs config-level checks only. For policy evaluation (Cedar/AVP), use
+    /// [`validate_javascript_code_async`] instead. Retained for backward
+    /// compatibility with callers that don't need policy enforcement.
     #[cfg(feature = "openapi-code-mode")]
     pub fn validate_javascript_code(
         &self,
@@ -543,74 +547,21 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
         context: &ValidationContext,
     ) -> Result<ValidationResult, ValidationError> {
         let start = Instant::now();
-
-        if !self.config.enabled {
-            return Err(ValidationError::ConfigError(
-                "Code Mode is not enabled for this server".into(),
-            ));
+        let code_info = self.validate_js_preamble(code)?;
+        if let Some(failure) = self.check_js_config_authorization(&code_info, start) {
+            return Ok(failure);
         }
-
-        if code.len() > self.config.max_query_length {
-            return Err(ValidationError::SecurityError {
-                message: format!(
-                    "Code length {} exceeds maximum {}",
-                    code.len(),
-                    self.config.max_query_length
-                ),
-                issue: crate::types::SecurityIssueType::HighComplexity,
-            });
-        }
-
-        let code_info = self.javascript_validator.validate(code)?;
-
-        if !code_info.is_read_only {
-            for method in &code_info.methods_used {
-                if !self.config.openapi_blocked_writes.is_empty()
-                    && self.config.openapi_blocked_writes.contains(method)
-                {
-                    return Ok(ValidationResult::failure(
-                        vec![PolicyViolation::new(
-                            "code_mode",
-                            "blocked_method",
-                            &format!("HTTP method '{}' is blocked for this server", method),
-                        )
-                        .with_suggestion("This method is in the blocklist and cannot be used")],
-                        self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
-                    ));
-                }
-            }
-
-            if !self.config.openapi_allowed_writes.is_empty() {
-                tracing::debug!(
-                    target: "code_mode",
-                    "Skipping method-level check - policy evaluator will check operation allowlist ({} entries)",
-                    self.config.openapi_allowed_writes.len()
-                );
-            } else if !self.config.openapi_allow_writes {
-                return Ok(ValidationResult::failure(
-                    vec![PolicyViolation::new(
-                        "code_mode",
-                        "allow_mutations",
-                        "Write HTTP methods (POST, PUT, DELETE, PATCH) are not enabled for this server",
-                    )
-                    .with_suggestion("Only read-only methods (GET, HEAD, OPTIONS) are allowed. Contact your administrator to enable write operations.")],
-                    self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
-                ));
-            }
-        }
-
         self.complete_js_validation(code, &code_info, context, start)
     }
 
     /// Validate JavaScript code with async policy evaluation.
     ///
     /// Mirrors [`validate_graphql_query_async`] but for JavaScript/OpenAPI:
-    /// 1. Parse JS via SWC + config-level checks (same as sync version)
-    /// 2. Policy evaluation via [`PolicyEvaluator::evaluate_script`] (async)
+    /// 1. Parse JS via SWC + config-level checks (shared with sync version)
+    /// 2. Policy evaluation via [`PolicyEvaluator::evaluate_script`] (async, fail-closed)
     /// 3. Security analysis + token generation
     ///
-    /// When no policy evaluator is configured, falls back to config-only
-    /// checks (same behavior as the sync version).
+    /// When no policy evaluator is configured, falls back to config-only checks.
     #[cfg(feature = "openapi-code-mode")]
     pub async fn validate_javascript_code_async(
         &self,
@@ -620,7 +571,51 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
         use crate::policy::types::ScriptEntity;
 
         let start = Instant::now();
+        let code_info = self.validate_js_preamble(code)?;
+        if let Some(failure) = self.check_js_config_authorization(&code_info, start) {
+            return Ok(failure);
+        }
 
+        // Policy evaluation via evaluate_script (mirrors GraphQL's evaluate_operation)
+        if let Some(ref evaluator) = self.policy_evaluator {
+            let sensitive_patterns: Vec<String> =
+                self.config.openapi_blocked_paths.iter().cloned().collect();
+            let script_entity = ScriptEntity::from_javascript_info(&code_info, &sensitive_patterns);
+            let server_entity = self.config.to_openapi_server_entity();
+
+            let decision = evaluator
+                .evaluate_script(&script_entity, &server_entity)
+                .await
+                .map_err(|e| {
+                    ValidationError::InternalError(format!("Policy evaluation error: {}", e))
+                })?;
+
+            if !decision.allowed {
+                let violations: Vec<PolicyViolation> = decision
+                    .determining_policies
+                    .iter()
+                    .map(|policy_id| {
+                        PolicyViolation::new(
+                            "policy",
+                            policy_id.clone(),
+                            "Policy denied the script",
+                        )
+                    })
+                    .collect();
+
+                return Ok(ValidationResult::failure(
+                    violations,
+                    self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
+                ));
+            }
+        }
+
+        self.complete_js_validation(code, &code_info, context, start)
+    }
+
+    /// Shared JavaScript preamble: enabled check, length check, parse.
+    #[cfg(feature = "openapi-code-mode")]
+    fn validate_js_preamble(&self, code: &str) -> Result<JavaScriptCodeInfo, ValidationError> {
         if !self.config.enabled {
             return Err(ValidationError::ConfigError(
                 "Code Mode is not enabled for this server".into(),
@@ -638,86 +633,59 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
             });
         }
 
-        let code_info = self.javascript_validator.validate(code)?;
+        Ok(self.javascript_validator.validate(code)?)
+    }
 
-        // Config-level checks (same as sync path)
-        if !code_info.is_read_only {
-            for method in &code_info.methods_used {
-                if !self.config.openapi_blocked_writes.is_empty()
-                    && self.config.openapi_blocked_writes.contains(method)
-                {
-                    return Ok(ValidationResult::failure(
-                        vec![PolicyViolation::new(
-                            "code_mode",
-                            "blocked_method",
-                            &format!("HTTP method '{}' is blocked for this server", method),
-                        )
-                        .with_suggestion("This method is in the blocklist and cannot be used")],
-                        self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
-                    ));
-                }
-            }
+    /// Config-level authorization checks for JavaScript code.
+    ///
+    /// Returns `Some(failure)` if a config check denied the code,
+    /// `None` if all checks pass. Shared between sync and async paths
+    /// (mirrors `check_config_authorization` for GraphQL).
+    #[cfg(feature = "openapi-code-mode")]
+    fn check_js_config_authorization(
+        &self,
+        code_info: &JavaScriptCodeInfo,
+        start: Instant,
+    ) -> Option<ValidationResult> {
+        if code_info.is_read_only {
+            return None;
+        }
 
-            if !self.config.openapi_allowed_writes.is_empty() {
-                tracing::debug!(
-                    target: "code_mode",
-                    "Skipping method-level check - policy evaluator will check operation allowlist ({} entries)",
-                    self.config.openapi_allowed_writes.len()
-                );
-            } else if !self.config.openapi_allow_writes {
-                return Ok(ValidationResult::failure(
+        for method in &code_info.methods_used {
+            if !self.config.openapi_blocked_writes.is_empty()
+                && self.config.openapi_blocked_writes.contains(method)
+            {
+                return Some(ValidationResult::failure(
                     vec![PolicyViolation::new(
                         "code_mode",
-                        "allow_mutations",
-                        "Write HTTP methods (POST, PUT, DELETE, PATCH) are not enabled for this server",
+                        "blocked_method",
+                        &format!("HTTP method '{}' is blocked for this server", method),
                     )
-                    .with_suggestion("Only read-only methods (GET, HEAD, OPTIONS) are allowed. Contact your administrator to enable write operations.")],
-                    self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
+                    .with_suggestion("This method is in the blocklist and cannot be used")],
+                    self.build_js_metadata(code_info, start.elapsed().as_millis() as u64),
                 ));
             }
         }
 
-        // Policy evaluation via evaluate_script (mirrors GraphQL's evaluate_operation)
-        if let Some(ref evaluator) = self.policy_evaluator {
-            let sensitive_patterns: Vec<String> =
-                self.config.openapi_blocked_paths.iter().cloned().collect();
-            let script_entity = ScriptEntity::from_javascript_info(&code_info, &sensitive_patterns);
-            let server_entity = self.config.to_openapi_server_entity();
-
-            match evaluator
-                .evaluate_script(&script_entity, &server_entity)
-                .await
-            {
-                Ok(decision) if !decision.allowed => {
-                    let violations: Vec<PolicyViolation> = decision
-                        .determining_policies
-                        .iter()
-                        .map(|policy_id| {
-                            PolicyViolation::new(
-                                "policy",
-                                policy_id.clone(),
-                                "Policy denied the script",
-                            )
-                        })
-                        .collect();
-
-                    return Ok(ValidationResult::failure(
-                        violations,
-                        self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
-                    ));
-                },
-                Err(e) => {
-                    // Fail-open: log warning, continue with validation
-                    tracing::warn!(
-                        error = %e,
-                        "Policy evaluation failed for JavaScript code, continuing (fail-open)"
-                    );
-                },
-                _ => {}, // Allowed — continue
-            }
+        if !self.config.openapi_allowed_writes.is_empty() {
+            tracing::debug!(
+                target: "code_mode",
+                "Skipping method-level check - policy evaluator will check operation allowlist ({} entries)",
+                self.config.openapi_allowed_writes.len()
+            );
+        } else if !self.config.openapi_allow_writes {
+            return Some(ValidationResult::failure(
+                vec![PolicyViolation::new(
+                    "code_mode",
+                    "allow_mutations",
+                    "Write HTTP methods (POST, PUT, DELETE, PATCH) are not enabled for this server",
+                )
+                .with_suggestion("Only read-only methods (GET, HEAD, OPTIONS) are allowed. Contact your administrator to enable write operations.")],
+                self.build_js_metadata(code_info, start.elapsed().as_millis() as u64),
+            ));
         }
 
-        self.complete_js_validation(code, &code_info, context, start)
+        None
     }
 
     /// Complete JavaScript validation after policy checks pass.

--- a/crates/pmcp-code-mode/src/validation.rs
+++ b/crates/pmcp-code-mode/src/validation.rs
@@ -7,7 +7,9 @@
 //! 4. Explanation generation
 //! 5. Token generation
 
-use crate::config::{CodeModeConfig, OperationRegistry};
+use crate::config::CodeModeConfig;
+#[cfg(feature = "openapi-code-mode")]
+use crate::config::OperationRegistry;
 use crate::explanation::{ExplanationGenerator, TemplateExplanationGenerator};
 use crate::graphql::{GraphQLQueryInfo, GraphQLValidator};
 use crate::policy::{OperationEntity, PolicyEvaluator};
@@ -602,7 +604,8 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
             } else {
                 Some(&self.operation_registry)
             };
-            let script_entity = ScriptEntity::from_javascript_info(&code_info, &sensitive_patterns, registry_ref);
+            let script_entity =
+                ScriptEntity::from_javascript_info(&code_info, &sensitive_patterns, registry_ref);
             let server_entity = self.config.to_openapi_server_entity();
 
             let decision = evaluator

--- a/crates/pmcp-code-mode/src/validation.rs
+++ b/crates/pmcp-code-mode/src/validation.rs
@@ -602,6 +602,124 @@ impl<T: TokenGenerator, E: ExplanationGenerator> ValidationPipeline<T, E> {
         self.complete_js_validation(code, &code_info, context, start)
     }
 
+    /// Validate JavaScript code with async policy evaluation.
+    ///
+    /// Mirrors [`validate_graphql_query_async`] but for JavaScript/OpenAPI:
+    /// 1. Parse JS via SWC + config-level checks (same as sync version)
+    /// 2. Policy evaluation via [`PolicyEvaluator::evaluate_script`] (async)
+    /// 3. Security analysis + token generation
+    ///
+    /// When no policy evaluator is configured, falls back to config-only
+    /// checks (same behavior as the sync version).
+    #[cfg(feature = "openapi-code-mode")]
+    pub async fn validate_javascript_code_async(
+        &self,
+        code: &str,
+        context: &ValidationContext,
+    ) -> Result<ValidationResult, ValidationError> {
+        use crate::policy::types::ScriptEntity;
+
+        let start = Instant::now();
+
+        if !self.config.enabled {
+            return Err(ValidationError::ConfigError(
+                "Code Mode is not enabled for this server".into(),
+            ));
+        }
+
+        if code.len() > self.config.max_query_length {
+            return Err(ValidationError::SecurityError {
+                message: format!(
+                    "Code length {} exceeds maximum {}",
+                    code.len(),
+                    self.config.max_query_length
+                ),
+                issue: crate::types::SecurityIssueType::HighComplexity,
+            });
+        }
+
+        let code_info = self.javascript_validator.validate(code)?;
+
+        // Config-level checks (same as sync path)
+        if !code_info.is_read_only {
+            for method in &code_info.methods_used {
+                if !self.config.openapi_blocked_writes.is_empty()
+                    && self.config.openapi_blocked_writes.contains(method)
+                {
+                    return Ok(ValidationResult::failure(
+                        vec![PolicyViolation::new(
+                            "code_mode",
+                            "blocked_method",
+                            &format!("HTTP method '{}' is blocked for this server", method),
+                        )
+                        .with_suggestion("This method is in the blocklist and cannot be used")],
+                        self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
+                    ));
+                }
+            }
+
+            if !self.config.openapi_allowed_writes.is_empty() {
+                tracing::debug!(
+                    target: "code_mode",
+                    "Skipping method-level check - policy evaluator will check operation allowlist ({} entries)",
+                    self.config.openapi_allowed_writes.len()
+                );
+            } else if !self.config.openapi_allow_writes {
+                return Ok(ValidationResult::failure(
+                    vec![PolicyViolation::new(
+                        "code_mode",
+                        "allow_mutations",
+                        "Write HTTP methods (POST, PUT, DELETE, PATCH) are not enabled for this server",
+                    )
+                    .with_suggestion("Only read-only methods (GET, HEAD, OPTIONS) are allowed. Contact your administrator to enable write operations.")],
+                    self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
+                ));
+            }
+        }
+
+        // Policy evaluation via evaluate_script (mirrors GraphQL's evaluate_operation)
+        if let Some(ref evaluator) = self.policy_evaluator {
+            let sensitive_patterns: Vec<String> =
+                self.config.openapi_blocked_paths.iter().cloned().collect();
+            let script_entity = ScriptEntity::from_javascript_info(&code_info, &sensitive_patterns);
+            let server_entity = self.config.to_openapi_server_entity();
+
+            match evaluator
+                .evaluate_script(&script_entity, &server_entity)
+                .await
+            {
+                Ok(decision) if !decision.allowed => {
+                    let violations: Vec<PolicyViolation> = decision
+                        .determining_policies
+                        .iter()
+                        .map(|policy_id| {
+                            PolicyViolation::new(
+                                "policy",
+                                policy_id.clone(),
+                                "Policy denied the script",
+                            )
+                        })
+                        .collect();
+
+                    return Ok(ValidationResult::failure(
+                        violations,
+                        self.build_js_metadata(&code_info, start.elapsed().as_millis() as u64),
+                    ));
+                },
+                Err(e) => {
+                    // Fail-open: log warning, continue with validation
+                    tracing::warn!(
+                        error = %e,
+                        "Policy evaluation failed for JavaScript code, continuing (fail-open)"
+                    );
+                },
+                _ => {}, // Allowed — continue
+            }
+        }
+
+        self.complete_js_validation(code, &code_info, context, start)
+    }
+
     /// Complete JavaScript validation after policy checks pass.
     #[cfg(feature = "openapi-code-mode")]
     fn complete_js_validation(

--- a/pmcp-book/src/SUMMARY.md
+++ b/pmcp-book/src/SUMMARY.md
@@ -32,6 +32,7 @@
 - [Chapter 12: Progress Tracking & Cancellation](ch12-progress-cancel.md)
 - [Chapter 12.5: MCP Apps Extension — Interactive UIs](ch12-5-mcp-apps.md)
 - [Chapter 12.7: MCP Tasks — Long-Running Operations](ch12-7-tasks.md)
+- [Chapter 12.9: Code Mode — LLM Code Validation & Execution](ch12-9-code-mode.md)
 
 ## Part IV: Real-World Applications
 

--- a/pmcp-book/src/ch12-9-code-mode.md
+++ b/pmcp-book/src/ch12-9-code-mode.md
@@ -1,0 +1,146 @@
+# Chapter 12.9: Code Mode — LLM Code Validation and Execution
+
+Code Mode enables MCP servers to validate, explain, and execute LLM-generated code (GraphQL, JavaScript, SQL, MCP compositions) with cryptographic approval tokens that bind the validated code to a specific user, session, and schema version.
+
+## The Problem
+
+When an LLM generates code to run against your backend — a GraphQL query, a JavaScript plan, a SQL statement — you face a security challenge: how do you ensure that the exact code a user approved is what gets executed, and that it respects your authorization policies?
+
+Without Code Mode, servers must hand-roll validation, token generation, and policy enforcement for every code-generating workflow. This leads to inconsistent security boundaries and duplicated boilerplate.
+
+## How It Works
+
+```text
+LLM generates code
+        │
+        ▼
+validate_code(code) ──────► ValidationPipeline
+        │                     ├── Parse (language-specific)
+        │                     ├── Security scan
+        │                     ├── Policy evaluation (Cedar/AVP/custom)
+        │                     ├── Explain (human-readable)
+        │                     └── HMAC-sign
+        ▼
+approval_token ◄──────────── (code hash + user + session + expiry)
+        │
+User reviews explanation, approves
+        │
+        ▼
+execute_code(code, token) ─► Token verification
+        │                     ├── Signature check
+        │                     ├── Code hash match
+        │                     ├── Expiry check
+        │                     └── Context match
+        ▼
+CodeExecutor::execute(code) → Result
+```
+
+The HMAC-SHA256 token binds: code hash, user ID, session ID, server ID, context hash, risk level, and expiry. Any modification to the code after validation invalidates the token.
+
+## Using the Derive Macro
+
+The `#[derive(CodeMode)]` macro eliminates ~80 lines of handler boilerplate per server:
+
+```rust,ignore
+use pmcp_code_mode::{CodeModeConfig, TokenSecret, NoopPolicyEvaluator, ValidationContext};
+use pmcp_code_mode_derive::CodeMode;
+use std::sync::Arc;
+
+#[derive(CodeMode)]
+#[code_mode(context_from = "get_context", language = "graphql")]
+struct MyServer {
+    code_mode_config: CodeModeConfig,
+    token_secret: TokenSecret,
+    policy_evaluator: Arc<NoopPolicyEvaluator>,
+    code_executor: Arc<MyExecutor>,
+}
+
+impl MyServer {
+    fn get_context(&self, extra: &pmcp::RequestHandlerExtra) -> ValidationContext {
+        // Build real context from the MCP session
+        ValidationContext::new("user-123", "session-456", "schema-v1", "perms-v1")
+    }
+}
+
+let server = Arc::new(MyServer { /* ... */ });
+let builder = server.register_code_mode_tools(pmcp::Server::builder())?;
+```
+
+### Supported Languages
+
+The `language` attribute selects the validation path at compile time:
+
+| Language | Attribute | Feature Required |
+|----------|----------|------------------|
+| GraphQL | `"graphql"` (default) | *(none)* |
+| JavaScript | `"javascript"` | `openapi-code-mode` |
+| SQL | `"sql"` | `sql-code-mode` |
+| MCP | `"mcp"` | `mcp-code-mode` |
+
+### Standard Adapters
+
+For JavaScript, SDK, and MCP servers, use the standard adapters instead of implementing `CodeExecutor` manually:
+
+```rust,ignore
+// JavaScript + HTTP calls (e.g., Cost Coach)
+let executor = Arc::new(JsCodeExecutor::new(http_client, ExecutionConfig::default()));
+
+// JavaScript + SDK operations
+let executor = Arc::new(SdkCodeExecutor::new(sdk_client, ExecutionConfig::default()));
+
+// MCP tool composition
+let executor = Arc::new(McpCodeExecutor::new(mcp_router, ExecutionConfig::default()));
+```
+
+## Deployment Configuration
+
+When deploying with `cargo pmcp deploy`, include a `config.toml` that declares your server's available operations. The pmcp.run platform reads this to populate the Code Mode policy page, allowing administrators to control operations by category.
+
+```toml
+[server]
+name = "cost-coach"
+type = "openapi-api"
+
+[code_mode]
+allow_writes = false
+allow_deletes = false
+
+[[code_mode.operations]]
+name = "getCostAndUsage"
+description = "Retrieve AWS cost and usage data"
+path = "/ce/GetCostAndUsage"
+method = "POST"
+
+[[code_mode.operations]]
+name = "deleteBudget"
+description = "Delete a budget"
+path = "/budgets/DeleteBudget"
+method = "POST"
+destructive_hint = true
+```
+
+Operations are automatically categorized (read/write/delete/admin) based on the server type and HTTP method, GraphQL operation type, or explicit `operation_category` overrides.
+
+## Policy Evaluation
+
+Code Mode supports pluggable policy evaluation between validation and token generation:
+
+- **Cedar:** Local policy evaluation via the `cedar` feature flag
+- **AWS Verified Permissions:** Remote evaluation via external crate
+- **Custom:** Implement the `PolicyEvaluator` trait
+
+The policy evaluator runs after parsing and security scanning, before the approval token is generated. A denied operation never receives a token.
+
+## Security Properties
+
+- Tokens are stateless (HMAC-verified, not stored server-side)
+- Default TTL: 5 minutes
+- `TokenSecret` uses `secrecy::SecretBox` with zeroize-on-drop
+- Minimum 16-byte secret enforced at construction (returns `Result`, no panic)
+- Code canonicalization prevents whitespace-based bypass
+
+## Next Steps
+
+- See the [pmcp-code-mode README](https://docs.rs/pmcp-code-mode) for the full API reference
+- See the [pmcp-code-mode-derive README](https://docs.rs/pmcp-code-mode-derive) for derive macro details
+- Run the example: `cargo run --example s41_code_mode_graphql --features full`

--- a/pmcp-course/src/SUMMARY.md
+++ b/pmcp-course/src/SUMMARY.md
@@ -165,6 +165,8 @@
   - [Capability Negotiation](./part8-advanced/ch21-02-capability-negotiation.md)
   - [Chapter 21 Exercises](./part8-advanced/ch21-exercises.md)
 
+- [Code Mode: Validated LLM Code Execution](./part8-advanced/ch22-code-mode.md)
+
 ---
 
 # Appendices

--- a/pmcp-course/src/part8-advanced/ch22-code-mode.md
+++ b/pmcp-course/src/part8-advanced/ch22-code-mode.md
@@ -1,0 +1,223 @@
+# Code Mode: Validated LLM Code Execution
+
+Code Mode is the PMCP SDK's framework for safely executing LLM-generated code against your backend — with validation, policy enforcement, and cryptographic approval tokens.
+
+## Learning Objectives
+
+After this chapter, you will be able to:
+
+1. Add Code Mode to any MCP server using `#[derive(CodeMode)]`
+2. Configure operation policies for your target system (GraphQL, JS/OpenAPI, SQL, MCP)
+3. Declare operations in `config.toml` for platform-level policy management
+4. Choose the right executor adapter for your backend pattern
+
+## Why Code Mode?
+
+When an LLM generates a GraphQL query, JavaScript plan, or SQL statement, three questions arise:
+
+1. **Is it safe?** — Does it access sensitive data? Does it modify production state?
+2. **Is it authorized?** — Does this user have permission for this operation?
+3. **Is it the same code the user approved?** — Can we prove tamper-free execution?
+
+Code Mode answers all three with a pipeline: **parse -> policy check -> explain -> HMAC sign -> user approves -> verify token -> execute**.
+
+## Adding Code Mode to Your Server
+
+### Step 1: Add Dependencies
+
+```toml
+[dependencies]
+pmcp = "2.3.0"
+pmcp-code-mode = "0.2.0"
+pmcp-code-mode-derive = "0.1.0"
+```
+
+### Step 2: Derive and Configure
+
+```rust,ignore
+use pmcp_code_mode::{CodeModeConfig, TokenSecret, NoopPolicyEvaluator, ValidationContext};
+use pmcp_code_mode_derive::CodeMode;
+use std::sync::Arc;
+
+#[derive(CodeMode)]
+#[code_mode(context_from = "get_context", language = "graphql")]
+struct MyServer {
+    code_mode_config: CodeModeConfig,
+    token_secret: TokenSecret,
+    policy_evaluator: Arc<NoopPolicyEvaluator>,
+    code_executor: Arc<MyExecutor>,
+}
+
+impl MyServer {
+    fn get_context(&self, extra: &pmcp::RequestHandlerExtra) -> ValidationContext {
+        ValidationContext::new("user-123", "session-456", "schema-v1", "perms-v1")
+    }
+}
+```
+
+The `language` attribute selects the validation path at compile time:
+
+| Language | Value | Feature |
+|----------|-------|---------|
+| GraphQL | `"graphql"` | *(default)* |
+| JavaScript/OpenAPI | `"javascript"` | `openapi-code-mode` |
+| SQL | `"sql"` | `sql-code-mode` |
+| MCP composition | `"mcp"` | `mcp-code-mode` |
+
+### Step 3: Choose Your Executor
+
+**Direct implementation** (GraphQL, SQL):
+
+```rust,ignore
+#[async_trait]
+impl CodeExecutor for MyGraphQLExecutor {
+    async fn execute(&self, code: &str, variables: Option<&Value>) -> Result<Value, ExecutionError> {
+        let result = self.pool.execute_graphql(code, variables).await?;
+        Ok(serde_json::to_value(result)?)
+    }
+}
+```
+
+**Standard adapters** (JavaScript, SDK, MCP):
+
+```rust,ignore
+// JS + HTTP (e.g., Cost Coach calling REST APIs)
+let executor = Arc::new(JsCodeExecutor::new(http_client, ExecutionConfig::default()));
+
+// JS + AWS SDK (e.g., direct Cost Explorer SDK calls)
+let executor = Arc::new(SdkCodeExecutor::new(sdk_client, ExecutionConfig::default()));
+
+// MCP tool composition (routing to other MCP servers)
+let executor = Arc::new(McpCodeExecutor::new(mcp_router, ExecutionConfig::default()));
+```
+
+### Step 4: Register and Build
+
+```rust,ignore
+let server = Arc::new(MyServer { /* ... */ });
+let builder = server.register_code_mode_tools(pmcp::Server::builder())?;
+// builder now has validate_code + execute_code tools
+```
+
+## Declaring Operations in config.toml
+
+The `config.toml` file declares what operations your server supports. When deployed via `cargo pmcp deploy`, this file is included in the deploy ZIP and extracted by the pmcp.run platform to populate the Code Mode policy page.
+
+### OpenAPI Example
+
+```toml
+[server]
+name = "cost-coach"
+type = "openapi-api"
+
+[code_mode]
+allow_writes = false
+allow_deletes = false
+
+[[code_mode.operations]]
+name = "getCostAndUsage"
+description = "Retrieve AWS cost and usage data"
+path = "/ce/GetCostAndUsage"
+method = "POST"
+
+[[code_mode.operations]]
+name = "deleteBudget"
+description = "Delete a budget"
+path = "/budgets/DeleteBudget"
+method = "POST"
+destructive_hint = true
+```
+
+### GraphQL Example
+
+```toml
+[server]
+name = "open-images"
+type = "graphql-api"
+
+[code_mode]
+allow_writes = false
+
+[[code_mode.operations]]
+name = "searchImages"
+operation_type = "query"
+
+[[code_mode.operations]]
+name = "deleteImage"
+operation_type = "mutation"
+destructive_hint = true
+```
+
+### SQL Example
+
+```toml
+[server]
+name = "analytics"
+type = "sql"
+
+[code_mode]
+allow_writes = true
+allow_deletes = false
+blocked_tables = ["audit_log", "credentials"]
+
+[database]
+[[database.tables]]
+name = "orders"
+description = "Customer order history"
+
+[[database.tables]]
+name = "products"
+description = "Product catalog"
+```
+
+### Categorization
+
+Operations are sorted into **read**, **write**, **delete**, and **admin** categories based on:
+
+- **OpenAPI:** HTTP method (GET=read, POST/PUT=write, DELETE=delete)
+- **GraphQL:** operation_type (query=read, mutation=write/delete)
+- **SQL:** statement type + `allow_writes`/`allow_deletes` settings
+- **MCP-API:** tool annotations + name pattern matching
+
+The `operation_category` field overrides automatic categorization when you need explicit control.
+
+## Policy Enforcement
+
+### Runtime (CodeModeConfig)
+
+`CodeModeConfig` controls what the validation pipeline allows at runtime — blocklists, allowlists, depth limits, field restrictions:
+
+```rust,ignore
+let config = CodeModeConfig {
+    enabled: true,
+    allow_mutations: false,
+    blocked_fields: HashSet::from(["User.ssn".into()]),
+    max_query_depth: 10,
+    token_ttl_seconds: 300,
+    ..CodeModeConfig::enabled()
+};
+```
+
+### Platform (config.toml)
+
+`config.toml` declares operations for platform-level management. Administrators can enable/disable individual operations in the pmcp.run admin UI without redeploying the server.
+
+### Authorization (PolicyEvaluator)
+
+For fine-grained per-user authorization, implement `PolicyEvaluator` with Cedar or AWS Verified Permissions:
+
+```rust,ignore
+// Cedar: local policy evaluation (no network)
+let evaluator = Arc::new(CedarPolicyEvaluator::new(policy_set));
+
+// Custom: your authorization backend
+let evaluator = Arc::new(MyAuthzBackend::new(authz_client));
+```
+
+## Key Takeaways
+
+1. `#[derive(CodeMode)]` + `language` attribute = zero-boilerplate Code Mode for any language
+2. `config.toml` declares operations for platform-level policy management
+3. Standard adapters (`JsCodeExecutor`, `SdkCodeExecutor`, `McpCodeExecutor`) bridge execution traits
+4. HMAC tokens cryptographically bind validated code to user, session, and schema
+5. Three layers of policy: runtime (`CodeModeConfig`), platform (`config.toml`), authorization (`PolicyEvaluator`)


### PR DESCRIPTION
## Summary

Complete Code Mode deployment and policy evaluation pipeline for external MCP servers (Cost Coach, OpenAPI servers).

### config.toml in deploy ZIP (cargo-pmcp 0.7.0)
- `cargo pmcp deploy` now includes `config.toml` alongside the bootstrap binary
- `CodeModeConfig::from_toml()` parses `[code_mode]` section from full server config in one line
- `OperationRegistry` maps raw API paths to canonical plain-name IDs for Cedar policy matching

### JavaScript async validation with policy enforcement
- Added `validate_javascript_code_async` — mirrors GraphQL's fail-closed pattern
- Fixed fail-open bug where policy evaluation errors were logged and ignored

### AVP policy evaluator moved to SDK (pmcp-code-mode 0.4.0)
- `AvpPolicyEvaluator`, `AvpClient`, `AvpConfig` moved from internal `mcp-server-common` to `pmcp-code-mode` behind `avp` feature flag
- External servers can now get real Cedar policy enforcement without copying internal code

### Cedar schema sync fix
- 3 schema sources (cedar_validation.rs, types.rs JSON export, entity builders) had drifted — deployed AVP schema was missing `writeMode`, `maxDepth`, `maxCost` on Server and `calledOperations` on Script
- Added missing attributes to all schema definitions
- Added sync tests that prevent future drift between schema sources

### Category-based action routing
- POST-for-reads (AWS SDK, Cost Coach) was always classified as "Write" based on HTTP method, making Cedar Read policies dead code
- `OperationRegistry` now exposes `lookup_category()` from `[[code_mode.operations]]` declarations
- `ScriptEntity` uses declared category when available, falls back to HTTP method when not (fully backwards-compatible)

### Derive macro bug fix (pmcp-code-mode-derive 0.2.0)
- `ValidationResponse::success()` was called unconditionally regardless of `is_valid`, causing policy denials to appear as valid
- Fixed to use `from_result()` + `is_valid` guard

### Multi-language validation dispatch
- `#[derive(CodeMode)]` `language` attribute selects validation method at compile time (graphql/javascript/sql/mcp)
- Standard adapters: `JsCodeExecutor`, `SdkCodeExecutor`, `McpCodeExecutor`

## Files Changed

| Area | Files | Change |
|------|-------|--------|
| Deploy | `cargo-pmcp/src/deployment/{builder,metadata}.rs` | config.toml in ZIP, operation metadata |
| Validation | `pmcp-code-mode/src/validation.rs` | `validate_javascript_code_async`, fail-closed policy |
| AVP | `pmcp-code-mode/src/avp.rs` | Full AVP evaluator behind `avp` feature |
| Schema | `pmcp-code-mode/src/cedar_validation.rs` | Missing attrs + sync tests |
| Schema | `pmcp-code-mode/src/policy/types.rs` | writeMode/maxFieldCount in JSON exports, category routing |
| Config | `pmcp-code-mode/src/config.rs` | `OperationRegistry` with `lookup_category()`, `from_toml()` |
| Cedar | `pmcp-code-mode/src/policy/cedar.rs` | `maxFieldCount` in local entity builder |
| Derive | `pmcp-code-mode-derive/src/lib.rs` | `from_result()` + `is_valid` fix, language dispatch |
| Docs | `pmcp-book/`, `pmcp-course/`, READMEs | Code Mode chapters and deployment guides |

## Test plan

- [x] 104 unit tests pass (`cargo test -p pmcp-code-mode --features "openapi-code-mode,cedar"`)
- [x] 14 property tests pass
- [x] Cedar schema sync tests verify no drift between 3 schema sources
- [x] Category routing: 7 tests covering POST-as-read, GET-as-write, delete, mixed, fallback, empty category
- [x] `from_toml()`: 8 tests including section extraction, missing section default, operations parsing
- [x] Derive macro trybuild tests updated for `from_result()` pattern
- [ ] CI quality gate (`make quality-gate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)