### PR TITLE
ci(release): publish the v2.2 toolkit crates (server-toolkit, sql/openapi-server, connectors)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,10 @@ jobs:
     # -> pmcp-code-mode (depends on pmcp)
     # -> pmcp-code-mode-derive (depends on pmcp-code-mode)
     # -> pmcp (depends on widget-utils + macros)
+    # -> pmcp-server-toolkit (depends on pmcp + pmcp-code-mode)
+    # -> pmcp-toolkit-postgres / -mysql / -athena (depend on the toolkit)
+    # -> pmcp-sql-server (depends on toolkit + the three connectors)
+    # -> pmcp-openapi-server (depends on the toolkit)
     # -> mcp-tester (depends on pmcp)
     # -> mcp-preview (depends on widget-utils)
     # -> cargo-pmcp (depends on pmcp, mcp-tester, mcp-preview)
@@ -198,6 +202,111 @@ jobs:
         }
 
     - name: Wait for crates.io to index pmcp
+      run: sleep 30
+
+    # --- v2.2 config-driven server toolkit (first published in v2.9.0) ---
+    # pmcp-server-toolkit depends on pmcp + pmcp-code-mode (both published above);
+    # the three per-backend connectors depend on the toolkit; pmcp-sql-server
+    # depends on the toolkit + all three connectors; pmcp-openapi-server depends
+    # on the toolkit. (mcp-tester is only a dev-dependency of the servers and is
+    # already on crates.io, so it does not gate this tier.)
+    - name: Publish pmcp-server-toolkit
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-server-toolkit..."
+        OUTPUT=$(cargo publish -p pmcp-server-toolkit 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-server-toolkit already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-server-toolkit"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index pmcp-server-toolkit
+      run: sleep 30
+
+    - name: Publish pmcp-toolkit-postgres
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-toolkit-postgres..."
+        OUTPUT=$(cargo publish -p pmcp-toolkit-postgres 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-toolkit-postgres already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-toolkit-postgres"
+            exit 1
+          fi
+        }
+
+    - name: Publish pmcp-toolkit-mysql
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-toolkit-mysql..."
+        OUTPUT=$(cargo publish -p pmcp-toolkit-mysql 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-toolkit-mysql already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-toolkit-mysql"
+            exit 1
+          fi
+        }
+
+    - name: Publish pmcp-toolkit-athena
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-toolkit-athena..."
+        OUTPUT=$(cargo publish -p pmcp-toolkit-athena 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-toolkit-athena already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-toolkit-athena"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index the toolkit connectors
+      run: sleep 30
+
+    - name: Publish pmcp-sql-server
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-sql-server..."
+        OUTPUT=$(cargo publish -p pmcp-sql-server 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-sql-server already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-sql-server"
+            exit 1
+          fi
+        }
+
+    - name: Publish pmcp-openapi-server
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-openapi-server..."
+        OUTPUT=$(cargo publish -p pmcp-openapi-server 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-openapi-server already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-openapi-server"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index the toolkit servers
       run: sleep 30
 
     - name: Publish mcp-tester


### PR DESCRIPTION
## Fix: publish the v2.2 toolkit crates

The **v2.9.0** release ([#267](https://github.com/paiml/rust-mcp-sdk/pull/267)) shipped, and `release.yml` successfully published the crates in its (hardcoded) list — `pmcp` 2.9.0, `pmcp-code-mode` 0.5.2, `cargo-pmcp` 0.15.0, etc. But the publish list **predates the v2.2 toolkit**, so the six new config-driven-server crates — the headline of the release — were **never published to crates.io**:

- `pmcp-server-toolkit`
- `pmcp-toolkit-postgres`, `pmcp-toolkit-mysql`, `pmcp-toolkit-athena`
- `pmcp-sql-server`, `pmcp-openapi-server`

This adds publish steps for all six, in dependency order, right after `pmcp` (their dependency floor, `pmcp` 2.9.0 + `pmcp-code-mode` 0.5.2, is published earlier in the job):

```
pmcp-server-toolkit
  → pmcp-toolkit-postgres / -mysql / -athena   (depend on the toolkit)
  → pmcp-sql-server, pmcp-openapi-server        (sql-server also needs the 3 connectors)
```

Each step reuses the **existing idempotent pattern** (`if "already exists" → continue`), so once this merges, **re-triggering the release** (a `v2.9.1` tag, or re-running the publish job) republishes only the six missing crates — the already-published ones become no-ops. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
