### PR TITLE
feat(cargo-pmcp): 0.8.0 — pmcp.run landing [login] + sign-up + swc deps

### DIFF
--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/cargo-pmcp/src/landing/config.rs
+++ b/cargo-pmcp/src/landing/config.rs
@@ -15,6 +15,38 @@ pub struct LandingConfig {
     /// Deployment configuration
     #[serde(default)]
     pub deployment: DeploymentSection,
+
+    /// Login-page branding pushed to the Cognito Managed Login hosted UI by
+    /// the pmcp.run deploy-landing Lambda. Independent of `landing.branding`,
+    /// which styles the landing site chrome — `login` styles the Cognito
+    /// hosted pages that end-users see when an MCP client triggers OAuth.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub login: Option<LoginConfig>,
+}
+
+/// Cognito Managed Login branding configuration
+///
+/// Fields here map to the Cognito `UpdateManagedLoginBranding` API and are
+/// applied to every (server × MCP client type) pair registered for a server.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LoginConfig {
+    /// Primary brand color (hex, #rrggbb or #rgb). Applied to primary buttons
+    /// and accent elements in the hosted UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_color: Option<String>,
+
+    /// Page background color (hex, #rrggbb or #rgb). Applied to the hosted UI
+    /// page background in light mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background_color: Option<String>,
+
+    /// Logo asset reference. Either:
+    ///   - `s3://bucket/key` — fetched from the landing assets bucket
+    ///   - `https://<landing-bucket>/path` — same bucket, different URL form
+    ///
+    /// Any other URL form is rejected by the platform (S3-only logo pattern).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logo: Option<String>,
 }
 
 /// Landing page content and branding
@@ -106,6 +138,22 @@ fn default_target() -> String {
     "pmcp.run".to_string()
 }
 
+fn validate_hex_color(color: &str, field: &str) -> Result<()> {
+    if !color.starts_with('#') || (color.len() != 4 && color.len() != 7) {
+        anyhow::bail!(
+            "{} must be a valid hex color (e.g., #fff or #ffffff)",
+            field
+        );
+    }
+    if !color[1..].chars().all(|c| c.is_ascii_hexdigit()) {
+        anyhow::bail!(
+            "{} must be a valid hex color (e.g., #fff or #ffffff)",
+            field
+        );
+    }
+    Ok(())
+}
+
 impl LandingConfig {
     /// Load configuration from a TOML file
     pub fn load(path: &Path) -> Result<Self> {
@@ -151,10 +199,16 @@ impl LandingConfig {
 
         // Validate primary color if provided
         if let Some(ref color) = self.landing.branding.primary_color {
-            if !color.starts_with('#') || (color.len() != 4 && color.len() != 7) {
-                anyhow::bail!(
-                    "landing.branding.primary_color must be a valid hex color (e.g., #fff or #ffffff)"
-                );
+            validate_hex_color(color, "landing.branding.primary_color")?;
+        }
+
+        // Validate login branding colors if provided
+        if let Some(ref login) = self.login {
+            if let Some(ref color) = login.primary_color {
+                validate_hex_color(color, "login.primary_color")?;
+            }
+            if let Some(ref color) = login.background_color {
+                validate_hex_color(color, "login.background_color")?;
             }
         }
 
@@ -198,6 +252,7 @@ impl LandingConfig {
                 server_id: None,
                 endpoint: None,
             },
+            login: None,
         }
     }
 }
@@ -260,5 +315,71 @@ mod tests {
 
         config.landing.branding.primary_color = Some("ffffff".to_string());
         assert!(config.validate().is_err());
+
+        // Non-hex characters are rejected too
+        config.landing.branding.primary_color = Some("#gggggg".to_string());
+        assert!(config.validate().is_err());
+    }
+
+    /// Regression test for pmcp.run platform CR-01: `[login]` sections were
+    /// silently dropped by serde because the struct had no `login` field,
+    /// so Cognito `UpdateManagedLoginBranding` was never fired end-to-end
+    /// from a real developer deploy.
+    #[test]
+    fn test_login_section_round_trips_through_toml() {
+        let toml = r##"
+[landing]
+server_name = "example"
+
+[login]
+primary_color = "#0972d3"
+background_color = "#ffffff"
+logo = "s3://pmcp-landings-dev/example/logo.png"
+"##;
+
+        let config: LandingConfig = toml::from_str(toml).expect("parse");
+        let login = config.login.as_ref().expect("[login] section preserved");
+        assert_eq!(login.primary_color.as_deref(), Some("#0972d3"));
+        assert_eq!(login.background_color.as_deref(), Some("#ffffff"));
+        assert_eq!(
+            login.logo.as_deref(),
+            Some("s3://pmcp-landings-dev/example/logo.png")
+        );
+
+        // Round-trip: serialize back and re-parse, values must survive
+        let emitted = toml::to_string(&config).expect("serialize");
+        let reparsed: LandingConfig = toml::from_str(&emitted).expect("reparse");
+        let login2 = reparsed.login.as_ref().expect("login survives round-trip");
+        assert_eq!(login2.primary_color.as_deref(), Some("#0972d3"));
+    }
+
+    #[test]
+    fn test_login_section_optional_backward_compatible() {
+        // Config with no [login] — must still parse and validate cleanly.
+        let toml = r#"
+[landing]
+server_name = "example"
+"#;
+        let config: LandingConfig = toml::from_str(toml).expect("parse");
+        assert!(config.login.is_none());
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_login_color_validation_rejects_bad_hex() {
+        let mut config = LandingConfig::default_for_server("test".to_string());
+        config.login = Some(LoginConfig {
+            primary_color: Some("not-a-color".to_string()),
+            background_color: None,
+            logo: None,
+        });
+        assert!(config.validate().is_err());
+
+        config.login = Some(LoginConfig {
+            primary_color: Some("#fff".to_string()),
+            background_color: Some("#0972d3".to_string()),
+            logo: Some("s3://bucket/logo.png".to_string()),
+        });
+        assert!(config.validate().is_ok());
     }
 }

--- a/cargo-pmcp/src/landing/config.rs
+++ b/cargo-pmcp/src/landing/config.rs
@@ -22,6 +22,24 @@ pub struct LandingConfig {
     /// hosted pages that end-users see when an MCP client triggers OAuth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub login: Option<LoginConfig>,
+
+    /// Sign-up flow configuration. The landing template's `/signup` route
+    /// redirects to the server's Cognito hosted UI; this controls where the
+    /// user lands afterwards. Consumed by the platform at deploy time and
+    /// injected into the Next.js build as `NEXT_PUBLIC_SIGNUP_REDIRECT_AFTER`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signup: Option<SignupConfig>,
+}
+
+/// Sign-up flow configuration
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SignupConfig {
+    /// Path on the landing site to redirect users to after they complete
+    /// the Cognito hosted UI sign-up flow. Must be a relative path starting
+    /// with `/` — absolute URLs and protocol-relative URLs (`//host`) are
+    /// rejected to prevent open-redirect misuse. Defaults to `/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redirect_after: Option<String>,
 }
 
 /// Cognito Managed Login branding configuration
@@ -154,6 +172,37 @@ fn validate_hex_color(color: &str, field: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate a same-site relative redirect path.
+///
+/// Rejects absolute URLs (`http://...`, `https://...`), protocol-relative URLs
+/// (`//evil.com/...`), and anything that doesn't start with a single `/`.
+/// This prevents the value from being used as an open-redirect vector when
+/// the landing template consumes `NEXT_PUBLIC_SIGNUP_REDIRECT_AFTER`.
+fn validate_relative_path(path: &str, field: &str) -> Result<()> {
+    if !path.starts_with('/') {
+        anyhow::bail!(
+            "{} must be a relative path starting with '/' (got {:?})",
+            field,
+            path
+        );
+    }
+    if path.starts_with("//") {
+        anyhow::bail!(
+            "{} must not start with '//' (protocol-relative URLs are rejected to prevent open redirects)",
+            field
+        );
+    }
+    // Cheap heuristic: anything containing "://" is clearly an absolute URL
+    if path.contains("://") {
+        anyhow::bail!(
+            "{} must be a relative path, not an absolute URL (got {:?})",
+            field,
+            path
+        );
+    }
+    Ok(())
+}
+
 impl LandingConfig {
     /// Load configuration from a TOML file
     pub fn load(path: &Path) -> Result<Self> {
@@ -212,6 +261,13 @@ impl LandingConfig {
             }
         }
 
+        // Validate signup redirect if provided
+        if let Some(ref signup) = self.signup {
+            if let Some(ref path) = signup.redirect_after {
+                validate_relative_path(path, "signup.redirect_after")?;
+            }
+        }
+
         Ok(())
     }
 
@@ -253,6 +309,7 @@ impl LandingConfig {
                 endpoint: None,
             },
             login: None,
+            signup: None,
         }
     }
 }
@@ -381,5 +438,85 @@ server_name = "example"
             logo: Some("s3://bucket/logo.png".to_string()),
         });
         assert!(config.validate().is_ok());
+    }
+
+    /// Regression test for CR-02: `[signup]` section must round-trip through
+    /// TOML so the platform deploy-landing Lambda can read `redirect_after`
+    /// and inject `NEXT_PUBLIC_SIGNUP_REDIRECT_AFTER` into the build env.
+    #[test]
+    fn test_signup_section_round_trips_through_toml() {
+        let toml = r#"
+[landing]
+server_name = "example"
+
+[signup]
+redirect_after = "/connect"
+"#;
+        let config: LandingConfig = toml::from_str(toml).expect("parse");
+        let signup = config.signup.as_ref().expect("[signup] section preserved");
+        assert_eq!(signup.redirect_after.as_deref(), Some("/connect"));
+
+        let emitted = toml::to_string(&config).expect("serialize");
+        let reparsed: LandingConfig = toml::from_str(&emitted).expect("reparse");
+        assert_eq!(
+            reparsed
+                .signup
+                .as_ref()
+                .and_then(|s| s.redirect_after.as_deref()),
+            Some("/connect")
+        );
+    }
+
+    #[test]
+    fn test_signup_section_optional_backward_compatible() {
+        let toml = r#"
+[landing]
+server_name = "example"
+"#;
+        let config: LandingConfig = toml::from_str(toml).expect("parse");
+        assert!(config.signup.is_none());
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_signup_redirect_after_rejects_open_redirect_vectors() {
+        let mut config = LandingConfig::default_for_server("test".to_string());
+
+        // Absolute URLs: rejected
+        config.signup = Some(SignupConfig {
+            redirect_after: Some("https://evil.com/connect".to_string()),
+        });
+        assert!(config.validate().is_err(), "absolute https URL must reject");
+
+        config.signup = Some(SignupConfig {
+            redirect_after: Some("http://evil.com/connect".to_string()),
+        });
+        assert!(config.validate().is_err(), "absolute http URL must reject");
+
+        // Protocol-relative: rejected
+        config.signup = Some(SignupConfig {
+            redirect_after: Some("//evil.com/connect".to_string()),
+        });
+        assert!(
+            config.validate().is_err(),
+            "protocol-relative URL must reject"
+        );
+
+        // Missing leading slash: rejected
+        config.signup = Some(SignupConfig {
+            redirect_after: Some("connect".to_string()),
+        });
+        assert!(
+            config.validate().is_err(),
+            "path without leading / must reject"
+        );
+
+        // Valid same-site paths: accepted
+        for ok in &["/", "/connect", "/signup/complete", "/a/b/c"] {
+            config.signup = Some(SignupConfig {
+                redirect_after: Some((*ok).to_string()),
+            });
+            assert!(config.validate().is_ok(), "{} should be accepted", ok);
+        }
     }
 }

--- a/cargo-pmcp/templates/landing/nextjs/app/components/ConnectSnippet.tsx
+++ b/cargo-pmcp/templates/landing/nextjs/app/components/ConnectSnippet.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState } from 'react'
+
+type ConnectSnippetProps = {
+  title: string
+  instructions: string
+  /** JSON config payload (for Claude Desktop / Claude Code style). */
+  config?: unknown
+  /** One-line shell command (for generic CLI usage). */
+  command?: string
+}
+
+export default function ConnectSnippet({
+  title,
+  instructions,
+  config,
+  command,
+}: ConnectSnippetProps) {
+  const [copied, setCopied] = useState(false)
+
+  const payload = config != null ? JSON.stringify(config, null, 2) : command
+
+  const handleCopy = async () => {
+    if (!payload) return
+    try {
+      await navigator.clipboard.writeText(payload)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard API may be blocked in insecure contexts (non-HTTPS). Fall
+      // back to a prompt so the user can still copy manually.
+      window.prompt('Copy:', payload)
+    }
+  }
+
+  return (
+    <section className="my-6 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        {payload ? (
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="rounded-md border border-gray-300 bg-gray-50 px-3 py-1 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        ) : null}
+      </div>
+      <p className="mt-2 text-sm text-gray-600">{instructions}</p>
+      {payload ? (
+        <pre className="mt-3 overflow-x-auto rounded-md bg-gray-900 p-4 text-sm text-gray-100">
+          <code>{payload}</code>
+        </pre>
+      ) : null}
+    </section>
+  )
+}

--- a/cargo-pmcp/templates/landing/nextjs/app/components/Header.tsx
+++ b/cargo-pmcp/templates/landing/nextjs/app/components/Header.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+const serverName = process.env.MCP_SERVER_NAME || 'MCP Server'
+
+export default function Header() {
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <nav className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+        <Link href="/" className="text-lg font-semibold text-gray-900">
+          {serverName}
+        </Link>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/connect"
+            className="text-sm font-medium text-gray-700 hover:text-gray-900"
+          >
+            Connect
+          </Link>
+          <Link
+            href="/signup"
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+          >
+            Sign up
+          </Link>
+        </div>
+      </nav>
+    </header>
+  )
+}

--- a/cargo-pmcp/templates/landing/nextjs/app/connect/page.tsx
+++ b/cargo-pmcp/templates/landing/nextjs/app/connect/page.tsx
@@ -1,0 +1,55 @@
+import Header from '../components/Header'
+import ConnectSnippet from '../components/ConnectSnippet'
+
+// `MCP_SERVER_NAME` is injected by the pmcp.run deploy-landing Lambda (it's
+// already the canonical identifier used in `pmcp proxy <name>` commands).
+const serverName = process.env.MCP_SERVER_NAME || 'your-server'
+
+const mcpClientConfig = {
+  mcpServers: {
+    [serverName]: {
+      command: 'pmcp',
+      args: ['proxy', serverName],
+    },
+  },
+}
+
+export default function Connect() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="text-3xl font-bold text-gray-900">
+          Connect your MCP client
+        </h1>
+        <p className="mt-3 text-gray-600">
+          Your account is created. Pick your MCP client below to finish
+          connecting.
+        </p>
+
+        <ConnectSnippet
+          title="Claude Desktop"
+          instructions="Add this to your claude_desktop_config.json, then restart Claude Desktop."
+          config={mcpClientConfig}
+        />
+
+        <ConnectSnippet
+          title="Claude Code"
+          instructions="Add this to ~/.claude/claude.json, or run `claude mcp add` with the same values."
+          config={mcpClientConfig}
+        />
+
+        <ConnectSnippet
+          title="ChatGPT"
+          instructions={`Open ChatGPT → Settings → MCP Connectors → Add, and paste the URL: https://${serverName}.us-east.true-mcp.com`}
+        />
+
+        <ConnectSnippet
+          title="Generic MCP CLI"
+          instructions="Run this in your terminal with the pmcp CLI installed."
+          command={`pmcp connect ${serverName}`}
+        />
+      </main>
+    </>
+  )
+}

--- a/cargo-pmcp/templates/landing/nextjs/app/page.tsx
+++ b/cargo-pmcp/templates/landing/nextjs/app/page.tsx
@@ -1,3 +1,4 @@
+import Header from './components/Header'
 import Hero from './components/Hero'
 import Features from './components/Features'
 import Installation from './components/Installation'
@@ -5,6 +6,7 @@ import Installation from './components/Installation'
 export default function Home() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-gray-50 to-white">
+      <Header />
       <Hero />
       <Features />
       <Installation />

--- a/cargo-pmcp/templates/landing/nextjs/app/signup/callback/page.tsx
+++ b/cargo-pmcp/templates/landing/nextjs/app/signup/callback/page.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+// Cognito redirects back here with ?code=... after hosted-UI sign-up. We do
+// NOT exchange the code for tokens — sign-up alone is the goal for Phase 71.
+// The `landing` Cognito client's confidential secret therefore stays server-
+// side. A future phase that needs a signed-in landing experience will add a
+// Route Handler (app/signup/callback/route.ts) that exchanges the code with
+// the secret and sets a session cookie; this page would then redirect via
+// the route handler instead of directly.
+export default function SignupCallback() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const target = process.env.NEXT_PUBLIC_SIGNUP_REDIRECT_AFTER || '/'
+    router.replace(target)
+  }, [router])
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <p className="text-gray-600">Welcome! Redirecting…</p>
+    </main>
+  )
+}

--- a/cargo-pmcp/templates/landing/nextjs/app/signup/page.tsx
+++ b/cargo-pmcp/templates/landing/nextjs/app/signup/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// Client-side redirect to the server's Cognito Managed Login hosted UI in
+// sign-up mode. The four NEXT_PUBLIC_* values are injected at build time by
+// the pmcp.run deploy-landing Lambda (via Amplify app-level environmentVariables)
+// — see rust-mcp-sdk/cargo-pmcp/CHANGES.md for the contract.
+export default function Signup() {
+  useEffect(() => {
+    const domain = process.env.NEXT_PUBLIC_COGNITO_DOMAIN
+    const region = process.env.NEXT_PUBLIC_COGNITO_REGION
+    const clientId = process.env.NEXT_PUBLIC_LANDING_CLIENT_ID
+
+    if (!domain || !region || !clientId) {
+      console.error(
+        'Sign-up is not configured: missing NEXT_PUBLIC_COGNITO_DOMAIN, ' +
+          'NEXT_PUBLIC_COGNITO_REGION, or NEXT_PUBLIC_LANDING_CLIENT_ID. ' +
+          'These are injected by the pmcp.run platform at deploy time.',
+      )
+      return
+    }
+
+    const origin = window.location.origin
+    const url = new URL(
+      `https://${domain}.auth.${region}.amazoncognito.com/signup`,
+    )
+    url.searchParams.set('client_id', clientId)
+    url.searchParams.set('response_type', 'code')
+    url.searchParams.set('scope', 'openid email')
+    url.searchParams.set('redirect_uri', `${origin}/signup/callback`)
+
+    window.location.replace(url.toString())
+  }, [])
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50">
+      <p className="text-gray-600">Redirecting to sign-up…</p>
+    </main>
+  )
+}

--- a/cargo-pmcp/templates/landing/nextjs/pmcp-landing.toml
+++ b/cargo-pmcp/templates/landing/nextjs/pmcp-landing.toml
@@ -24,3 +24,12 @@ target = "pmcp.run"
 # primary_color = "#0972d3"
 # background_color = "#ffffff"
 # logo = "s3://pmcp-landings-<env>/<server>/logo.png"  # S3 URL; same bucket as landing assets
+
+# [signup] controls the /signup flow the landing template ships. Post-sign-up,
+# the hosted UI callback redirects users to `redirect_after` on this site
+# (must be a relative path — absolute URLs are rejected to prevent open
+# redirects). Default: "/". Recommended: "/connect" — the connect page this
+# template ships with copy-paste snippets for Claude Desktop, Claude Code, etc.
+#
+# [signup]
+# redirect_after = "/connect"

--- a/cargo-pmcp/templates/landing/nextjs/pmcp-landing.toml
+++ b/cargo-pmcp/templates/landing/nextjs/pmcp-landing.toml
@@ -14,3 +14,13 @@ primary_color = "{{PRIMARY_COLOR}}"
 [deployment]
 target = "pmcp.run"
 # server_id and endpoint are auto-populated from deployment
+
+# [login] styles the Cognito Managed Login hosted UI that end-users see when
+# an MCP client triggers OAuth. This is distinct from [landing.branding] above,
+# which styles the landing site chrome. Uncomment and customize to push custom
+# colors and logo to your server's hosted login pages.
+#
+# [login]
+# primary_color = "#0972d3"
+# background_color = "#ffffff"
+# logo = "s3://pmcp-landings-<env>/<server>/logo.png"  # S3 URL; same bucket as landing assets

--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -34,9 +34,9 @@ toml = "1.0"
 
 # JavaScript parsing (optional, for OpenAPI Code Mode)
 swc_ecma_parser = { version = "38", optional = true }
-swc_ecma_ast = { version = "19", optional = true }
+swc_ecma_ast = { version = "23", optional = true }
 swc_ecma_visit = { version = "23", optional = true }
-swc_common = { version = "18", optional = true }
+swc_common = { version = "21", optional = true }
 
 # SQL parsing (optional, for SQL Code Mode)
 sqlparser = { version = "0.61", optional = true }


### PR DESCRIPTION
Lands **cargo-pmcp 0.8.0** with two pmcp.run platform change requests and a dependency bump that supersedes the two open dependabot PRs.

## 1. CR-01 — `[login]` section in `pmcp-landing.toml` (silent data-loss bug)

`[login]` blocks in `pmcp-landing.toml` were being silently dropped by serde because `LandingConfig` had no `login` field, so the pmcp.run deploy-landing Lambda never received the branding and `UpdateManagedLoginBranding` was never fired end-to-end from a developer deploy.

- `LoginConfig { primary_color, background_color, logo }` + `LandingConfig.login: Option<LoginConfig>`
- Hex-color validation mirrored for `login.primary_color` / `login.background_color` at parse time (caught locally, not deferred to the Lambda)
- 3 regression tests (round-trip, backward-compat, validation)
- Template `pmcp-landing.toml` gets a commented `[login]` example that names the distinction between `landing.branding` (landing site chrome) and `[login]` (Cognito hosted UI)

## 2. CR-02 — Sign-up entry, `/connect` page, `[signup]` TOML (App Router)

Extends the `landing/nextjs` template so server end-users can sign up to the Cognito pool from the landing site instead of having to trigger a DCR flow from an MCP client.

Rust (`src/landing/config.rs`):
- `SignupConfig { redirect_after: Option<String> }` + `LandingConfig.signup: Option<SignupConfig>`
- `validate_relative_path()` rejects absolute URLs, protocol-relative URLs (`//evil.com`), and paths without a leading `/` — closes an open-redirect vector before the value lands in `NEXT_PUBLIC_SIGNUP_REDIRECT_AFTER`
- 3 regression tests (round-trip, backward-compat, open-redirect guard)

Next.js template (App Router):
- `app/signup/page.tsx` — `'use client'`; redirects to the server's Cognito hosted UI `/signup` with `response_type=code&scope=openid+email`
- `app/signup/callback/page.tsx` — `'use client'`; `useRouter().replace()` to `NEXT_PUBLIC_SIGNUP_REDIRECT_AFTER` (default `/`). Does **not** exchange the authorization code — Phase 71 goal is account creation only, so the landing client's confidential secret never reaches the browser
- `app/connect/page.tsx` — server component with copy-paste snippets for Claude Desktop, Claude Code, ChatGPT, and the generic MCP CLI
- `components/ConnectSnippet.tsx` — `'use client'`; copy-to-clipboard with `prompt()` fallback for insecure (non-HTTPS) contexts
- `components/Header.tsx` — new; mounted in landing `/` and `/connect`
- `pmcp-landing.toml` — commented `[signup]` example alongside CR-01's `[login]`

### Build contract verification (AC#9 from CR-02)

`next build` succeeds cleanly with all four `NEXT_PUBLIC_*` env vars **unset** — produces 5 static routes (`/`, `/connect`, `/signup`, `/signup/callback`, `/_not-found`). Platform injects the 4 env vars at deploy time via Amplify app-level `environmentVariables` on `CreateAppCommand`/`UpdateAppCommand` (same pattern already used today for `MCP_SERVER_NAME` and `PMCP_API_URL` — see pmcp-run `deploy-landing/handler.ts:197-200`).

## 3. swc family bump — supersedes dependabot #237 and #235

Brings `pmcp-code-mode` swc deps to a consistent set matching what the two open dependabot PRs would produce combined, so they can be closed as redundant once this merges:

| Crate | Before | After |
|---|---|---|
| `swc_ecma_parser` | 38 | 38 *(already on main via #236)* |
| `swc_ecma_ast` | 19 | **23** *(dependabot #235)* |
| `swc_ecma_visit` | 23 | 23 *(already on main via #233)* |
| `swc_common` | 18 | **21** *(dependabot #237)* |

Verified with `cargo check/test -p pmcp-code-mode --features openapi-code-mode --lib` — 112/112 lib tests pass, no API drift.

## Quality gate

`make quality-gate` → green locally on rebased-to-upstream/main state. Rust: fmt + clippy (pedantic + nursery) + build + tests clean.

## Version bump

- `cargo-pmcp`: 0.7.1 → **0.8.0** (minor — new user-visible template feature)
- No other workspace crate version bumps

## Test plan

- [ ] CI: Rust fmt / clippy / build / test pass
- [ ] CI: doctest validation passes
- [ ] Reviewer spot-check: scaffold a fresh project with this template, run `next build` locally — should produce 5 static routes with no env vars set
- [ ] Coordinating platform PR in pmcp-run (Phase 71 Plan 71-02) will inject the 4 `NEXT_PUBLIC_*` env vars + add `/signup/callback` to the landing Day-1 client's `CallbackURLs`; that PR is not blocked by this one and env vars sit unused until the template consumes them

## Closes
- Supersedes paiml/rust-mcp-sdk#237 (`swc_common` 18→21)
- Supersedes paiml/rust-mcp-sdk#235 (`swc_ecma_ast` 19→23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)