### PR TITLE
fix(readme): repair top-line badges + quality-badges workflow

### DIFF
--- a/.github/workflows/quality-badges.yml
+++ b/.github/workflows/quality-badges.yml
@@ -38,8 +38,9 @@ jobs:
     
     - name: Install PMAT
       run: |
-        # Install PMAT (Pragmatic Modular Analysis Toolkit)
-        cargo install pmat-cli || echo "PMAT installation failed, continuing..."
+        # The crate is published as `pmat`, not `pmat-cli`. Fail loudly if
+        # install breaks so we don't silently fall back to sentinel badges.
+        cargo install pmat --locked
     
     - name: Generate TDG Score Badge
       run: |

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@
 [![Technical Debt](https://img.shields.io/badge/Tech%20Debt-0h-brightgreen)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)
 <!-- QUALITY BADGES END -->
 
-[![CI](https://github.com/paiml/pmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/pmcp/actions/workflows/ci.yml)
-[![Quality Gate](https://img.shields.io/badge/Quality%20Gate-passing-brightgreen)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)
-[![TDG Score](https://img.shields.io/badge/TDG%20Score-0.76-green)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)
-[![Coverage](https://img.shields.io/badge/coverage-52%25-yellow.svg)](https://github.com/paiml/pmcp)
+[![CI](https://github.com/paiml/rust-mcp-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-52%25-yellow.svg)](https://github.com/paiml/rust-mcp-sdk)
 [![Crates.io](https://img.shields.io/crates/v/pmcp.svg)](https://crates.io/crates/pmcp)
 [![Documentation](https://docs.rs/pmcp/badge.svg)](https://docs.rs/pmcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Summary

Three independent bugs were producing the confusing top of the README — contradictory "failing" Quality Gate next to "clean" Complexity and "0h" Tech Debt, plus a broken CI badge and a duplicate hardcoded row with different values.

## Root cause analysis

### 1. CI badge URL points at the old repo name
The CI badge on line 9 points at `github.com/paiml/pmcp`, which has been renamed to `paiml/rust-mcp-sdk`. GitHub returns a `301` redirect for the old URL but badge renderers don't follow 301s for badge images, so the CI badge was broken.

### 2. Coverage badge link has the same stale target
Same 301 issue, just on the link (not the image) so it was less visible.

### 3. `quality-badges.yml` installs a crate that doesn't exist
The workflow runs `cargo install pmat-cli`. **There is no `pmat-cli` crate on crates.io** — the actual crate is named `pmat` (v3.15.0). Install fails every run, and the `|| echo "PMAT installation failed, continuing..."` silently swallows the error. Every subsequent `pmat` call falls back to its sentinel default:

| Step | Expected (with pmat) | Actual (pmat missing) | Badge output |
|------|---------------------|----------------------|-------------|
| `pmat analyze tdg ...` | real TDG score | `{"summary":{"average_tdg":0}}` fallback | **TDG Score 0.00** |
| `pmat quality-gate --fail-on-violation` | exit 0 when clean | exit non-zero (pmat missing) | **Quality Gate failing** |
| `pmat quality-gate --checks complexity` | real violation count | 0 violations fallback | **Complexity clean** |
| `pmat analyze tdg` (debt hours) | real debt hours | 0 debt hours fallback | **Tech Debt 0h** |

That's why the top line is self-contradictory: every value is a pmat-absent sentinel, not a real measurement. The `|| echo` hid the failure.

### 4. README has two rows of badges that conflict
The auto-generated row (top) showed "Quality Gate: failing / TDG: 0.00" while a hardcoded second row (lines 10-11) showed "Quality Gate: passing / TDG: 0.76". The hardcoded row predates the quality-badges workflow and was never cleaned up.

## Changes

**`README.md`:**
- CI badge URL `paiml/pmcp` → `paiml/rust-mcp-sdk`.
- Coverage badge link URL `paiml/pmcp` → `paiml/rust-mcp-sdk`.
- Deleted the two hardcoded duplicate badges (Quality Gate 'passing', TDG Score '0.76') that conflicted with the auto-generated top row.

**`.github/workflows/quality-badges.yml`:**
- `cargo install pmat-cli` → `cargo install pmat --locked`.
- Dropped `|| echo "PMAT installation failed, continuing..."` so future install regressions fail the workflow loudly instead of silently shipping fake green badges.

## What happens after merge

The next scheduled run (06:00 UTC) or the next push to `main` will:
1. Successfully install `pmat` from crates.io.
2. Run real TDG / quality-gate / complexity / debt analysis.
3. Overwrite the auto-generated badge row between the HTML comment markers with actual measurements.

The CI badge on the second row will reflect real CI state as soon as the README is rendered (no workflow run needed).

If `pmat` itself subsequently reports real quality-gate failures, that will show up as a genuine red badge — which is the behaviour we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)