### PR TITLE
fix(release): publish workbook leaves before pmcp-server-toolkit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,42 @@ jobs:
     # depends on the toolkit + all three connectors; pmcp-openapi-server depends
     # on the toolkit. (mcp-tester is only a dev-dependency of the servers and is
     # already on crates.io, so it does not gate this tier.)
+    # --- v2.3 workbook leaves — MUST precede pmcp-server-toolkit, which has an
+    # OPTIONAL dependency on pmcp-workbook-runtime; crates.io rejects a publish whose
+    # dependencies (even optional) are not yet on the index. Both are leaves.
+    - name: Publish pmcp-workbook-dialect
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-workbook-dialect..."
+        OUTPUT=$(cargo publish -p pmcp-workbook-dialect 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-workbook-dialect already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-workbook-dialect"
+            exit 1
+          fi
+        }
+
+    - name: Publish pmcp-workbook-runtime
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-workbook-runtime..."
+        OUTPUT=$(cargo publish -p pmcp-workbook-runtime 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-workbook-runtime already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-workbook-runtime"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index the workbook leaves
+      run: sleep 30
+
     - name: Publish pmcp-server-toolkit
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -309,46 +345,12 @@ jobs:
     - name: Wait for crates.io to index the toolkit servers
       run: sleep 30
 
-    # --- v2.3 Excel-as-Configuration workbook crates (first published here) ---
-    # pmcp-workbook-dialect + pmcp-workbook-runtime are leaves (the runtime carries
-    # rust_xlsxwriter; the reader umya stays confined to the compiler). The compiler
-    # depends on both + pmcp-server-toolkit[workbook] (a dev-dependency only — the
-    # purity boundary keeps umya out of the served tree). pmcp-workbook-server
-    # depends on the toolkit[workbook,http]. cargo-pmcp (below) depends on the
-    # compiler, so all four must publish before it.
-    - name: Publish pmcp-workbook-dialect
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: |
-        echo "Publishing pmcp-workbook-dialect..."
-        OUTPUT=$(cargo publish -p pmcp-workbook-dialect 2>&1) && echo "$OUTPUT" || {
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "already exists"; then
-            echo "pmcp-workbook-dialect already published, continuing..."
-          else
-            echo "::error::Failed to publish pmcp-workbook-dialect"
-            exit 1
-          fi
-        }
-
-    - name: Publish pmcp-workbook-runtime
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: |
-        echo "Publishing pmcp-workbook-runtime..."
-        OUTPUT=$(cargo publish -p pmcp-workbook-runtime 2>&1) && echo "$OUTPUT" || {
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "already exists"; then
-            echo "pmcp-workbook-runtime already published, continuing..."
-          else
-            echo "::error::Failed to publish pmcp-workbook-runtime"
-            exit 1
-          fi
-        }
-
-    - name: Wait for crates.io to index the workbook leaves
-      run: sleep 30
-
+    # --- v2.3 workbook compiler + server (after the toolkit they depend on) ---
+    # pmcp-workbook-dialect + pmcp-workbook-runtime were published earlier (BEFORE
+    # pmcp-server-toolkit, which optionally depends on the runtime). The compiler
+    # depends on dialect + runtime + pmcp-server-toolkit[workbook] (a dev-dependency);
+    # pmcp-workbook-server depends on the toolkit[workbook,http]. cargo-pmcp (below)
+    # depends on the compiler, so both must publish before it.
     - name: Publish pmcp-workbook-compiler
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The v2.9.2 release run failed at `Publish pmcp-server-toolkit` with `failed to prepare local package for uploading` — `pmcp-server-toolkit` has an **optional** dep on `pmcp-workbook-runtime`, and crates.io rejects a publish whose deps (even optional) aren't on the index yet. The workbook crates were ordered *after* the toolkit, so nothing new published (verified: all versions unchanged on crates.io).

This moves `pmcp-workbook-dialect` + `pmcp-workbook-runtime` (leaves) to publish **before** `pmcp-server-toolkit`; `pmcp-workbook-compiler` + `pmcp-workbook-server` stay after (they depend on the toolkit). YAML validated; idempotent steps unchanged.

After merge: re-point the `v2.9.2` tag (nothing published, so reuse is clean) and re-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)