### PR TITLE
chore(release): v2.9.2 — workbook crates first publish + toolkit/mysql/cargo-pmcp bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,79 @@ jobs:
     - name: Wait for crates.io to index the toolkit servers
       run: sleep 30
 
+    # --- v2.3 Excel-as-Configuration workbook crates (first published here) ---
+    # pmcp-workbook-dialect + pmcp-workbook-runtime are leaves (the runtime carries
+    # rust_xlsxwriter; the reader umya stays confined to the compiler). The compiler
+    # depends on both + pmcp-server-toolkit[workbook] (a dev-dependency only — the
+    # purity boundary keeps umya out of the served tree). pmcp-workbook-server
+    # depends on the toolkit[workbook,http]. cargo-pmcp (below) depends on the
+    # compiler, so all four must publish before it.
+    - name: Publish pmcp-workbook-dialect
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-workbook-dialect..."
+        OUTPUT=$(cargo publish -p pmcp-workbook-dialect 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-workbook-dialect already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-workbook-dialect"
+            exit 1
+          fi
+        }
+
+    - name: Publish pmcp-workbook-runtime
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-workbook-runtime..."
+        OUTPUT=$(cargo publish -p pmcp-workbook-runtime 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-workbook-runtime already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-workbook-runtime"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index the workbook leaves
+      run: sleep 30
+
+    - name: Publish pmcp-workbook-compiler
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-workbook-compiler..."
+        OUTPUT=$(cargo publish -p pmcp-workbook-compiler 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-workbook-compiler already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-workbook-compiler"
+            exit 1
+          fi
+        }
+
+    - name: Publish pmcp-workbook-server
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-workbook-server..."
+        OUTPUT=$(cargo publish -p pmcp-workbook-server 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-workbook-server already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-workbook-server"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index the workbook crates
+      run: sleep 30
+
     - name: Publish mcp-tester
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.2] - 2026-06-20
+
+Excel-as-Configuration workbook servers: the table-based authoring contract, and
+the first crates.io release of the workbook crate tree.
+
+### Added
+
+- **Table-based workbook authoring** — author inputs and outputs as named Excel
+  Tables (`name | value | description | tier`); each output Table becomes its own
+  named, DAG-typed MCP tool (multi-tool fan-out, one tool per output Table with a
+  per-tool input schema reaching only the inputs its formulas use). Supersedes the
+  per-cell `in_*`/`out_*` named-range model.
+- **`cargo pmcp workbook explain <file>`** (`cargo-pmcp` 0.17.0) — read-only,
+  pre-deploy preview of the exact served tool surface, projected through the same
+  production compiler path the server registers (so it cannot drift); text +
+  `--format json`.
+- **First crates.io release of the workbook crate tree** — `pmcp-workbook-dialect`,
+  `pmcp-workbook-runtime`, `pmcp-workbook-compiler`, and `pmcp-workbook-server`
+  at 0.1.0. The Excel reader (umya) stays confined to the compiler; the served
+  crates are reader-free (purity gate).
+
+### Changed
+
+- **`pmcp-server-toolkit` 0.1.1** — the served workbook surface fans out to one
+  tool per output Table with DAG-derived per-tool input schemas; `get_manifest`
+  advertises the stripped served keys; compile-time gates reject reserved-tool-name
+  and output-key collisions. (Additive behind the `workbook` feature — the SQL
+  connectors' `^0.1.0` pins are unaffected.)
+
+### Fixed
+
+- **`pmcp-toolkit-mysql` 0.1.1** — sqlx 0.9 `SqlSafeStr`: wrap the audited dynamic
+  query in `AssertSqlSafe` (the SQL is placeholder-translated and every value is
+  bound via `bind_one`, never interpolated).
+
 ## [2.9.1] - 2026-05-31
 
 Completes the v2.9.0 release and fixes a yanked-dependency breakage.

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/crates/pmcp-server-toolkit/Cargo.toml
+++ b/crates/pmcp-server-toolkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-server-toolkit"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paiml/rust-mcp-sdk"

--- a/crates/pmcp-toolkit-mysql/Cargo.toml
+++ b/crates/pmcp-toolkit-mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-toolkit-mysql"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paiml/rust-mcp-sdk"


### PR DESCRIPTION
## Release v2.9.2 — workbook crates first publish + toolkit/mysql/cargo-pmcp bumps

Cuts the crates.io release for the Excel-as-Configuration workbook work (merged in #280) so downstream consumers — including the pmcp.run team and `cargo install cargo-pmcp` users — can pull the table-authoring multi-tool surface and `cargo pmcp workbook explain`.

### Versions (publish order)

| Crate | crates.io | This release | Notes |
|-------|-----------|--------------|-------|
| `pmcp` | 2.9.0 | — (unchanged) | root crate not touched |
| `pmcp-workbook-dialect` | — | **0.1.0** | **first publish** (leaf) |
| `pmcp-workbook-runtime` | — | **0.1.0** | **first publish** (writer-only; reader-free) |
| `pmcp-server-toolkit` | 0.1.0 | **0.1.1** | additive workbook multi-tool surface |
| `pmcp-toolkit-mysql` | 0.1.0 | **0.1.1** | sqlx 0.9 `AssertSqlSafe` fix |
| `pmcp-workbook-compiler` | — | **0.1.0** | **first publish** (umya confined here) |
| `pmcp-workbook-server` | — | **0.1.0** | **first publish** (served cone reader-free) |
| `cargo-pmcp` | 0.15.0 | **0.17.0** | `workbook explain`; now depends on the compiler |

The SQL connectors (`-postgres` / `-athena` / `-sql-server` / `-openapi-server`) are **untouched** — their `^0.1.0` pins resolve to toolkit `0.1.1`, so there's no needless version cascade.

### Workflow change

`release.yml` had **no publish steps for the workbook crates** (they were never released). This PR adds them in dependency order — `pmcp-workbook-dialect`, `pmcp-workbook-runtime` → `pmcp-workbook-compiler`, `pmcp-workbook-server` — **before** `cargo-pmcp`, which now depends on `pmcp-workbook-compiler`. Each step matches the existing `cargo publish … || already-exists-continue` pattern with crates.io index waits.

### Verification

- [x] `make quality-gate` green (the version bumps resolve; path deps see toolkit 0.1.1).
- [x] `make purity-check` green — the served workbook crates stay reader-free; the Excel reader (umya) is confined to `pmcp-workbook-compiler`.
- [x] No pin edits needed (all `^0.1.0` pins accept 0.1.1); `Cargo.lock` (gitignored) regenerates in CI.

### After merge

Tag `v2.9.2` on `main` and push it — `release.yml` publishes all new-version crates to crates.io in order (skipping already-published ones) and creates the GitHub Release from this CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
