### PR TITLE
chore(deps): align swc to coherent 41-generation (fixes code-mode build)

### DIFF
--- a/crates/pmcp-code-mode/Cargo.toml
+++ b/crates/pmcp-code-mode/Cargo.toml
@@ -33,14 +33,14 @@ graphql-parser = "0.4"
 toml = "1.0"
 
 # JavaScript parsing (optional, for OpenAPI Code Mode).
-# Pinned to the swc "39" generation: the "40" generation (parser 40.0.0, ast/visit
-# 24.0.0, common 22.0.0) was YANKED wholesale from crates.io, which made the prior
-# mixed pins (parser "40" + visit "24") unresolvable. This 39-gen set is non-yanked
-# and is the generation this crate's code compiles against.
+# Aligned to the coherent swc "41" generation (parser 41, ast 25, visit 25,
+# common 23). These four crates share generated AST/visitor types and MUST move
+# together — a mixed set (e.g. parser 41 + ast 23) resolves two copies of
+# swc_ecma_ast and breaks the `Visit` impl in javascript.rs with E0053.
 swc_ecma_parser = { version = "41", optional = true }
-swc_ecma_ast = { version = "23", optional = true }
+swc_ecma_ast = { version = "25", optional = true }
 swc_ecma_visit = { version = "25", optional = true }
-swc_common = { version = "21", optional = true }
+swc_common = { version = "23", optional = true }
 
 # SQL parsing (optional, for SQL Code Mode)
 sqlparser = { version = "0.62", optional = true }


### PR DESCRIPTION
## Summary

Resolves the swc dependency conflicts in `crates/pmcp-code-mode` by aligning all four swc crates to the coherent **"41" generation**.

After #272 (`swc_ecma_visit` 23→25) and #274 (`swc_ecma_parser` 39→41) merged, `main` was left in a **mixed/incoherent** state — `parser 41` + `visit 25` but `ast 23` + `common 21`. Because `parser 41` and `visit 25` pull `swc_ecma_ast 25` / `swc_common 23` transitively, the crate resolved **two copies** of each, and the `Visit` impl in `javascript.rs` failed to compile:

```
error[E0053]: method `visit_block_stmt` has an incompatible type for trait
... (every visit_* method — ast 23 node types vs visit 25's expected ast 25 types)
```

This is also why the remaining dependabot PRs (#270 `ast`→25, #271 `common`→23) conflict — they each move *one* crate, but the set has to move together.

## Change

One file — `crates/pmcp-code-mode/Cargo.toml`:
- `swc_ecma_ast` 23 → **25**
- `swc_common` 21 → **23**
- (`swc_ecma_parser` 41 and `swc_ecma_visit` 25 already correct)
- Updated the now-stale "39 generation" pin comment.

**No source changes needed** — the `Visit` method signatures match once the AST types are unified to a single generation.

## Verification

- [x] `make quality-gate` — **PASS** (fmt / clippy pedantic+nursery / build / test / audit / validate-always).
- [x] `pmcp-code-mode` builds + tests (114 + 14 + 1) pass + clippy clean across `openapi-code-mode`, `js-runtime`, `mcp-code-mode`.
- [x] Dependents build: `pmcp-openapi-server --all-features`, `pmcp-server-toolkit`, `pmcp-code-mode-derive`.
- [x] `cargo tree` now resolves a **single** `swc_ecma_ast v25` / `swc_common v23` (no duplicates).

## Supersedes

Closes #270 and #271 — this does the coherent alignment they each partially attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
