### PR TITLE
fix(release): publish pmcp-macros-support before pmcp-macros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+  # Allow manual re-runs (e.g., after a workflow fix when a publish step
+  # failed and we want to re-fire against an existing tag). All publish
+  # steps already skip gracefully when the version is already on crates.io.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: never
@@ -77,10 +81,16 @@ jobs:
         key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
 
     # Publish order: leaf dependencies first, then dependents.
-    # pmcp-widget-utils (no deps) -> pmcp (depends on widget-utils)
-    # -> mcp-tester (depends on pmcp) -> mcp-preview (depends on widget-utils)
-    # -> pmcp-server (depends on pmcp, mcp-tester)
+    # pmcp-widget-utils (no internal deps)
+    # -> pmcp-macros-support (no internal deps; consumed by pmcp-macros)
+    # -> pmcp-macros (depends on pmcp-macros-support)
+    # -> pmcp-code-mode (depends on pmcp)
+    # -> pmcp-code-mode-derive (depends on pmcp-code-mode)
+    # -> pmcp (depends on widget-utils + macros)
+    # -> mcp-tester (depends on pmcp)
+    # -> mcp-preview (depends on widget-utils)
     # -> cargo-pmcp (depends on pmcp, mcp-tester, mcp-preview)
+    # -> pmcp-server (depends on pmcp, mcp-tester)
 
     - name: Publish pmcp-widget-utils
       env:
@@ -98,6 +108,24 @@ jobs:
         }
 
     - name: Wait for crates.io to index pmcp-widget-utils
+      run: sleep 30
+
+    - name: Publish pmcp-macros-support
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-macros-support..."
+        OUTPUT=$(cargo publish -p pmcp-macros-support 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-macros-support already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-macros-support"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index pmcp-macros-support
       run: sleep 30
 
     - name: Publish pmcp-macros


### PR DESCRIPTION
**Blocks v2.4.0 release** — the current release workflow run failed with:

\`\`\`
error: failed to prepare local package for uploading
Caused by: no matching package named \`pmcp-macros-support\` found
\`\`\`

\`pmcp-macros\` 0.6.0 depends on the new workspace crate \`pmcp-macros-support\` 0.1.0 (landed in the 2.4.0 window), but \`.github/workflows/release.yml\` didn't have a publish step for it, so it tried to publish \`pmcp-macros\` against a registry that had no \`pmcp-macros-support\`.

## Fixes

1. **Publish \`pmcp-macros-support\` before \`pmcp-macros\`** — new step + 30s index wait, using the same \"already exists → continue\" idempotency as every other publish step
2. **Add \`workflow_dispatch:\` trigger** — lets us manually re-fire against the existing \`v2.4.0\` tag without deleting/recreating it. Safe because every publish step is already idempotent on \"already exists\"
3. **Update the publish-order comment** to reflect the current crate graph (the comment had drifted against \`pmcp-macros-support\`, \`pmcp-code-mode\`, \`pmcp-code-mode-derive\`)

## No version bumps

No source/crate changes. After this merges I'll re-trigger the workflow against \`v2.4.0\` via \`gh workflow run release.yml --ref v2.4.0\`.

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(...)'\` passes — YAML still parses
- [x] Grep confirms the new step order: widget-utils → macros-support → macros → code-mode → code-mode-derive → pmcp → ...
- [ ] After merge: run \`gh workflow run release.yml --ref v2.4.0\` and verify the pmcp-macros-support step fires and pmcp-macros then succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)