### PR TITLE
fix(badge): replace static Quality Gate badge with workflow-status badge

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,70 @@
+name: Quality Gate
+
+# Dedicated workflow whose pass/fail honestly reflects the PMAT complexity gate.
+#
+# The README's "Quality Gate" badge points at this workflow's status badge
+# (`actions/workflows/quality-gate.yml/badge.svg?branch=main`). When this
+# workflow's latest run on `main` succeeds, the badge is green; when it fails,
+# the badge is red — no manual flipping, no swallowed push errors, no
+# protected-branch token escalation needed.
+#
+# The same gate command also runs in `ci.yml` (the merge-blocking gate). This
+# workflow exists separately so the badge is dynamically driven by a single,
+# uncontaminated job — independent of unrelated CI steps that might fail.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Daily check so the badge re-validates against any environmental drift
+    # (e.g., PMAT version changes, dependency updates). Aligned with
+    # quality-badges.yml's 06:00 UTC slot.
+    - cron: '5 6 * * *'
+
+env:
+  # Pin matches ci.yml + quality-badges.yml so badge, gate, and CI stay
+  # aligned (Phase 75 D-09). Bumping requires re-running the W0 spike.
+  PMAT_VERSION: "3.15.0"
+
+jobs:
+  gate:
+    name: PMAT complexity gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ${{ runner.os }}-pmat-${{ env.PMAT_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-pmat-
+
+      - name: Install PMAT (cache-aware; reused across runs via ~/.cargo/bin)
+        run: |
+          if ! command -v pmat &>/dev/null || ! pmat --version | grep -qE "^pmat ${PMAT_VERSION}$"; then
+            cargo install pmat --version "=${PMAT_VERSION}" --locked
+          fi
+
+      - name: Verify PMAT version
+        run: |
+          pmat --version
+          pmat --version | grep -qE "^pmat ${PMAT_VERSION}$" || {
+            echo "ERROR: PMAT version mismatch — expected pmat ${PMAT_VERSION}"
+            exit 1
+          }
+
+      - name: Run PMAT quality gate (complexity only — see Phase 75 D-01 / D-11-B)
+        run: pmat quality-gate --fail-on-violation --checks complexity

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PMCP - Pragmatic Model Context Protocol
 <!-- QUALITY BADGES START -->
-[![Quality Gate](https://img.shields.io/badge/Quality%20Gate-failing-red)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)
+[![Quality Gate](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-gate.yml/badge.svg?branch=main)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-gate.yml)
 [![TDG Score](https://img.shields.io/badge/TDG%20Score-0.00-brightgreen)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)
 [![Complexity](https://img.shields.io/badge/Complexity-clean-brightgreen)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)
 [![Technical Debt](https://img.shields.io/badge/Tech%20Debt-0h-brightgreen)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)


### PR DESCRIPTION
## Summary

Make the README's "Quality Gate" badge honest by construction. The previous static shields.io URL had the literal text `failing-red` in markdown, and the `quality-badges.yml` workflow that was supposed to update it can't push to protected `main` (`GITHUB_TOKEN` lacks bypass permission, and the workflow's `git push origin main || echo "Failed to push changes"` swallows the error). After PR #250 (Phase 75 + 75.5) brought complexity violations to zero, the badge log correctly computed `Quality%20Gate-passing-brightgreen` — but the README never got updated.

A manual badge flip would just hardcode a different lie. This PR removes the static URL entirely.

## Changes

**1. New workflow `.github/workflows/quality-gate.yml`**

Minimal dedicated workflow whose single job runs `pmat quality-gate --fail-on-violation --checks complexity` (the same command in ci.yml's `quality-gate` job and quality-badges.yml's gate step). The workflow run exits non-zero on any violation, so its status badge accurately reflects gate pass/fail.

PMAT pinned to 3.15.0 (matches ci.yml + quality-badges.yml per Phase 75 D-09). Same cache-aware install pattern as ci.yml. Daily 06:05 UTC cron run validates against environmental drift (PMAT version updates, dependency changes).

**2. README.md badge URL**

```diff
-[![Quality Gate](https://img.shields.io/badge/Quality%20Gate-failing-red)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-badges.yml)
+[![Quality Gate](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-gate.yml/badge.svg?branch=main)](https://github.com/paiml/rust-mcp-sdk/actions/workflows/quality-gate.yml)
```

Now the badge image URL is dynamic — GitHub serves a green-or-red SVG based on the latest workflow run on `main`. No hardcoded text, no manual flips, no token escalation, no dependence on the broken push step.

## Why a separate workflow (not just ci.yml's badge)?

ci.yml already has a quality-gate job with the same command, but ci.yml also runs tests, doc-check, formatting, and other steps. If a doc-check change breaks while complexity is still clean, the ci.yml badge would (correctly) turn red — but a "Quality Gate" badge tied to ci.yml would also turn red, misleading readers about gate state.

The dedicated `quality-gate.yml` runs only the gate, so its badge says exactly one thing: "the PMAT complexity gate is/isn't passing right now."

## Out of scope (follow-up)

The TDG / Complexity / Tech Debt badges on lines 4-6 of README still use static shields.io URLs and suffer from the same push-failure problem. They're currently displaying the values PR #246 manually set. Fixing those needs either similar dynamic-badge replacement or converting `quality-badges.yml`'s commit step to `peter-evans/create-pull-request`. Tracked separately.

## Test plan

- [ ] CI on this PR runs `quality-gate.yml` and it passes (proves the workflow works on a known-green tree)
- [ ] After merge: README shows green "Quality Gate" badge served from GitHub Actions
- [ ] Manual smoke test: introduce a contrived complexity violation in a future PR and confirm the badge auto-flips to red on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)