### PR TITLE
fix(release): publish pmcp-workbook-runtime before -dialect

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,22 +212,9 @@ jobs:
     # already on crates.io, so it does not gate this tier.)
     # --- v2.3 workbook leaves — MUST precede pmcp-server-toolkit, which has an
     # OPTIONAL dependency on pmcp-workbook-runtime; crates.io rejects a publish whose
-    # dependencies (even optional) are not yet on the index. Both are leaves.
-    - name: Publish pmcp-workbook-dialect
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: |
-        echo "Publishing pmcp-workbook-dialect..."
-        OUTPUT=$(cargo publish -p pmcp-workbook-dialect 2>&1) && echo "$OUTPUT" || {
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q "already exists"; then
-            echo "pmcp-workbook-dialect already published, continuing..."
-          else
-            echo "::error::Failed to publish pmcp-workbook-dialect"
-            exit 1
-          fi
-        }
-
+    # dependencies (even optional) are not yet on the index.
+    # Internal order matters: pmcp-workbook-runtime is the only true leaf;
+    # pmcp-workbook-dialect depends on it, so runtime must publish AND index first.
     - name: Publish pmcp-workbook-runtime
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -239,6 +226,24 @@ jobs:
             echo "pmcp-workbook-runtime already published, continuing..."
           else
             echo "::error::Failed to publish pmcp-workbook-runtime"
+            exit 1
+          fi
+        }
+
+    - name: Wait for crates.io to index pmcp-workbook-runtime
+      run: sleep 30
+
+    - name: Publish pmcp-workbook-dialect
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-workbook-dialect..."
+        OUTPUT=$(cargo publish -p pmcp-workbook-dialect 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-workbook-dialect already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-workbook-dialect"
             exit 1
           fi
         }


### PR DESCRIPTION
## Problem

The `v2.9.2` release (run 27908614790) failed at **Publish pmcp-workbook-dialect**:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `pmcp-workbook-runtime` found
  required by package `pmcp-workbook-dialect`
```

PR #282 moved the workbook leaves ahead of `pmcp-server-toolkit` (correct, since the toolkit optionally depends on runtime) — but it ordered them **dialect → runtime**. That's inverted: `pmcp-workbook-dialect` *depends on* `pmcp-workbook-runtime`, so runtime is the only true leaf and must publish + index first.

## Fix

Swap the two steps (runtime first) and add a 30s index wait between them.

Final workbook publish order:
`runtime → dialect → server-toolkit → … → compiler → server → cargo-pmcp`

Nothing has published to crates.io yet across the two failed runs, so re-tagging `v2.9.2` after merge is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)