### PR TITLE
feat(tasks): correct-by-construction tools-as-Tasks server DX (pmcp 2.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-06-21
+
+### Added — Tools-as-Tasks server DX (correct-by-construction task lifecycle)
+
+Make a server that exposes a tool as an MCP **Task** (async, pollable)
+correct-by-construction: the entire `tasks/*` wire surface is served from the
+SDK's typed structs, eliminating the class of silent shape-mismatch bugs that
+came from hand-writing the protocol. Extends the existing `TaskStore` path with
+no breaking changes.
+
+- `tasks/result` is now served typed (`CallToolResult`) from the configured
+  `TaskStore`, with `TaskRouter` fall-through for the legacy path. A tool-created
+  task is now actually pollable: the store mints the task id and it is written to
+  both the wire `task.taskId` and the `_meta` related-task link.
+- New additive `TaskStore` methods — `set_result` / `get_result` /
+  `supports_results` — all with default impls (existing stores keep compiling);
+  a not-yet-completed `tasks/result` returns a specified error.
+- Registering a `TaskStore` (or a `with_task_support` tool) now auto-advertises
+  the server-level `tasks` capability; a `TaskSupport::Required` tool with no
+  backing store/router makes `build()` return an error instead of advertising a
+  hollow capability.
+- The client emits a `WARN` (method + transport identity + serde error) on any
+  `tasks/*` deserialize failure instead of silently folding it into the result.
+- New feature-gated `pmcp::testing` module with
+  `assert_roundtrips_through_client`, a conformance helper that feeds real server
+  dispatch output through the client deserialization types (`testing` is folded
+  into `full`, omitted from `default`).
+- New worked example `s45_tool_as_task_lifecycle` and a live in-process
+  round-trip acceptance test driving `initialize → call(task) → tasks/get →
+  tasks/result`.
+- Docs: the book/course/design task chapters and rustdoc now lead with the
+  recommended `task_store` + `with_task_support` pattern; the hand-rolled
+  `TaskRouter` / hand-written task JSON path is reframed as legacy.
+
+Note: task dispatch + `TaskStore` currently live on `ServerCoreBuilder` /
+`ServerCore`; the high-level `pmcp::Server` (and `StreamableHttpServer`) does not
+yet carry a `TaskStore` (tracked as a follow-up).
+
 ## [2.9.2] - 2026-06-20
 
 Excel-as-Configuration workbook servers: the table-based authoring contract, and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"
@@ -150,7 +150,7 @@ pmcp-code-mode-derive = { version = "0.2.0", path = "crates/pmcp-code-mode-deriv
 
 [features]
 default = ["logging"]
-full = ["websocket", "http", "streamable-http", "sse", "validation", "resource-watcher", "rayon", "schema-generation", "jwt-auth", "composition", "mcp-apps", "http-client", "logging", "macros"]
+full = ["websocket", "http", "streamable-http", "sse", "validation", "resource-watcher", "rayon", "schema-generation", "jwt-auth", "composition", "mcp-apps", "http-client", "logging", "macros", "testing"]
 composition = ["streamable-http"]
 # MCP Apps Extension - Interactive UI support for ChatGPT Apps, MCP-UI, and standard MCP hosts
 mcp-apps = []
@@ -187,6 +187,10 @@ rayon = ["dep:rayon"]
 
 # Testing support
 test-helpers = []
+# Conformance helpers (pmcp::testing) — folded into `full` so the quality gate
+# compiles the module AND runs the tasks-lifecycle integration test. NOT in
+# `default`, so lean release builds omit it.
+testing = []
 
 [[bench]]
 name = "simple_test"
@@ -533,6 +537,11 @@ required-features = ["skills", "full"]
 name = "c10_client_skills"
 path = "examples/c10_client_skills.rs"
 required-features = ["skills", "full"]
+
+[[example]]
+name = "s45_tool_as_task_lifecycle"
+path = "examples/s45_tool_as_task_lifecycle.rs"
+required-features = ["full"]
 
 [[bench]]
 name = "comprehensive_benchmarks"

--- a/docs/TASKS_WITH_POLLING.md
+++ b/docs/TASKS_WITH_POLLING.md
@@ -4,33 +4,74 @@ MCP Tasks let servers manage long-running operations that outlive a single reque
 
 In v2.0, task detection is **requestor-driven**: the SDK returns `CreateTaskResult` only when the client sends a `task` field in the `tools/call` request. Without it, the tool result is wrapped as a normal `CallToolResult`. This is capability-based negotiation, not client sniffing.
 
-## Quick Start
+## Recommended Server Setup
+
+Register a task-capable tool (`with_task_support`) and back it with a `TaskStore` via `task_store(...)`. The SDK serves `tasks/get | result | list | cancel` typed from your store — **you never hand-write `tasks/*` wire JSON**, and the `tasks` capability is auto-advertised because a store backs it.
 
 ```rust
 use pmcp::server::builder::ServerCoreBuilder;
+use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+use pmcp::server::typed_tool::TypedTool;
 use pmcp::types::{ToolExecution, TaskSupport};
-use pmcp_tasks::{InMemoryTaskStore, TaskRouterImpl, TaskSecurityConfig};
+use serde_json::json;
 use std::sync::Arc;
 
-let store = Arc::new(
-    InMemoryTaskStore::new()
-        .with_security(TaskSecurityConfig::default().with_allow_anonymous(true)),
-);
-let router = Arc::new(TaskRouterImpl::new(store.clone()));
+let task_tool = TypedTool::new_with_schema(
+    "long_analysis",
+    json!({ "type": "object" }),
+    |_args, _extra| Box::pin(async { Ok(json!({ "content": [] })) }),
+)
+.with_description("Run a long analysis as an MCP Task")
+.with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+
+let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
 
 let server = ServerCoreBuilder::new()
     .name("my-server")
     .version("1.0.0")
-    .with_task_store(router)
-    // ... register tools with .with_execution() ...
+    .tool("long_analysis", task_tool)
+    .task_store(store)   // presence of a store auto-advertises the `tasks` capability
     .build()?;
 ```
 
 The builder:
-- Sets `ServerCapabilities.tasks` automatically (list, cancel, tools/call)
-- Dispatches `tasks/get`, `tasks/list`, `tasks/cancel` through your store
+- Sets the standard top-level `ServerCapabilities.tasks` automatically (list, cancel, tools/call) **because a store backs the endpoints** — a `TaskSupport::Required` tool with **no** store makes `build()` return `Err` (no hollow capability)
+- Dispatches `tasks/get`, `tasks/list`, `tasks/cancel`, and `tasks/result` through your store, serialized from typed structs
 - Resolves task owners from auth context for multi-tenant isolation
-- Returns `CreateTaskResult` or `CallToolResult` based on the client's request
+- Mints the task id in the store and returns it to the client; returns `CreateTaskResult` or `CallToolResult` based on the client's request
+
+> **Scope caveat (current SDK):** the `TaskStore` path lives on `ServerCoreBuilder` / `ServerCore`. The high-level `pmcp::Server` (and `StreamableHttpServer`) does not yet carry a `TaskStore`. For a complete runnable round-trip, see [`examples/s45_tool_as_task_lifecycle.rs`](../examples/s45_tool_as_task_lifecycle.rs).
+
+> **Legacy path:** `with_task_store(Arc<dyn TaskRouter>)` (wrapping a store in `pmcp_tasks::TaskRouterImpl`) is the older experimental wiring; it advertises under `experimental.tasks` and expects hand-emitted `task` JSON. Prefer `task_store(...)` + `with_task_support` for new code.
+
+## Recommended Client Walkthrough
+
+The typed client never touches `tasks/*` JSON either:
+
+```rust
+use pmcp::ToolCallResponse;
+
+// 1) Call the tool as a task — receive the STORE-MINTED id.
+let task_id = match client
+    .call_tool_with_task("long_analysis".to_string(), serde_json::json!({}))
+    .await?
+{
+    ToolCallResponse::Task(task) => task.task_id,
+    ToolCallResponse::Result(_) => unreachable!("Required task tool always creates a task"),
+};
+
+// 2) Poll the typed `Task` until it reaches a terminal status.
+let mut task = client.tasks_get(&task_id).await?;
+while !task.status.is_terminal() {
+    tokio::time::sleep(std::time::Duration::from_millis(task.poll_interval.unwrap_or(2000))).await;
+    task = client.tasks_get(&task_id).await?;
+}
+
+// 3) Fetch the typed terminal `CallToolResult`.
+let result = client.tasks_result(&task_id).await?;
+```
+
+`client.tasks_list(cursor)` and `client.tasks_cancel(&task_id)` complete the typed client surface.
 
 ## Declaring Task Support on Tools
 

--- a/docs/design/tasks-feature-design.md
+++ b/docs/design/tasks-feature-design.md
@@ -1151,6 +1151,35 @@ impl DynamoDbTaskStore {
 
 ## 8. Integration with Existing SDK
 
+> **Current recommended pattern (Phase 101) — shipped API.** The integration sketched in this section has since landed in a cleaner, *typed, correct-by-construction* form. You declare task support on a tool and register a `TaskStore`; the SDK mints the task id, auto-advertises the capability, and serves every `tasks/*` response from typed structs — **no hand-written `tasks/*` wire JSON**:
+>
+> ```rust,ignore
+> use std::sync::Arc;
+> use pmcp::server::builder::ServerCoreBuilder;
+> use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+> use pmcp::server::typed_tool::TypedTool;
+> use pmcp::types::{ToolExecution, TaskSupport};
+>
+> let task_tool = TypedTool::new_with_schema("summarize", schema, handler)
+>     .with_description("Summarize asynchronously as an MCP Task")
+>     .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+>
+> let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+> let server = ServerCoreBuilder::new()
+>     .name("my-server").version("1.0.0")
+>     .tool("summarize", task_tool)
+>     .task_store(store)        // presence of a store auto-advertises the `tasks` capability
+>     .build()?;
+> ```
+>
+> Client side: `client.call_tool_with_task(name, args).await?` → `ToolCallResponse::Task(task)` with the store-minted `task.task_id`; poll typed `client.tasks_get(&id).await?` until `task.status.is_terminal()`; then `client.tasks_result(&id).await?` for the typed terminal `CallToolResult`.
+>
+> Notes vs. the design sketch below:
+> - The capability now ships as a **dedicated top-level `ServerCapabilities.tasks` field** (not `experimental.tasks`) when registered via `task_store(...)` — the "Future (post-stabilization)" path in §8.1 is the shipped path. (`with_task_store(Arc<dyn TaskRouter>)` remains the legacy experimental wiring and still advertises under `experimental.tasks`.)
+> - A `TaskSupport::Required` tool with **no** `TaskStore`/`TaskRouter` is a build-time error (`build()` → `Err`) rather than a hollow capability.
+> - **Scope caveat:** the `TaskStore` path lives on `ServerCoreBuilder` / `ServerCore`; the high-level `pmcp::Server` (and `StreamableHttpServer`) does not yet carry a `TaskStore`.
+> - Reference example: [`examples/s45_tool_as_task_lifecycle.rs`](../../examples/s45_tool_as_task_lifecycle.rs).
+
 ### 8.1 Capability Negotiation
 
 Tasks capabilities must be added to `ServerCapabilities` and `ClientCapabilities`.
@@ -1360,6 +1389,8 @@ impl Default for TaskSecurityConfig {
 ---
 
 ## 10. Examples
+
+> **Shipped reference example (Phase 101):** the canonical, runnable end-to-end round-trip is [`examples/s45_tool_as_task_lifecycle.rs`](../../examples/s45_tool_as_task_lifecycle.rs). It registers a `with_task_support` tool plus an `InMemoryTaskStore`, then drives a live `pmcp::Client` through `initialize → call_tool_with_task → tasks_get` (poll) `→ tasks_result` — all typed, no hand-written `tasks/*` JSON. Prefer it over the sketched examples below as the source of truth for the current API. The numbered examples below remain the original design sketch.
 
 ### Example 60: Basic Task-Augmented Tool Call
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -260,6 +260,21 @@ don't yet speak SEP-2640 — the two surfaces are byte-equal by construction.
 cargo run --example s44_server_skills --features skills,full
 ```
 
+### MCP Tasks
+
+**s45_tool_as_task_lifecycle** — THE canonical tools-as-Tasks example: the
+recommended, all-typed pattern for exposing a tool as an async MCP Task. Register
+a `with_task_support(TaskSupport::Required)` tool plus an `InMemoryTaskStore` on
+`ServerCoreBuilder` (the store auto-advertises the `tasks` capability and mints
+the task id) — you never hand-write any `tasks/*` wire JSON. Drives the full path
+through a LIVE in-process client round-trip (`initialize → call(task) → tasks/get
+poll → tasks/result`), proving the four original tools-as-tasks wire-shape bugs
+are impossible on the SDK path: store-minted id consistency, auto-advertised
+`tasks` capability, typed `tasks/get`, and a typed non-empty `tasks/result`.
+```bash
+cargo run --example s45_tool_as_task_lifecycle --features full
+```
+
 ---
 
 ## Client Examples

--- a/examples/s45_tool_as_task_lifecycle.rs
+++ b/examples/s45_tool_as_task_lifecycle.rs
@@ -1,0 +1,228 @@
+//! # Server example: Tool-as-Task lifecycle (Phase 101)
+//!
+//! This is the RECOMMENDED pattern for exposing a tool as an async MCP Task:
+//! register a `with_task_support(TaskSupport::Required)` tool plus a `TaskStore`
+//! on `ServerCoreBuilder` and let the SDK serve `tasks/*` typed — no hand-written
+//! `tasks/*` wire JSON.
+//!
+//! Demonstrates the all-typed MCP Tasks path end-to-end through a LIVE
+//! in-process client round-trip. It registers a `with_task_support` tool plus
+//! an `InMemoryTaskStore`, then drives the real `pmcp::Client` through:
+//!
+//! ```text
+//! initialize -> call(tool with task) -> tasks/get (poll) -> tasks/result
+//! ```
+//!
+//! It proves all four original wire-shape bugs from the tools-as-tasks incident
+//! are impossible on the SDK path:
+//!
+//! 1. **id consistency** — the `CreateTaskResult.task.taskId` returned to the
+//!    client is the store-minted id, and `tasks/get` polls that same id (not a
+//!    404 on a tool-fabricated id).
+//! 2. **advertised capability** — `initialize` shows the server auto-advertised
+//!    the `tasks` capability (endpoint-backed).
+//! 3. **typed `tasks/get`** — the polled status deserializes into the typed
+//!    `Task` via the client.
+//! 4. **typed `tasks/result`** — the terminal result deserializes into a typed,
+//!    non-empty `CallToolResult`.
+//!
+//! The high-level `pmcp::Server` (and `StreamableHttpServer`) does not carry a
+//! `TaskStore`; the task path lives on `ServerCore`. So this example pairs a
+//! real `pmcp::Client` with a `ServerCore` over an in-process duplex transport
+//! — the equivalent of an HTTP loopback for the task-bearing dispatch path.
+//!
+//! Run with: `cargo run --example s45_tool_as_task_lifecycle --features full`
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use pmcp::server::builder::ServerCoreBuilder;
+use pmcp::server::core::ProtocolHandler;
+use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+use pmcp::server::typed_tool::TypedTool;
+use pmcp::shared::{Transport, TransportMessage};
+use pmcp::types::{ClientCapabilities, TaskSupport, ToolExecution};
+use pmcp::{Client, Error, ToolCallResponse};
+use tokio::sync::mpsc;
+
+/// One half of an in-process duplex transport (client <-> server).
+#[derive(Debug)]
+struct DuplexTransport {
+    tx: mpsc::UnboundedSender<TransportMessage>,
+    rx: mpsc::UnboundedReceiver<TransportMessage>,
+    connected: bool,
+}
+
+impl DuplexTransport {
+    fn pair() -> (Self, Self) {
+        let (client_tx, server_rx) = mpsc::unbounded_channel();
+        let (server_tx, client_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                tx: client_tx,
+                rx: client_rx,
+                connected: true,
+            },
+            Self {
+                tx: server_tx,
+                rx: server_rx,
+                connected: true,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl Transport for DuplexTransport {
+    async fn send(&mut self, message: TransportMessage) -> pmcp::Result<()> {
+        self.tx
+            .send(message)
+            .map_err(|_| Error::internal("duplex peer dropped"))
+    }
+
+    async fn receive(&mut self) -> pmcp::Result<TransportMessage> {
+        self.rx
+            .recv()
+            .await
+            .ok_or_else(|| Error::internal("duplex peer closed"))
+    }
+
+    async fn close(&mut self) -> pmcp::Result<()> {
+        self.connected = false;
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    fn transport_type(&self) -> &'static str {
+        "in-process-duplex"
+    }
+}
+
+/// Serve `handler` over the server side of a duplex transport until the client
+/// half is dropped.
+fn spawn_server_pump(mut server_transport: DuplexTransport, handler: Arc<dyn ProtocolHandler>) {
+    tokio::spawn(async move {
+        while let Ok(message) = server_transport.receive().await {
+            if let TransportMessage::Request { id, request } = message {
+                let response = handler.handle_request(id, request, None).await;
+                if server_transport
+                    .send(TransportMessage::Response(response))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[tokio::main]
+async fn main() -> pmcp::Result<()> {
+    // A `with_task_support` tool that completes synchronously: it returns a
+    // Task-shaped value carrying a nested `result` (the terminal CallToolResult),
+    // so plan 01's create path records create + set_result + Completed before
+    // returning. `tasks/get` then sees Completed and `tasks/result` serves the
+    // non-empty content.
+    let task_tool = TypedTool::new_with_schema(
+        "summarize",
+        serde_json::json!({ "type": "object" }),
+        |_args: serde_json::Value, _extra| {
+            Box::pin(async {
+                Ok(serde_json::json!({
+                    "taskId": "tool-fabricated",
+                    "status": "completed",
+                    "ttl": 60000,
+                    "createdAt": "2026-06-21T00:00:00Z",
+                    "lastUpdatedAt": "2026-06-21T00:00:00Z",
+                    "result": {
+                        "content": [
+                            { "type": "text", "text": "summary: 3 items processed" }
+                        ]
+                    }
+                }))
+            })
+        },
+    )
+    .with_description("Summarize asynchronously as an MCP Task")
+    .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+
+    let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+    let server: Arc<dyn ProtocolHandler> = Arc::new(
+        ServerCoreBuilder::new()
+            .name("tool-as-task-example")
+            .version("1.0.0")
+            .tool("summarize", task_tool)
+            .task_store(store)
+            .build()?,
+    );
+
+    let (client_transport, server_transport) = DuplexTransport::pair();
+    spawn_server_pump(server_transport, server);
+    let mut client = Client::new(client_transport);
+
+    // 1) initialize — the server auto-advertised the `tasks` capability.
+    let init = client.initialize(ClientCapabilities::default()).await?;
+    println!(
+        "initialize: tasks capability advertised = {}",
+        init.capabilities.tasks.is_some()
+    );
+    assert!(
+        init.capabilities.tasks.is_some(),
+        "server must auto-advertise the tasks capability"
+    );
+
+    // 2) call(tool with task) -> CreateTaskResult with the store-minted id.
+    let task_id = match client
+        .call_tool_with_task("summarize".to_string(), serde_json::json!({}))
+        .await?
+    {
+        ToolCallResponse::Task(task) => {
+            println!("created task (store-minted id): {}", task.task_id);
+            task.task_id
+        },
+        ToolCallResponse::Result(_) => {
+            return Err(Error::internal(
+                "expected a created task, got a sync result",
+            ))
+        },
+    };
+
+    // 3) poll tasks/get until terminal — typed Task each iteration.
+    let mut task = client.tasks_get(&task_id).await?;
+    let mut polls = 0;
+    while !task.status.is_terminal() && polls < 50 {
+        println!("  poll {polls}: status = {}", task.status);
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        task = client.tasks_get(&task_id).await?;
+        polls += 1;
+    }
+    println!(
+        "  terminal status = {} (polled id = {})",
+        task.status, task.task_id
+    );
+    assert_eq!(
+        task.task_id, task_id,
+        "polled id must equal the store-minted id"
+    );
+    assert!(
+        task.status.is_terminal(),
+        "task must reach a terminal status"
+    );
+
+    // 4) tasks/result -> typed, non-empty CallToolResult.
+    let result = client.tasks_result(&task_id).await?;
+    assert!(
+        !result.content.is_empty(),
+        "tasks/result must carry the persisted terminal content"
+    );
+    println!("tasks/result content items: {}", result.content.len());
+    println!("tool-as-task lifecycle OK — all four wire shapes verified through the live client");
+
+    Ok(())
+}

--- a/pmcp-book/src/ch12-7-tasks.md
+++ b/pmcp-book/src/ch12-7-tasks.md
@@ -2,7 +2,86 @@
 
 When a tool takes five seconds, request/response is fine. When it takes five minutes -- deploying infrastructure, processing a large dataset, running a multi-step pipeline -- the caller needs more than silence followed by a result. MCP Tasks solve this with a stateless polling model that works everywhere from local development to serverless Lambda functions.
 
-This chapter covers the design rationale, the protocol flow, and how to integrate tasks into your PMCP server using the `pmcp-tasks` crate.
+This chapter covers the design rationale, the protocol flow, and how to integrate tasks into your PMCP server.
+
+> **Read this first.** PMCP ships a *typed, correct-by-construction* task path: you register a task-capable tool plus a `TaskStore`, and the SDK serves `tasks/get | result | list | cancel` for you from typed structs. **You never hand-write `tasks/*` wire JSON.** Start with the [Recommended Pattern](#recommended-pattern-tools-as-tasks) below. The hand-rolled `pmcp-tasks` / `TaskRouter` approach shown later in this chapter is the **legacy experimental path** — kept for reference, but not what you should reach for in new code.
+
+---
+
+## Recommended Pattern: Tools as Tasks
+
+The clean way to expose a long-running tool as an async MCP **Task** is to declare task support on the tool and back it with a `TaskStore`. The SDK does the rest — it mints the task id, advertises the `tasks` capability, and serializes every `tasks/*` response from typed structs (`GetTaskResult`, `CreateTaskResult`, `CallToolResult`). Because both server and client speak the same typed shapes, an entire class of silent wire-shape bugs (mismatched ids, hollow capabilities, malformed `tasks/result` payloads) becomes impossible.
+
+### Server
+
+The task path lives on `ServerCoreBuilder` / `ServerCore`:
+
+```rust,ignore
+use std::sync::Arc;
+use pmcp::server::builder::ServerCoreBuilder;
+use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+use pmcp::server::typed_tool::TypedTool;
+use pmcp::types::{TaskSupport, ToolExecution};
+use serde_json::json;
+
+let schema = json!({ "type": "object" });
+
+let task_tool = TypedTool::new_with_schema("summarize", schema, |_args, _extra| {
+    Box::pin(async {
+        // ... do the work, return a CallToolResult-shaped value ...
+        Ok(json!({ "content": [{ "type": "text", "text": "done" }] }))
+    })
+})
+.with_description("Summarize asynchronously as an MCP Task")
+.with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+
+let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+
+let server = ServerCoreBuilder::new()
+    .name("my-server")
+    .version("1.0.0")
+    .tool("summarize", task_tool)
+    .task_store(store)   // presence of a store auto-advertises the `tasks` capability
+    .build()?;
+```
+
+Four things the SDK guarantees here:
+
+1. **You never hand-write `tasks/*` JSON.** The SDK serializes every response from typed structs, so server and client agree by construction.
+2. **`task_store(...)` auto-advertises the `tasks` capability.** A `TaskSupport::Required` tool with **no** store (or router) makes `build()` return an `Err` — no hollow capability that advertises endpoints which cannot work.
+3. **The store mints the task id.** The id returned to the client is the store-minted id, and it is exactly the id the client polls.
+4. **`tasks/result` is served typed from the store** (with `TaskRouter` fall-through for the legacy path).
+
+### Client
+
+```rust,ignore
+use pmcp::ToolCallResponse;
+
+// 1) Call the tool as a task — get back the store-minted id.
+let task_id = match client
+    .call_tool_with_task("summarize".to_string(), serde_json::json!({}))
+    .await?
+{
+    ToolCallResponse::Task(task) => task.task_id,
+    ToolCallResponse::Result(_) => unreachable!("Required task tool always creates a task"),
+};
+
+// 2) Poll the typed `Task` until it reaches a terminal status.
+let mut task = client.tasks_get(&task_id).await?;
+while !task.status.is_terminal() {
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    task = client.tasks_get(&task_id).await?;
+}
+
+// 3) Fetch the typed terminal `CallToolResult`.
+let result = client.tasks_result(&task_id).await?;
+```
+
+`client.tasks_list(cursor)` and `client.tasks_cancel(&task_id)` round out the typed client surface.
+
+> **Scope caveat (current SDK).** Task dispatch and the `TaskStore` live on `ServerCoreBuilder` / `ServerCore`. The high-level `pmcp::Server` (and `StreamableHttpServer`) does **not** yet carry a `TaskStore` — wire the task path through `ServerCore` for now. For a complete, runnable end-to-end round-trip (initialize → call-with-task → poll → result), see the reference example [`examples/s45_tool_as_task_lifecycle.rs`](https://github.com/paiml/rust-mcp-sdk/blob/main/examples/s45_tool_as_task_lifecycle.rs).
+
+The rest of this chapter explains *why* the polling model exists, the task state machine, and the legacy `pmcp-tasks` path you may still encounter in older code.
 
 ---
 
@@ -111,7 +190,9 @@ The client can also list all its tasks with `tasks/list` and cancel an in-progre
 
 ---
 
-## Setting Up TaskStore
+## Legacy: Setting Up TaskStore via `pmcp-tasks`
+
+> **Legacy / experimental path.** The sections from here through "Writing Dual-Path Tool Handlers" describe the older `pmcp-tasks` + `TaskRouter` approach, where you hand-construct the store, wire it with `with_task_store(...)`, and emit `task` JSON by hand inside the handler. New code should prefer the [Recommended Pattern](#recommended-pattern-tools-as-tasks) above (`task_store(...)` + `with_task_support`), which removes the hand-rolled JSON entirely. The material below is retained because you may encounter it in existing servers and because the production backends (DynamoDB, Redis) documented here are still the way to persist tasks.
 
 Tasks need persistent storage. The `pmcp-tasks` crate provides the `TaskStore` trait and two ready-made backends:
 
@@ -168,7 +249,9 @@ let store = Arc::new(
 
 All domain logic -- state machine validation, owner isolation, variable merge, TTL enforcement -- lives in `GenericTaskStore`. The backend is a dumb key-value store. This means switching from in-memory to DynamoDB requires zero changes to your tool handlers.
 
-### Wiring the Store to the Server
+### Wiring the Store to the Server (legacy `with_task_store`)
+
+> The `with_task_store(Arc<dyn TaskRouter>)` builder method shown here is the **legacy experimental** wiring. It advertises under `experimental.tasks` and expects you to emit `task` JSON by hand. The recommended path is `task_store(Arc<dyn TaskStore>)` (see the [Recommended Pattern](#recommended-pattern-tools-as-tasks)), which advertises the standard top-level `tasks` capability and serves every `tasks/*` response typed.
 
 The `pmcp-tasks` crate ships a `TaskRouterImpl` that bridges any `TaskStore` to the `TaskRouter` trait the SDK consumes. Wrap the store in `TaskRouterImpl`, then register it with `ServerCoreBuilder::with_task_store(...)`:
 
@@ -360,19 +443,17 @@ This principle applies beyond tasks. It is the same pattern used for progress to
 
 ### Server Capability Advertisement
 
-The server side of negotiation happens during initialization. When you call `.with_task_store(router)` on the builder, PMCP automatically advertises task support under `experimental.tasks`:
+The server side of negotiation happens during initialization. With the recommended `task_store(...)` path, PMCP advertises task support under the **standard top-level `tasks` capability** (`ServerCapabilities.tasks`) as soon as a store backs the endpoints — you do not set it manually:
 
 ```json
 {
   "capabilities": {
-    "experimental": {
-      "tasks": {
-        "list": {},
-        "cancel": {},
-        "requests": {
-          "tools": {
-            "call": {}
-          }
+    "tasks": {
+      "list": {},
+      "cancel": {},
+      "requests": {
+        "tools": {
+          "call": {}
         }
       }
     }
@@ -381,6 +462,8 @@ The server side of negotiation happens during initialization. When you call `.wi
 ```
 
 This tells clients: "I support tasks for `tools/call`, and I support `tasks/list` and `tasks/cancel`." Clients that understand tasks will include the `task` field when calling tools that advertise `TaskSupport::Optional` or `TaskSupport::Required`.
+
+The advertisement follows the backend, not tool metadata alone: it appears only when a store (or, on the legacy path, a router) is present. A tool declaring `TaskSupport::Required` with **no** backend is a build-time error rather than a hollow capability — `build()` returns an `Err`. (The legacy `with_task_store(router)` path instead advertises under `experimental.tasks`.)
 
 ---
 
@@ -587,6 +670,7 @@ MCP Tasks extend the request/response model with durable, pollable operations th
 
 **Key concepts:**
 
+- **Recommended pattern:** declare `with_task_support` on the tool and register a `TaskStore` with `task_store(...)`. The SDK mints the id, auto-advertises the `tasks` capability, and serves every `tasks/*` response typed — you never hand-write `tasks/*` wire JSON. See [`examples/s45_tool_as_task_lifecycle.rs`](https://github.com/paiml/rust-mcp-sdk/blob/main/examples/s45_tool_as_task_lifecycle.rs).
 - **Two-phase flow:** `tools/call` returns a task, `tasks/get` polls status, `tasks/result` retrieves the outcome.
 - **Stateless negotiation:** The `task` field in each request is the capability signal. No session state required.
 - **Dual-path handlers:** `extra.is_task_request()` lets the same tool handler serve both task-aware and non-task-aware clients.

--- a/pmcp-course/src/part8-advanced/ch21-01-lifecycle.md
+++ b/pmcp-course/src/part8-advanced/ch21-01-lifecycle.md
@@ -14,24 +14,26 @@ By the end of this section, you will be able to:
 
 ## Setting Up TaskStore in the Server Builder
 
-The builder's `.task_store()` method does two things: it stores the backend and it auto-configures the server's capabilities so clients can discover task support during initialization.
+The builder's `.task_store()` method does two things: it records the backend, and it makes the server **auto-advertise** the `tasks` capability so clients can discover task support during initialization. The capability follows the backend — you never set it by hand. (We will see in [Capability Negotiation](./ch21-02-capability-negotiation.md) that a `TaskSupport::Required` tool with *no* store is a build-time error, precisely so the advertised capability is never hollow.)
+
+> **Which builder?** The task path lives on `ServerCoreBuilder` (the lower-level core builder), and `.task_store()` is a method on it. The high-level `Server::builder()` (and `StreamableHttpServer`) does **not** yet carry a `TaskStore`, so wire the task path through `ServerCoreBuilder` / `ServerCore` for now. The runnable reference is [`examples/s45_tool_as_task_lifecycle.rs`](https://github.com/paiml/rust-mcp-sdk/blob/main/examples/s45_tool_as_task_lifecycle.rs).
 
 ```rust
-use pmcp::prelude::*;
-use pmcp::server::task_store::InMemoryTaskStore;
+use pmcp::server::builder::ServerCoreBuilder;
+use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
 use std::sync::Arc;
 
-let store = Arc::new(InMemoryTaskStore::new());
+let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
 
-let server = Server::builder()
+let server = ServerCoreBuilder::new()
     .name("satellite-analysis")
     .version("1.0.0")
     .task_store(store.clone())
-    // ... register tools ...
+    // ... register a task tool with .with_task_support(...) ...
     .build()?;
 ```
 
-After calling `.task_store()`, the server advertises these capabilities during `initialize`:
+After calling `.task_store()`, the server advertises these capabilities during `initialize` (the standard top-level `tasks` capability):
 
 ```json
 {
@@ -95,7 +97,53 @@ The `execution` field appears in the `tools/list` response:
 }
 ```
 
-## Writing a Dual-Path Tool Handler
+## Recommended Pattern: Let the SDK Own the Wire Protocol
+
+The cleanest way to expose a tool as a Task is to declare `with_task_support` and register a `TaskStore` — then **let the SDK mint the task id, advertise the capability, and serialize every `tasks/*` response from typed structs.** Your handler does *not* hand-write `tasks/*` JSON, does *not* mint ids, and does *not* construct a `CreateTaskResult`. It just registers the tool:
+
+```rust
+use pmcp::server::typed_tool::TypedTool;
+use pmcp::types::{ToolExecution, TaskSupport};
+use serde_json::json;
+
+let task_tool = TypedTool::new_with_schema(
+    "analyze_imagery",
+    json!({ "type": "object", "properties": { "image_uri": { "type": "string" } } }),
+    |_args, _extra| Box::pin(async {
+        // Do the work; return a CallToolResult-shaped value.
+        Ok(json!({ "content": [{ "type": "text", "text": "terrain classified" }] }))
+    }),
+)
+.with_description("Analyze satellite imagery for terrain classification")
+.with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+```
+
+Register that tool plus a `task_store(...)` on `ServerCoreBuilder` (as shown above) and the SDK serves `tasks/get | result | list | cancel` for you. On the client, the round-trip is fully typed:
+
+```rust
+use pmcp::ToolCallResponse;
+
+let task_id = match client
+    .call_tool_with_task("analyze_imagery".to_string(), serde_json::json!({ "image_uri": "s3://..." }))
+    .await?
+{
+    ToolCallResponse::Task(task) => task.task_id, // store-minted id
+    ToolCallResponse::Result(_) => unreachable!("Required task tool always creates a task"),
+};
+
+let mut task = client.tasks_get(&task_id).await?;
+while !task.status.is_terminal() {
+    tokio::time::sleep(std::time::Duration::from_millis(task.poll_interval.unwrap_or(2000))).await;
+    task = client.tasks_get(&task_id).await?;
+}
+let result = client.tasks_result(&task_id).await?; // typed CallToolResult
+```
+
+This is the pattern to reach for. **You never assemble `tasks/*` wire JSON by hand**, so the server and client agree by construction — eliminating an entire class of silent wire-shape bugs (mismatched ids, malformed `tasks/result` payloads). The runnable end-to-end version is [`examples/s45_tool_as_task_lifecycle.rs`](https://github.com/paiml/rust-mcp-sdk/blob/main/examples/s45_tool_as_task_lifecycle.rs).
+
+## Advanced: Hand-Rolled Dual-Path Handler (`is_task_request`)
+
+> The pattern below predates the recommended path above. It hand-constructs the `task` payload and branches with `extra.is_task_request()`. Study it to understand what the SDK now does *for* you — and prefer the recommended pattern in new code. It remains useful when you need full manual control over background scheduling (for example, enqueueing to SQS instead of `tokio::spawn`).
 
 The core pattern for `TaskSupport::Optional` tools is a branch inside the handler. When `extra.is_task_request()` returns `true`, the client sent a `task` parameter and expects a `CreateTaskResult`. When it returns `false`, the client expects a synchronous `CallToolResult`.
 
@@ -334,38 +382,38 @@ Non-task-aware client flow:
 
 ## Putting It All Together
 
-Here is how the pieces connect in a complete server:
+Here is how the pieces connect in a complete server. The task path lives on `ServerCoreBuilder` (see the "Which builder?" note above):
 
 ```rust
-use pmcp::prelude::*;
-use pmcp::server::task_store::InMemoryTaskStore;
+use pmcp::server::builder::ServerCoreBuilder;
+use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
 use std::sync::Arc;
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    let store = Arc::new(InMemoryTaskStore::new());
+# fn build() -> pmcp::Result<()> {
+let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
 
-    let server = Server::builder()
-        .name("satellite-analysis")
-        .version("1.0.0")
-        .task_store(store.clone())
-        .tool("analyze_imagery", build_analyze_tool(store.clone()))
-        .tool("get_task_result", build_get_task_result_tool(store.clone()))
-        .build()?;
-
-    server.run_stdio().await
-}
+let server = ServerCoreBuilder::new()
+    .name("satellite-analysis")
+    .version("1.0.0")
+    .task_store(store.clone())
+    .tool("analyze_imagery", build_analyze_tool(store.clone()))
+    .tool("get_task_result", build_get_task_result_tool(store.clone()))
+    .build()?;
+# let _ = server;
+# Ok(())
+# }
 ```
 
-The server advertises task support in its capabilities. The `analyze_imagery` tool declares `Optional` task support. Clients that send the `task` parameter get immediate acknowledgment. Clients that do not get synchronous results. And any client can use `get_task_result` as a universal polling mechanism.
+`build_analyze_tool` here registers `analyze_imagery` with `with_task_support(...)`. Because a `task_store` backs it, the server auto-advertises the `tasks` capability and serves `tasks/get | result | list | cancel` typed. The `get_task_result` fallback tool below remains useful for clients that cannot speak the native `tasks/*` methods at all (it is a plain `Forbidden` tool that reads the store).
 
 ## Key Takeaways
 
-- `.task_store()` on the builder auto-configures server capabilities -- you do not set them manually
+- **Recommended pattern:** register a `with_task_support` tool + `task_store(...)` on `ServerCoreBuilder`, and let the SDK mint the id, advertise the capability, and serve `tasks/*` typed. You never hand-write `tasks/*` wire JSON. (Client side: `call_tool_with_task` → poll `tasks_get` → `tasks_result`.)
+- `.task_store()` on `ServerCoreBuilder` auto-advertises the standard `tasks` capability -- you do not set it manually. (`Server::builder()` does not yet carry a `TaskStore`.)
 - `.with_execution(ToolExecution::new().with_task_support(...))` on the tool declares per-tool task behavior
-- `extra.is_task_request()` is the branch point in your handler -- one handler, two execution paths
-- The `get_task_result` fallback tool ensures every client can access async results, regardless of task support
-- The `TaskStore` enforces the state machine -- your handler only calls `create`, `update_status`, and `get`
+- `extra.is_task_request()` is the branch point in the *hand-rolled* dual-path handler -- a more advanced, manual alternative to the recommended pattern
+- The `get_task_result` fallback tool ensures even clients that cannot speak `tasks/*` natively can access async results
+- The `TaskStore` enforces the state machine -- transitions like `completed -> working` are rejected at the store level
 
 ---
 

--- a/pmcp-course/src/part8-advanced/ch21-02-capability-negotiation.md
+++ b/pmcp-course/src/part8-advanced/ch21-02-capability-negotiation.md
@@ -8,6 +8,7 @@ By the end of this section, you will be able to:
 
 - Explain why MCP uses per-request capability signals instead of per-session negotiation
 - Describe how `req.task` serves as the capability signal
+- Explain why the **server's** `tasks` capability follows the backend (a `TaskStore`) -- and why an unbacked `TaskSupport::Required` tool is a build-time error
 - List the three client profiles and the code path each takes
 - Compare task negotiation with HTTP content negotiation
 - Identify when Lambda timeout limitations make tasks mandatory vs optional
@@ -54,6 +55,29 @@ async fn handle(args: AnalyzeArgs, extra: RequestHandlerExtra) -> Result<Value> 
 ```
 
 This is the entire negotiation. No handshake. No feature flags stored in session state. The request carries its own capability declaration.
+
+## The Other Half: The Server's Capability Follows Its Backend
+
+Per-request negotiation describes the *client's* signal. The *server* makes a matching declaration during `initialize`, and the SDK derives it for you: the `tasks` capability is advertised **only when a real backend exists** to serve the `tasks/*` endpoints — i.e. when you registered a `TaskStore` via `task_store(...)`. This is the same correctness principle as the client side: the advertised capability is never a hollow claim. The endpoints it promises are always backed.
+
+Two consequences fall directly out of this rule:
+
+1. **Register a `task_store` → the `tasks` capability is auto-advertised.** You never set it by hand. (Tool metadata alone — a `taskSupport` value in `tools/list` — does *not* advertise the capability; only a backend does.)
+
+2. **A `TaskSupport::Required` tool with *no* backend is a build-time error.** `ServerCoreBuilder::build()` returns an `Err` rather than advertising `tasks/*` endpoints that cannot work:
+
+   ```rust,ignore
+   // No task_store() — build() fails because a Required tool has nothing to back it.
+   let result = ServerCoreBuilder::new()
+       .name("svc").version("1.0.0")
+       .tool("analyze_imagery", required_task_tool) // with_task_support(Required)
+       .build();
+   assert!(result.is_err()); // "a tool declares TaskSupport::Required but no TaskStore ... is configured"
+   ```
+
+   An `Optional` or `Forbidden` tool with no backend is *not* an error — it simply does not advertise (or use) the task path.
+
+So capability follows the backend on both ends: the client advertises per-request via the `task` field, and the server advertises via the presence of a `TaskStore`. Neither side can claim support it cannot honor.
 
 ## How the Signal Flows
 
@@ -255,7 +279,8 @@ if extra.is_task_request() {
 ## Key Takeaways
 
 - Task negotiation is per-request, not per-session -- the `task` field in the request is the only signal
-- `extra.is_task_request()` is the single branch point in your handler code
+- The **server's** `tasks` capability follows the backend: registering a `TaskStore` auto-advertises it, and a `TaskSupport::Required` tool with no store is a build-time error (no hollow capability)
+- `extra.is_task_request()` is the single branch point in the hand-rolled dual-path handler; the recommended pattern lets the SDK serve `tasks/*` typed instead
 - No session state, no client registry, no feature flag database needed
 - Three client profiles (task-native, tool-polling, sync-only) are all served by the same dual-path handler plus `get_task_result`
 - For serverless: match `TaskSupport` level to your Lambda timeout and expected operation duration

--- a/pmcp-course/src/part8-advanced/ch21-tasks.md
+++ b/pmcp-course/src/part8-advanced/ch21-tasks.md
@@ -9,11 +9,12 @@ MCP Tasks solve this with a two-phase model: the server accepts the request imme
 By the end of this chapter, you will be able to:
 
 - Explain why polling is preferred over SSE for serverless deployments
-- Configure a `TaskStore` on your server builder
+- Use the recommended pattern: register a `with_task_support` tool + a `TaskStore` on `ServerCoreBuilder` and let the SDK serve `tasks/*` typed -- so you never hand-write `tasks/*` wire JSON
+- Drive the typed client round-trip: `call_tool_with_task` → poll `tasks_get` → `tasks_result`
 - Declare `TaskSupport::Optional` on tools using `.with_execution()`
-- Write a dual-path tool handler that branches on `extra.is_task_request()`
+- Write a dual-path tool handler that branches on `extra.is_task_request()` (the advanced manual alternative)
 - Build a `get_task_result` fallback tool for clients that do not support tasks natively
-- Describe how capability negotiation works at the per-request level
+- Describe how capability negotiation works at the per-request level, and why the server's `tasks` capability follows its backend
 
 ## Why Tasks Matter for Enterprise MCP
 
@@ -96,6 +97,8 @@ let store = Arc::new(InMemoryTaskStore::new());
 ```
 
 The SDK provides `InMemoryTaskStore` for development. For production, the `pmcp-tasks` crate provides DynamoDB and Redis backends that survive Lambda cold starts and container restarts.
+
+> **Recommended pattern (read the next section with this in mind).** The clean way to expose a tool as a Task is to declare `with_task_support` on the tool and register the store with `task_store(...)` on `ServerCoreBuilder`. The SDK then mints the task id, auto-advertises the `tasks` capability, and serves `tasks/get | result | list | cancel` typed from the store -- **you never hand-write `tasks/*` wire JSON**. The runnable reference is [`examples/s45_tool_as_task_lifecycle.rs`](https://github.com/paiml/rust-mcp-sdk/blob/main/examples/s45_tool_as_task_lifecycle.rs). Note the task path lives on `ServerCoreBuilder` / `ServerCore`; the high-level `pmcp::Server` (and `StreamableHttpServer`) does not yet carry a `TaskStore`.
 
 | Backend | Crate | Use Case |
 |---------|-------|----------|

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -562,16 +562,8 @@ impl<T: Transport> Client<T> {
         let request_id = RequestId::String(Uuid::new_v4().to_string());
         let response = self.send_request(request_id, request).await?;
 
-        match response.payload {
-            crate::types::jsonrpc::ResponsePayload::Result(result) => {
-                let task_result: GetTaskResult =
-                    serde_json::from_value(result).map_err(|e| Error::parse(e.to_string()))?;
-                Ok(task_result.task)
-            },
-            crate::types::jsonrpc::ResponsePayload::Error(error) => {
-                Err(Error::from_jsonrpc_error(error))
-            },
-        }
+        let task_result: GetTaskResult = self.parse_task_payload(response, "tasks/get").await?;
+        Ok(task_result.task)
     }
 
     /// Get the final result of a completed task.
@@ -591,14 +583,8 @@ impl<T: Transport> Client<T> {
         let request_id = RequestId::String(Uuid::new_v4().to_string());
         let response = self.send_request(request_id, request).await?;
 
-        match response.payload {
-            crate::types::jsonrpc::ResponsePayload::Result(result) => {
-                serde_json::from_value(result).map_err(|e| Error::parse(e.to_string()))
-            },
-            crate::types::jsonrpc::ResponsePayload::Error(error) => {
-                Err(Error::from_jsonrpc_error(error))
-            },
-        }
+        self.parse_task_payload::<CallToolResult>(response, "tasks/result")
+            .await
     }
 
     /// List tasks owned by the current client.
@@ -612,14 +598,8 @@ impl<T: Transport> Client<T> {
         let request_id = RequestId::String(Uuid::new_v4().to_string());
         let response = self.send_request(request_id, request).await?;
 
-        match response.payload {
-            crate::types::jsonrpc::ResponsePayload::Result(result) => {
-                serde_json::from_value(result).map_err(|e| Error::parse(e.to_string()))
-            },
-            crate::types::jsonrpc::ResponsePayload::Error(error) => {
-                Err(Error::from_jsonrpc_error(error))
-            },
-        }
+        self.parse_task_payload::<ListTasksResult>(response, "tasks/list")
+            .await
     }
 
     /// Cancel a running task.
@@ -634,11 +614,38 @@ impl<T: Transport> Client<T> {
         let request_id = RequestId::String(Uuid::new_v4().to_string());
         let response = self.send_request(request_id, request).await?;
 
+        let cancel_result: CancelTaskResult =
+            self.parse_task_payload(response, "tasks/cancel").await?;
+        Ok(cancel_result.task)
+    }
+
+    /// Deserialize a `tasks/*` response payload into `T`, emitting a structured
+    /// WARN (method + transport identity + serde error) on a deserialize failure
+    /// before surfacing it. Centralizes the four task endpoints' identical
+    /// result-vs-error handling.
+    ///
+    /// Lock-on-error: the transport identity is read only on the cold failure
+    /// path (D-LOCK-ON-ERROR — no cached field on `Client`).
+    async fn parse_task_payload<D: serde::de::DeserializeOwned>(
+        &self,
+        response: crate::types::JSONRPCResponse,
+        method: &'static str,
+    ) -> Result<D> {
         match response.payload {
             crate::types::jsonrpc::ResponsePayload::Result(result) => {
-                let cancel_result: CancelTaskResult =
-                    serde_json::from_value(result).map_err(|e| Error::parse(e.to_string()))?;
-                Ok(cancel_result.task)
+                match serde_json::from_value::<D>(result) {
+                    Ok(value) => Ok(value),
+                    Err(e) => {
+                        let transport = self.transport.read().await.transport_type();
+                        Self::log_task_deserialize_error(
+                            method,
+                            std::any::type_name::<D>(),
+                            transport,
+                            &e,
+                        );
+                        Err(Error::parse(e.to_string()))
+                    },
+                }
             },
             crate::types::jsonrpc::ResponsePayload::Error(error) => {
                 Err(Error::from_jsonrpc_error(error))
@@ -1860,6 +1867,34 @@ impl<T: Transport> Client<T> {
             .await
     }
 
+    /// Emit a `WARN` when a `tasks/*` response fails to deserialize.
+    ///
+    /// This is the single shared observability helper for all four task
+    /// deserialize sites (`tasks/get`, `tasks/result`, `tasks/list`,
+    /// `tasks/cancel`). It logs the originating `method`, the available
+    /// transport identity, the deserialize `target` type, and the serde
+    /// `error` — then the caller still returns `Err` (control flow is
+    /// unchanged; this only adds observability, closing TASKDX-03).
+    ///
+    /// `transport` is [`Transport::transport_type`] (e.g. `"stdio"`,
+    /// `"http"`) — the only server identity available here, because the
+    /// `Transport` trait exposes no per-instance URL. TASKDX-03 logs this
+    /// identity, not a genuine endpoint URL.
+    fn log_task_deserialize_error(
+        method: &'static str,
+        target_type: &'static str,
+        transport: &'static str,
+        error: &serde_json::Error,
+    ) {
+        tracing::warn!(
+            method = method,
+            transport = transport,
+            target = target_type,
+            error = %error,
+            "task response failed to deserialize",
+        );
+    }
+
     /// Check if client is initialized.
     fn ensure_initialized(&self) -> Result<()> {
         if self.initialized {
@@ -2955,5 +2990,209 @@ mod tests {
         let all = client.list_all_resource_templates().await.expect("ok");
         let names: Vec<_> = all.into_iter().map(|t| t.name).collect();
         assert_eq!(names, vec!["ta", "tb"]);
+    }
+
+    // === TASKDX-03: WARN on task deserialize failure ===
+
+    /// A single captured tracing event's structured fields.
+    #[derive(Debug, Clone, Default)]
+    struct CapturedEvent {
+        level: String,
+        fields: std::collections::HashMap<String, String>,
+        message: String,
+    }
+
+    /// Minimal in-test recording subscriber that captures events' structured
+    /// fields into a shared `Vec`, with NO dependency on `tracing-subscriber`.
+    ///
+    /// Installed via `tracing::subscriber::with_default` (scoped, never a global
+    /// `init()`), so it cannot leak across tests run under `--test-threads=1`.
+    #[derive(Clone, Default)]
+    struct RecordingSubscriber {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    struct FieldCollector<'a>(&'a mut CapturedEvent);
+
+    impl tracing::field::Visit for FieldCollector<'_> {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            let rendered = format!("{value:?}");
+            if field.name() == "message" {
+                // Debug-rendered messages are wrapped in quotes; strip them.
+                self.0.message = rendered.trim_matches('"').to_string();
+            } else {
+                self.0.fields.insert(
+                    field.name().to_string(),
+                    rendered.trim_matches('"').to_string(),
+                );
+            }
+        }
+
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            if field.name() == "message" {
+                self.0.message = value.to_string();
+            } else {
+                self.0
+                    .fields
+                    .insert(field.name().to_string(), value.to_string());
+            }
+        }
+    }
+
+    impl tracing::Subscriber for RecordingSubscriber {
+        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+        fn event(&self, event: &tracing::Event<'_>) {
+            let mut captured = CapturedEvent {
+                level: event.metadata().level().to_string(),
+                ..Default::default()
+            };
+            event.record(&mut FieldCollector(&mut captured));
+            self.events.lock().unwrap().push(captured);
+        }
+
+        fn enter(&self, _span: &tracing::span::Id) {}
+        fn exit(&self, _span: &tracing::span::Id) {}
+    }
+
+    /// Build an init response advertising the `tasks` capability.
+    fn tasks_init_response() -> TransportMessage {
+        TransportMessage::Response(JSONRPCResponse {
+            jsonrpc: "2.0".to_string(),
+            id: RequestId::from(1i64),
+            payload: ResponsePayload::Result(json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": { "tasks": {} },
+                "serverInfo": { "name": "test-server", "version": "1.0.0" }
+            })),
+        })
+    }
+
+    #[test]
+    fn test_tasks_get_malformed_response_emits_warn_and_errs() {
+        // A flat Task missing the required `task` wrapper — the deliberately
+        // wrong shape for GetTaskResult (incident bug #3).
+        let malformed = TransportMessage::Response(JSONRPCResponse {
+            jsonrpc: "2.0".to_string(),
+            id: RequestId::from(2i64),
+            payload: ResponsePayload::Result(json!({
+                "taskId": "abc",
+                "status": "completed"
+            })),
+        });
+        let transport = MockTransport::with_responses(vec![malformed, tasks_init_response()]);
+        let mut client = Client::new(transport);
+        let _ = futures::executor::block_on(client.initialize(ClientCapabilities::default()));
+
+        let recorder = RecordingSubscriber::default();
+        let sink = recorder.events.clone();
+        let result = tracing::subscriber::with_default(recorder, || {
+            futures::executor::block_on(client.tasks_get("abc"))
+        });
+
+        // Control flow unchanged: still returns Err (a parse error).
+        assert!(result.is_err(), "malformed tasks/get must still return Err");
+
+        // Structural WARN assertion (not a substring of the message text).
+        let events = sink.lock().unwrap();
+        let warn = events
+            .iter()
+            .find(|e| e.fields.get("method").map(String::as_str) == Some("tasks/get"))
+            .expect("a WARN naming method=tasks/get must be captured");
+        assert_eq!(warn.level, "WARN", "must be a WARN level event");
+        assert!(
+            warn.fields.contains_key("error"),
+            "WARN must carry the serde error field, got: {:?}",
+            warn.fields
+        );
+        assert!(
+            warn.fields.contains_key("transport"),
+            "WARN must carry the transport identity field, got: {:?}",
+            warn.fields
+        );
+    }
+
+    #[test]
+    fn test_tasks_result_malformed_response_emits_warn_and_errs() {
+        // CallToolResult requires `content`; a bare bool is the wrong shape.
+        let malformed = TransportMessage::Response(JSONRPCResponse {
+            jsonrpc: "2.0".to_string(),
+            id: RequestId::from(2i64),
+            payload: ResponsePayload::Result(json!(true)),
+        });
+        let transport = MockTransport::with_responses(vec![malformed, tasks_init_response()]);
+        let mut client = Client::new(transport);
+        let _ = futures::executor::block_on(client.initialize(ClientCapabilities::default()));
+
+        let recorder = RecordingSubscriber::default();
+        let sink = recorder.events.clone();
+        let result = tracing::subscriber::with_default(recorder, || {
+            futures::executor::block_on(client.tasks_result("abc"))
+        });
+
+        assert!(
+            result.is_err(),
+            "malformed tasks/result must still return Err"
+        );
+
+        let events = sink.lock().unwrap();
+        let warn = events
+            .iter()
+            .find(|e| e.fields.get("method").map(String::as_str) == Some("tasks/result"))
+            .expect("a WARN naming method=tasks/result must be captured");
+        assert_eq!(warn.level, "WARN");
+        assert!(warn.fields.contains_key("error"), "got: {:?}", warn.fields);
+        assert!(
+            warn.fields.contains_key("transport"),
+            "got: {:?}",
+            warn.fields
+        );
+    }
+
+    #[test]
+    fn test_tasks_get_well_formed_response_emits_no_warn() {
+        let well_formed = TransportMessage::Response(JSONRPCResponse {
+            jsonrpc: "2.0".to_string(),
+            id: RequestId::from(2i64),
+            payload: ResponsePayload::Result(json!({
+                "task": {
+                    "taskId": "abc",
+                    "status": "completed",
+                    "createdAt": "2026-06-21T00:00:00Z",
+                    "lastUpdatedAt": "2026-06-21T00:00:00Z"
+                }
+            })),
+        });
+        let transport = MockTransport::with_responses(vec![well_formed, tasks_init_response()]);
+        let mut client = Client::new(transport);
+        let _ = futures::executor::block_on(client.initialize(ClientCapabilities::default()));
+
+        let recorder = RecordingSubscriber::default();
+        let sink = recorder.events.clone();
+        let result = tracing::subscriber::with_default(recorder, || {
+            futures::executor::block_on(client.tasks_get("abc"))
+        });
+
+        assert!(
+            result.is_ok(),
+            "well-formed tasks/get must succeed: {result:?}"
+        );
+        let events = sink.lock().unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.fields.get("method").map(String::as_str) == Some("tasks/get")),
+            "no task-deserialize WARN must fire on a well-formed response"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,15 @@ pub mod shared;
 pub mod types;
 pub mod utils;
 
+/// Conformance helpers for proving the `tasks/*` wire surface round-trips
+/// through the real client deserialization types.
+///
+/// Feature-gated behind `testing` (folded into `full`) so it is available to
+/// integration tests, examples, and the quality gate, but omitted from lean
+/// default release builds. See [`testing::assert_roundtrips_through_client`].
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
 #[cfg(feature = "simd")]
 pub mod simd;
 

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -720,7 +720,14 @@ impl ServerCoreBuilder {
         self
     }
 
-    /// Enable experimental MCP Tasks support with a task router.
+    /// Enable experimental MCP Tasks support with a task router (LEGACY).
+    ///
+    /// **Legacy / experimental.** This is the older `pmcp-tasks`
+    /// `TaskRouter` path and advertises `experimental.tasks` rather than the
+    /// standard `ServerCapabilities.tasks`. For the recommended, all-typed
+    /// tools-as-Tasks pattern, register a
+    /// [`TaskStore`](crate::server::task_store::TaskStore) via
+    /// [`Self::task_store`] instead (see `examples/s45_tool_as_task_lifecycle.rs`).
     ///
     /// The task router handles task lifecycle operations (`tasks/get`, `tasks/result`,
     /// `tasks/list`, `tasks/cancel`) and task-augmented `tools/call` requests.
@@ -759,33 +766,88 @@ impl ServerCoreBuilder {
         self
     }
 
-    /// Register a task store for MCP Tasks with polling.
+    /// Register a [`TaskStore`](crate::server::task_store::TaskStore) for MCP
+    /// Tasks (RECOMMENDED tools-as-Tasks path).
+    ///
+    /// This is the recommended, all-typed path for exposing a tool as an async
+    /// MCP Task: pair a task-capable
+    /// [`TypedTool`](crate::server::typed_tool::TypedTool) (marked
+    /// [`with_task_support(TaskSupport::Required)`](crate::types::ToolExecution::with_task_support))
+    /// with a store here, and the SDK serves `tasks/*` typed from the store —
+    /// you never hand-write `tasks/*` wire JSON, and the store mints the task id.
+    /// For the legacy experimental router path via `pmcp-tasks`, use
+    /// [`Self::with_task_store`].
     ///
     /// When a task store is registered, the server:
-    /// - Advertises `ServerCapabilities.tasks` with list and cancel support
-    /// - Handles `tasks/get`, `tasks/list`, `tasks/cancel` requests via the store
+    /// - **Auto-advertises** `ServerCapabilities.tasks` (with list and cancel
+    ///   support) in `initialize` — the mere presence of a store flips the
+    ///   capability on, unless an explicit `tasks` capability was already
+    ///   configured (additive-only; an explicit value is preserved verbatim).
+    /// - Handles `tasks/get`, `tasks/result`, `tasks/list`, `tasks/cancel`
+    ///   requests via the store
     /// - Resolves task owner from auth context (OAuth subject, client ID, or session ID)
     ///
-    /// This is the standard capability path (uses `ServerCapabilities.tasks`).
-    /// For the legacy experimental path via `pmcp-tasks`, use [`Self::with_task_store`].
+    /// A tool declaring
+    /// [`TaskSupport::Required`](crate::types::tools::TaskSupport::Required)
+    /// with NO store (or router) makes [`Self::build`] return an `Err`, rather
+    /// than advertising a hollow `tasks` capability whose endpoints cannot work.
+    ///
+    /// See `examples/s45_tool_as_task_lifecycle.rs` for the full client
+    /// round-trip.
     ///
     /// # Examples
     ///
-    /// ```rust,ignore
-    /// use pmcp::server::task_store::InMemoryTaskStore;
+    /// ```no_run
     /// use std::sync::Arc;
+    /// use pmcp::server::builder::ServerCoreBuilder;
+    /// use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+    /// use pmcp::server::typed_tool::TypedTool;
+    /// use pmcp::types::{TaskSupport, ToolExecution};
     ///
-    /// let store = Arc::new(InMemoryTaskStore::new());
-    /// let server = Server::builder()
+    /// # fn build() -> pmcp::Result<()> {
+    /// let task_tool = TypedTool::new_with_schema(
+    ///     "summarize",
+    ///     serde_json::json!({ "type": "object" }),
+    ///     |_args: serde_json::Value, _extra| {
+    ///         Box::pin(async { Ok(serde_json::json!({ "status": "completed" })) })
+    ///     },
+    /// )
+    /// .with_description("Summarize asynchronously as an MCP Task")
+    /// .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+    ///
+    /// let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+    /// let server = ServerCoreBuilder::new()
     ///     .name("my-server")
     ///     .version("1.0.0")
-    ///     .task_store(store)
+    ///     .tool("summarize", task_tool)
+    ///     .task_store(store) // presence of a store auto-advertises the `tasks` capability
     ///     .build()?;
+    /// # let _ = server;
+    /// # Ok(())
+    /// # }
     /// ```
     #[cfg(not(target_arch = "wasm32"))]
     pub fn task_store(mut self, store: Arc<dyn crate::server::task_store::TaskStore>) -> Self {
-        // Set ServerCapabilities.tasks (standard, not experimental)
-        self.capabilities.tasks = Some(crate::types::capabilities::ServerTasksCapability {
+        // Capability advertisement is centralized in `build()` (see
+        // `default_tasks_capability` and the endpoint-backed injection rule).
+        // Registering a store records the backend; it does NOT itself set
+        // `capabilities.tasks` so an explicitly-configured capability is never
+        // clobbered (additive-only, per D-CAPABILITY-ENDPOINT-BACKED).
+        self.task_store = Some(store);
+        self
+    }
+
+    /// Build the default server-level `tasks` capability advertised when a
+    /// task backend (a [`TaskStore`](crate::server::task_store::TaskStore) or a
+    /// [`TaskRouter`]) is present.
+    ///
+    /// This is the exact shape previously assigned inline by `task_store()`.
+    /// Centralizing it here lets `build()` inject the capability once, only when
+    /// an endpoint backend exists and the author has not already configured a
+    /// custom `tasks` capability (additive-only).
+    #[cfg(not(target_arch = "wasm32"))]
+    fn default_tasks_capability() -> crate::types::capabilities::ServerTasksCapability {
+        crate::types::capabilities::ServerTasksCapability {
             list: Some(serde_json::json!({})),
             cancel: Some(serde_json::json!({})),
             requests: Some(crate::types::capabilities::ServerTasksRequestCapability {
@@ -793,10 +855,52 @@ impl ServerCoreBuilder {
                     call: Some(serde_json::json!({})),
                 }),
             }),
+        }
+    }
+
+    /// Apply the endpoint-backed `tasks`-capability rule (D-CAPABILITY-ENDPOINT-BACKED).
+    ///
+    /// The `tasks` capability advertised in `initialize` represents REAL endpoint
+    /// support, never tool metadata alone:
+    /// - It is auto-advertised only when a backend exists
+    ///   (`task_store.is_some() || task_router.is_some()`) and the author has not
+    ///   already configured a custom `tasks` capability (additive-only — an
+    ///   explicit value is preserved verbatim).
+    /// - A tool declaring [`TaskSupport::Required`](crate::types::tools::TaskSupport)
+    ///   with NO backend is a build-time validation error (rather than a hollow
+    ///   capability that advertises `tasks/*` endpoints that cannot work).
+    /// - An `Optional`/`Forbidden` task tool with no backend is NOT an error and
+    ///   does NOT by itself trigger advertisement.
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error if any registered tool declares
+    /// [`TaskSupport::Required`] but no `TaskStore` or `TaskRouter` backs the
+    /// `tasks/*` endpoints.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn apply_tasks_capability_rule(&mut self) -> Result<()> {
+        use crate::types::tools::TaskSupport;
+
+        let has_backend = self.task_store.is_some() || self.task_router.is_some();
+        let has_required_task_tool = self.tool_infos.values().any(|info| {
+            info.execution
+                .as_ref()
+                .and_then(|e| e.task_support)
+                .is_some_and(|ts| matches!(ts, TaskSupport::Required))
         });
 
-        self.task_store = Some(store);
-        self
+        if has_required_task_tool && !has_backend {
+            return Err(Error::validation(
+                "a tool declares TaskSupport::Required but no TaskStore or TaskRouter \
+                 is configured to back the tasks/* endpoints",
+            ));
+        }
+
+        if self.capabilities.tasks.is_none() && has_backend {
+            self.capabilities.tasks = Some(Self::default_tasks_capability());
+        }
+
+        Ok(())
     }
 
     /// Detect if running in a stateless/serverless environment.
@@ -955,6 +1059,13 @@ impl ServerCoreBuilder {
     /// Returns an error if required fields (name, version) are not set.
     #[allow(unused_mut)]
     pub fn build(mut self) -> Result<ServerCore> {
+        // Endpoint-backed `tasks` capability injection (D-CAPABILITY-ENDPOINT-BACKED):
+        // advertise `tasks` only when a store/router backend exists, error on a
+        // Required task tool with no backend, and never clobber an explicit value.
+        // Done first, before any partial move of `self` below.
+        #[cfg(not(target_arch = "wasm32"))]
+        self.apply_tasks_capability_rule()?;
+
         let name = self
             .name
             .ok_or_else(|| Error::validation("Server name is required"))?;
@@ -1323,24 +1434,179 @@ mod tests {
 
     #[test]
     fn test_builder_task_store_sets_capabilities() {
+        // Capability injection is centralized in build() (endpoint-backed rule),
+        // so the store records the backend but does NOT set the capability on the
+        // builder itself — it appears on the BUILT capabilities.
         let store = Arc::new(crate::server::task_store::InMemoryTaskStore::new());
         let builder = ServerCoreBuilder::new()
             .name("test")
             .version("1.0.0")
             .task_store(store);
-        // Verify capabilities were set by the builder method
-        assert!(
-            builder.capabilities.tasks.is_some(),
-            "ServerCapabilities.tasks should be set"
-        );
-        let tasks_cap = builder.capabilities.tasks.as_ref().unwrap();
-        assert!(tasks_cap.list.is_some(), "tasks.list should be set");
-        assert!(tasks_cap.cancel.is_some(), "tasks.cancel should be set");
-        assert!(tasks_cap.requests.is_some(), "tasks.requests should be set");
-        // Verify task_store field is populated
+        // task_store field is populated, but capability is not yet injected.
         assert!(
             builder.task_store.is_some(),
             "task_store field should be set"
+        );
+        assert!(
+            builder.capabilities.tasks.is_none(),
+            "capability injection is deferred to build()"
+        );
+
+        let server = builder.build().unwrap();
+        let tasks_cap = server
+            .capabilities()
+            .tasks
+            .as_ref()
+            .expect("ServerCapabilities.tasks should be set after build()");
+        assert!(tasks_cap.list.is_some(), "tasks.list should be set");
+        assert!(tasks_cap.cancel.is_some(), "tasks.cancel should be set");
+        assert!(tasks_cap.requests.is_some(), "tasks.requests should be set");
+    }
+
+    /// A `TaskRouter` (with no store) is a valid backend — `build()` must
+    /// advertise the `tasks` capability.
+    #[test]
+    fn test_builder_task_router_only_advertises_tasks() {
+        let server = ServerCoreBuilder::new()
+            .name("test")
+            .version("1.0.0")
+            .with_task_store(Arc::new(WorkflowMockTaskRouter))
+            .build()
+            .unwrap();
+        assert!(
+            server.capabilities().tasks.is_some(),
+            "router-only backend should advertise tasks"
+        );
+    }
+
+    /// Helper tool exposing a configurable `TaskSupport` via its execution metadata.
+    struct TaskSupportTool(crate::types::tools::TaskSupport);
+
+    #[async_trait]
+    impl ToolHandler for TaskSupportTool {
+        async fn handle(&self, _args: Value, _extra: RequestHandlerExtra) -> Result<Value> {
+            Ok(Value::Null)
+        }
+        fn metadata(&self) -> Option<ToolInfo> {
+            let mut info = ToolInfo::new("task-tool", None, serde_json::json!({"type": "object"}));
+            info.execution =
+                Some(crate::types::tools::ToolExecution::new().with_task_support(self.0));
+            Some(info)
+        }
+    }
+
+    /// A `Required` task tool with NO backend is a build-time validation error,
+    /// not a hollow capability.
+    #[test]
+    fn test_builder_required_task_tool_without_backend_errors() {
+        use crate::types::tools::TaskSupport;
+
+        let result = ServerCoreBuilder::new()
+            .name("test")
+            .version("1.0.0")
+            .tool("task-tool", TaskSupportTool(TaskSupport::Required))
+            .build();
+        assert!(
+            result.is_err(),
+            "Required task tool with no backend must fail build()"
+        );
+    }
+
+    /// A `Required` task tool WITH a store backend builds successfully and
+    /// advertises the capability.
+    #[test]
+    fn test_builder_required_task_tool_with_store_builds() {
+        use crate::types::tools::TaskSupport;
+
+        let store = Arc::new(crate::server::task_store::InMemoryTaskStore::new());
+        let server = ServerCoreBuilder::new()
+            .name("test")
+            .version("1.0.0")
+            .tool("task-tool", TaskSupportTool(TaskSupport::Required))
+            .task_store(store)
+            .build()
+            .unwrap();
+        assert!(
+            server.capabilities().tasks.is_some(),
+            "Required task tool with a store backend should advertise tasks"
+        );
+    }
+
+    /// An `Optional` task tool with NO backend is NOT an error and does NOT
+    /// trigger a false-positive capability.
+    #[test]
+    fn test_builder_optional_task_tool_without_backend_no_capability() {
+        use crate::types::tools::TaskSupport;
+
+        let server = ServerCoreBuilder::new()
+            .name("test")
+            .version("1.0.0")
+            .tool("task-tool", TaskSupportTool(TaskSupport::Optional))
+            .build()
+            .unwrap();
+        assert!(
+            server.capabilities().tasks.is_none(),
+            "Optional task tool with no backend must not advertise tasks"
+        );
+    }
+
+    /// A `Forbidden`-only task tool with NO backend is NOT an error and does NOT
+    /// trigger a false-positive capability.
+    #[test]
+    fn test_builder_forbidden_task_tool_without_backend_no_capability() {
+        use crate::types::tools::TaskSupport;
+
+        let server = ServerCoreBuilder::new()
+            .name("test")
+            .version("1.0.0")
+            .tool("task-tool", TaskSupportTool(TaskSupport::Forbidden))
+            .build()
+            .unwrap();
+        assert!(
+            server.capabilities().tasks.is_none(),
+            "Forbidden task tool with no backend must not advertise tasks"
+        );
+    }
+
+    /// An explicitly-configured custom `tasks` capability is preserved verbatim
+    /// even when a store backend is present (additive-only).
+    #[test]
+    fn test_builder_explicit_tasks_capability_not_clobbered() {
+        use crate::types::capabilities::ServerTasksCapability;
+
+        // A distinctive custom capability (list omitted) so we can prove it survives.
+        let custom = ServerTasksCapability {
+            list: None,
+            cancel: Some(serde_json::json!({"custom": true})),
+            requests: None,
+        };
+        let capabilities = crate::types::ServerCapabilities {
+            tasks: Some(custom),
+            ..Default::default()
+        };
+
+        let store = Arc::new(crate::server::task_store::InMemoryTaskStore::new());
+        let server = ServerCoreBuilder::new()
+            .name("test")
+            .version("1.0.0")
+            .capabilities(capabilities)
+            .task_store(store)
+            .build()
+            .unwrap();
+
+        let built = server
+            .capabilities()
+            .tasks
+            .as_ref()
+            .expect("explicit tasks capability should remain set");
+        assert!(
+            built.list.is_none(),
+            "explicit capability must not be replaced by the default (which sets list)"
+        );
+        assert_eq!(
+            built.cancel,
+            Some(serde_json::json!({"custom": true})),
+            "explicit custom cancel value must survive build()"
         );
     }
 

--- a/src/server/core.rs
+++ b/src/server/core.rs
@@ -38,7 +38,7 @@ use super::tasks::TaskRouter;
 use super::tool_middleware::{ToolContext, ToolMiddlewareChain};
 use super::{PromptHandler, ResourceHandler, SamplingHandler, ToolHandler};
 #[cfg(not(target_arch = "wasm32"))]
-use crate::types::tasks::RELATED_TASK_META_KEY;
+use crate::types::tasks::{TaskStatus, RELATED_TASK_META_KEY};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::types::tools::TaskSupport;
 
@@ -299,9 +299,18 @@ pub struct ServerCore {
 enum ToolCallOutcome {
     /// Standard tool result wrapped as `CallToolResult`
     Result(CallToolResult),
-    /// Tool returned a Task-shaped value — returned as `CreateTaskResult` with `_meta`
+    /// Tool returned a Task-shaped value — returned as `CreateTaskResult` with `_meta`.
+    ///
+    /// `result` carries the explicit terminal [`CallToolResult`] when the tool
+    /// completed synchronously (the tool value carried a `result`/`content`
+    /// payload). When `None`, the task is genuinely pending and is completed
+    /// asynchronously elsewhere.
     #[cfg(not(target_arch = "wasm32"))]
-    TaskCreated { task_id: String, task_value: Value },
+    TaskCreated {
+        task_id: String,
+        task_value: Value,
+        result: Option<CallToolResult>,
+    },
 }
 
 impl ServerCore {
@@ -438,6 +447,24 @@ impl ServerCore {
             tools,
             next_cursor: None,
         })
+    }
+
+    /// Extract the terminal [`CallToolResult`] from a task-shaped tool value.
+    ///
+    /// Per `D-TERMINAL-RESULT-CONTRACT`: if the value carries a `result` object
+    /// or a `content` array, deserialize it into a [`CallToolResult`]; otherwise
+    /// the task is genuinely pending and there is no synchronous terminal result.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn extract_terminal_result(value: &Value) -> Option<CallToolResult> {
+        // Prefer an explicit nested `result` payload, else a top-level `content`
+        // array (the conventional CallToolResult shape).
+        if let Some(result_value) = value.get("result") {
+            return serde_json::from_value::<CallToolResult>(result_value.clone()).ok();
+        }
+        if value.get("content").is_some() {
+            return serde_json::from_value::<CallToolResult>(value.clone()).ok();
+        }
+        None
     }
 
     /// Handle call tool request.
@@ -590,9 +617,16 @@ impl ServerCore {
             if has_task_support {
                 if let Some(task_id) = value.get("taskId").and_then(|v| v.as_str()) {
                     if value.get("status").is_some() {
+                        let task_id = task_id.to_string();
+                        // D-TERMINAL-RESULT-CONTRACT: the terminal CallToolResult
+                        // is born HERE, explicitly, when the tool value carries a
+                        // result/content payload. Otherwise the task is genuinely
+                        // pending (completed asynchronously elsewhere).
+                        let result = Self::extract_terminal_result(&value);
                         return Ok(ToolCallOutcome::TaskCreated {
-                            task_id: task_id.to_string(),
+                            task_id,
                             task_value: value,
+                            result,
                         });
                     }
                 }
@@ -955,6 +989,142 @@ impl ServerCore {
         None
     }
 
+    /// Build the `tools/call` create-task response for a `TaskCreated` outcome.
+    ///
+    /// Per `D-STORE-MINTS-ID` (review finding #3): when a [`TaskStore`] is
+    /// configured the store mints the canonical task id via `store.create()`;
+    /// that store-minted id is reflected on the WIRE in BOTH
+    /// `CreateTaskResult.task.taskId` AND the `_meta.relatedTask.taskId`
+    /// envelope (never the tool's fabricated id). When the terminal `result`
+    /// is present (synchronous completion) it is persisted via
+    /// `store.set_result()` and the task is transitioned `Working -> Completed`
+    /// BEFORE the response returns, so a subsequent `tasks/get` shows
+    /// `Completed`.
+    ///
+    /// Falls back to the legacy tool-fabricated envelope only when no store is
+    /// configured (preserves prior behavior for router-only servers).
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn build_task_created_response(
+        &self,
+        id: RequestId,
+        task_id: &str,
+        task_value: &Value,
+        result: Option<CallToolResult>,
+        auth_context: Option<&AuthContext>,
+    ) -> JSONRPCResponse {
+        let Some(store) = self.task_store.as_ref() else {
+            // No store: preserve the legacy tool-fabricated envelope.
+            let result_value = serde_json::json!({
+                "task": task_value,
+                "_meta": { RELATED_TASK_META_KEY: { "taskId": task_id } }
+            });
+            return Self::success_response(id, result_value);
+        };
+
+        let owner_id = self
+            .resolve_task_owner(auth_context)
+            .unwrap_or_else(|| "local".to_string());
+
+        // Carry the tool's requested TTL onto the store-minted task, if present.
+        let ttl = task_value.get("ttl").and_then(serde_json::Value::as_u64);
+
+        let created = match store.create(&owner_id, ttl).await {
+            Ok(task) => task,
+            Err(e) => return Self::error_response(id, -32603, e.to_string()),
+        };
+        let store_id = created.task_id.clone();
+
+        // Synchronous completion: persist the terminal result and complete.
+        let final_task = if let Some(call_result) = result {
+            if let Err(e) = store.set_result(&store_id, &owner_id, call_result).await {
+                return Self::error_response(id, -32603, e.to_string());
+            }
+            match store
+                .update_status(&store_id, &owner_id, TaskStatus::Completed, None)
+                .await
+            {
+                Ok(task) => task,
+                Err(e) => return Self::error_response(id, -32603, e.to_string()),
+            }
+        } else {
+            created
+        };
+
+        // Build the wire envelope from the STORE-minted task (typed, no
+        // hand-written task JSON) so task.taskId == _meta id == store id.
+        let create_result = crate::types::tasks::CreateTaskResult::new(final_task);
+        let mut envelope = serde_json::to_value(create_result).unwrap_or_default();
+        if let Some(obj) = envelope.as_object_mut() {
+            obj.insert(
+                "_meta".to_string(),
+                serde_json::json!({ RELATED_TASK_META_KEY: { "taskId": store_id } }),
+            );
+        }
+        Self::success_response(id, envelope)
+    }
+
+    /// Handle a `tasks/result` request.
+    ///
+    /// Per review finding #2 (store-vs-router precedence): serves from the
+    /// configured [`TaskStore`] FIRST when it `supports_results()`, but FALLS
+    /// THROUGH to the [`TaskRouter`](crate::server::tasks::TaskRouter) on store
+    /// `NotFound`/unsupported — never a hard error when a router can serve it.
+    /// When the store has no result and NO router is configured, returns a
+    /// SPECIFIED "task not completed" error (`-32002`), distinct from the
+    /// truly-no-backend `-32601`.
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn handle_tasks_result(
+        &self,
+        id: RequestId,
+        params: &crate::types::tasks::GetTaskPayloadRequest,
+        auth_context: Option<&AuthContext>,
+    ) -> JSONRPCResponse {
+        let owner_id = self
+            .resolve_task_owner(auth_context)
+            .unwrap_or_else(|| "local".to_string());
+
+        // Store-first: serve a typed CallToolResult when the store persists one.
+        if let Some(ref store) = self.task_store {
+            if store.supports_results() {
+                match store.get_result(&params.task_id, &owner_id).await {
+                    Ok(call_result) => {
+                        return Self::success_response(
+                            id,
+                            serde_json::to_value(call_result).unwrap_or_default(),
+                        );
+                    },
+                    // NotFound = store doesn't have it (absent / pending /
+                    // owner mismatch): fall through to the router below.
+                    Err(crate::server::task_store::TaskStoreError::NotFound { .. }) => {},
+                    Err(e) => return Self::error_response(id, -32603, e.to_string()),
+                }
+            }
+        }
+
+        // Router fallback — behavior UNCHANGED for router-backed servers.
+        if let Some(ref task_router) = self.task_router {
+            return match task_router
+                .handle_tasks_result(serde_json::to_value(params).unwrap_or_default(), &owner_id)
+                .await
+            {
+                Ok(result) => Self::success_response(id, result),
+                Err(e) => Self::error_response(id, -32603, e.to_string()),
+            };
+        }
+
+        // No router: distinguish "store exists but task not completed yet"
+        // (specified error) from "no task backend at all".
+        if self.task_store.is_some() {
+            Self::error_response(
+                id,
+                -32002,
+                "task result not available: task not completed".to_string(),
+            )
+        } else {
+            Self::error_response(id, -32601, "tasks/result not supported".to_string())
+        }
+    }
+
     /// Internal request handler without middleware processing.
     async fn handle_request_internal(
         &self,
@@ -1052,14 +1222,16 @@ impl ServerCore {
                                 ToolCallOutcome::TaskCreated {
                                     task_id,
                                     task_value,
+                                    result,
                                 } => {
-                                    let result_value = serde_json::json!({
-                                        "task": task_value,
-                                        "_meta": {
-                                            RELATED_TASK_META_KEY: { "taskId": task_id }
-                                        }
-                                    });
-                                    Self::success_response(id, result_value)
+                                    self.build_task_created_response(
+                                        id,
+                                        &task_id,
+                                        &task_value,
+                                        result,
+                                        auth_context.as_ref(),
+                                    )
+                                    .await
                                 },
                                 ToolCallOutcome::Result(result) => {
                                     // Fire-and-forget workflow continuation recording
@@ -1172,28 +1344,8 @@ impl ServerCore {
                     },
                     #[cfg(not(target_arch = "wasm32"))]
                     ClientRequest::TasksResult(params) => {
-                        // tasks/result is a PMCP extension -- delegate to TaskRouter only
-                        if let Some(ref task_router) = self.task_router {
-                            let owner_id = self
-                                .resolve_task_owner(auth_context.as_ref())
-                                .unwrap_or_else(|| "local".to_string());
-                            match task_router
-                                .handle_tasks_result(
-                                    serde_json::to_value(params).unwrap_or_default(),
-                                    &owner_id,
-                                )
-                                .await
-                            {
-                                Ok(result) => Self::success_response(id, result),
-                                Err(e) => Self::error_response(id, -32603, e.to_string()),
-                            }
-                        } else {
-                            Self::error_response(
-                                id,
-                                -32601,
-                                "tasks/result not supported".to_string(),
-                            )
-                        }
+                        self.handle_tasks_result(id, params, auth_context.as_ref())
+                            .await
                     },
                     #[cfg(not(target_arch = "wasm32"))]
                     ClientRequest::TasksList(params) => {

--- a/src/server/core_tests.rs
+++ b/src/server/core_tests.rs
@@ -865,17 +865,31 @@ mod tests {
                     "Response should NOT have 'content' field (that would be CallToolResult)"
                 );
 
-                // Verify task fields
-                assert_eq!(result["task"]["taskId"], "t-test-123");
+                // D-STORE-MINTS-ID (finding #3): the wire task.taskId is the
+                // STORE-minted id, NOT the tool's fabricated "t-test-123".
+                let wire_task_id = result["task"]["taskId"]
+                    .as_str()
+                    .expect("task.taskId must be a string");
+                assert_ne!(
+                    wire_task_id, "t-test-123",
+                    "wire id must be the store-minted id, not the tool's fabricated id"
+                );
+                // The tool's value carried no result content, so the task stays
+                // Working (pending) -- no synchronous completion.
                 assert_eq!(result["task"]["status"], "working");
 
-                // Verify _meta with related-task reference (D-08, D-09)
+                // Verify _meta with related-task reference (D-08, D-09) and that
+                // it equals the store-minted wire id.
                 assert!(
                     result.get("_meta").is_some(),
                     "Response should have '_meta' with related-task"
                 );
                 let related = &result["_meta"][RELATED_TASK_META_KEY];
-                assert_eq!(related["taskId"], "t-test-123");
+                assert_eq!(
+                    related["taskId"].as_str(),
+                    Some(wire_task_id),
+                    "_meta task id must equal the wire task.taskId (store-minted)"
+                );
             },
             _ => panic!("Expected successful tool call with CreateTaskResult"),
         }
@@ -994,6 +1008,295 @@ mod tests {
             },
             _ => panic!("Expected successful tool call with CallToolResult"),
         }
+    }
+
+    /// Helper: extract the `Result` payload Value or panic.
+    fn expect_result_payload(
+        response: crate::types::jsonrpc::JSONRPCResponse,
+    ) -> serde_json::Value {
+        match response.payload {
+            crate::types::jsonrpc::ResponsePayload::Result(v) => v,
+            other => panic!("expected Result payload, got: {other:?}"),
+        }
+    }
+
+    /// Helper: extract the error code from an `Error` payload or panic.
+    fn expect_error_code(response: crate::types::jsonrpc::JSONRPCResponse) -> i32 {
+        match response.payload {
+            crate::types::jsonrpc::ResponsePayload::Error(e) => e.code,
+            other => panic!("expected Error payload, got: {other:?}"),
+        }
+    }
+
+    /// Finding #1 + #3 acceptance: a synchronously-completing task tool drives
+    /// create -> the wire id is the store-minted id reflected in BOTH
+    /// `task.taskId` AND `_meta` -> `tasks/get` finds it (not `NotFound`) and
+    /// shows `Completed` -> `tasks/result` returns non-empty
+    /// `CallToolResult.content`.
+    #[tokio::test]
+    async fn test_task_create_roundtrip_store_minted_id_and_typed_result() {
+        use crate::server::task_store::InMemoryTaskStore;
+        use crate::server::typed_tool::TypedTool;
+        use crate::types::tasks::{GetTaskPayloadRequest, GetTaskRequest, RELATED_TASK_META_KEY};
+        use crate::types::{TaskSupport, ToolExecution};
+
+        // Tool returns a Task-shaped value that ALSO carries terminal `content`
+        // (synchronous completion per D-TERMINAL-RESULT-CONTRACT).
+        let task_tool = TypedTool::new_with_schema(
+            "task_tool",
+            json!({"type": "object"}),
+            |_args: serde_json::Value, _extra| {
+                Box::pin(async {
+                    Ok(json!({
+                        "taskId": "tool-fabricated-id",
+                        "status": "working",
+                        "content": [{ "type": "text", "text": "the answer is 42" }]
+                    }))
+                })
+            },
+        )
+        .with_description("A synchronously-completing task tool")
+        .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+
+        let task_store =
+            Arc::new(InMemoryTaskStore::new()) as Arc<dyn crate::server::task_store::TaskStore>;
+
+        let server = ServerCoreBuilder::new()
+            .name("test-server")
+            .version("1.0.0")
+            .tool("task_tool", task_tool)
+            .task_store(task_store)
+            .build()
+            .unwrap();
+
+        server
+            .handle_request(RequestId::from(0i64), create_init_request(), None)
+            .await;
+
+        // create
+        let mut call_req = CallToolRequest::new("task_tool", json!({}));
+        call_req.task = Some(json!({}));
+        let request = Request::Client(Box::new(ClientRequest::CallTool(call_req)));
+        let create = expect_result_payload(
+            server
+                .handle_request(RequestId::from(1i64), request, None)
+                .await,
+        );
+
+        // finding #3: wire task.taskId == _meta id == store-minted (not the tool's)
+        let wire_id = create["task"]["taskId"]
+            .as_str()
+            .expect("task.taskId string")
+            .to_string();
+        assert_ne!(wire_id, "tool-fabricated-id");
+        assert_eq!(
+            create["_meta"][RELATED_TASK_META_KEY]["taskId"].as_str(),
+            Some(wire_id.as_str())
+        );
+        // synchronous completion visible on the create envelope
+        assert_eq!(create["task"]["status"], "completed");
+
+        // tasks/get with the store-minted id finds the task (NOT NotFound)
+        let get_req = Request::Client(Box::new(ClientRequest::TasksGet(GetTaskRequest {
+            task_id: wire_id.clone(),
+        })));
+        let got = expect_result_payload(
+            server
+                .handle_request(RequestId::from(2i64), get_req, None)
+                .await,
+        );
+        assert_eq!(got["task"]["taskId"].as_str(), Some(wire_id.as_str()));
+        assert_eq!(got["task"]["status"], "completed");
+
+        // finding #1: tasks/result returns a typed, NON-EMPTY CallToolResult
+        let result_req = Request::Client(Box::new(ClientRequest::TasksResult(
+            GetTaskPayloadRequest {
+                task_id: wire_id.clone(),
+            },
+        )));
+        let result = expect_result_payload(
+            server
+                .handle_request(RequestId::from(3i64), result_req, None)
+                .await,
+        );
+        let content = result["content"]
+            .as_array()
+            .expect("CallToolResult.content array");
+        assert!(
+            !content.is_empty(),
+            "tasks/result must return non-empty terminal content"
+        );
+        assert_eq!(content[0]["text"], "the answer is 42");
+    }
+
+    /// MED refinement: a pending task (no synchronous result) with a store but
+    /// NO router yields the SPECIFIED not-completed error (-32002), not
+    /// `NotFound` and not the no-backend -32601.
+    #[tokio::test]
+    async fn test_tasks_result_pending_task_returns_specified_error() {
+        use crate::server::task_store::InMemoryTaskStore;
+        use crate::server::typed_tool::TypedTool;
+        use crate::types::tasks::GetTaskPayloadRequest;
+        use crate::types::{TaskSupport, ToolExecution};
+
+        // Tool returns a Task-shaped value with NO content -> task stays pending.
+        let task_tool = TypedTool::new_with_schema(
+            "task_tool",
+            json!({"type": "object"}),
+            |_args: serde_json::Value, _extra| {
+                Box::pin(async { Ok(json!({ "taskId": "pending", "status": "working" })) })
+            },
+        )
+        .with_description("A pending task tool")
+        .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+
+        let task_store =
+            Arc::new(InMemoryTaskStore::new()) as Arc<dyn crate::server::task_store::TaskStore>;
+
+        let server = ServerCoreBuilder::new()
+            .name("test-server")
+            .version("1.0.0")
+            .tool("task_tool", task_tool)
+            .task_store(task_store)
+            .build()
+            .unwrap();
+
+        server
+            .handle_request(RequestId::from(0i64), create_init_request(), None)
+            .await;
+
+        let mut call_req = CallToolRequest::new("task_tool", json!({}));
+        call_req.task = Some(json!({}));
+        let create = expect_result_payload(
+            server
+                .handle_request(
+                    RequestId::from(1i64),
+                    Request::Client(Box::new(ClientRequest::CallTool(call_req))),
+                    None,
+                )
+                .await,
+        );
+        let wire_id = create["task"]["taskId"].as_str().unwrap().to_string();
+        assert_eq!(create["task"]["status"], "working");
+
+        let result_req = Request::Client(Box::new(ClientRequest::TasksResult(
+            GetTaskPayloadRequest { task_id: wire_id },
+        )));
+        let code = expect_error_code(
+            server
+                .handle_request(RequestId::from(2i64), result_req, None)
+                .await,
+        );
+        assert_eq!(
+            code, -32002,
+            "pending task must return the specified not-completed error"
+        );
+    }
+
+    /// Finding #2: with BOTH a `TaskStore` (which has no result for the polled
+    /// id) AND a `TaskRouter`, `tasks/result` FALLS THROUGH to the router
+    /// (router serves it) rather than returning a hard error.
+    #[tokio::test]
+    async fn test_tasks_result_falls_through_to_router_on_store_miss() {
+        use crate::server::task_store::InMemoryTaskStore;
+        use crate::server::tasks::TaskRouter;
+        use crate::types::tasks::GetTaskPayloadRequest;
+
+        // Minimal router that serves tasks/result with a sentinel payload.
+        struct FallbackRouter;
+        #[async_trait]
+        impl TaskRouter for FallbackRouter {
+            async fn handle_task_call(
+                &self,
+                _tool_name: &str,
+                _arguments: serde_json::Value,
+                _task_params: serde_json::Value,
+                _owner_id: &str,
+                _progress_token: Option<serde_json::Value>,
+            ) -> Result<serde_json::Value> {
+                Ok(Value::Null)
+            }
+            async fn handle_tasks_get(
+                &self,
+                _params: serde_json::Value,
+                _owner_id: &str,
+            ) -> Result<serde_json::Value> {
+                Ok(json!({}))
+            }
+            async fn handle_tasks_result(
+                &self,
+                _params: serde_json::Value,
+                _owner_id: &str,
+            ) -> Result<serde_json::Value> {
+                Ok(json!({ "content": [{ "type": "text", "text": "from-router" }] }))
+            }
+            async fn handle_tasks_list(
+                &self,
+                _params: serde_json::Value,
+                _owner_id: &str,
+            ) -> Result<serde_json::Value> {
+                Ok(json!({ "tasks": [] }))
+            }
+            async fn handle_tasks_cancel(
+                &self,
+                _params: serde_json::Value,
+                _owner_id: &str,
+            ) -> Result<serde_json::Value> {
+                Ok(json!({}))
+            }
+            fn resolve_owner(
+                &self,
+                _subject: Option<&str>,
+                _client_id: Option<&str>,
+                _session_id: Option<&str>,
+            ) -> String {
+                "local".to_string()
+            }
+            fn tool_requires_task(
+                &self,
+                _tool_name: &str,
+                _tool_execution: Option<&Value>,
+            ) -> bool {
+                false
+            }
+            fn task_capabilities(&self) -> Value {
+                json!({ "supported": true })
+            }
+        }
+
+        let task_store =
+            Arc::new(InMemoryTaskStore::new()) as Arc<dyn crate::server::task_store::TaskStore>;
+        let router = Arc::new(FallbackRouter) as Arc<dyn crate::server::tasks::TaskRouter>;
+
+        // `with_task_store(Arc<dyn TaskRouter>)` is the (legacy-named) router
+        // setter; `task_store(..)` sets the store. Configure BOTH.
+        let server = ServerCoreBuilder::new()
+            .name("test-server")
+            .version("1.0.0")
+            .task_store(task_store)
+            .with_task_store(router)
+            .build()
+            .unwrap();
+
+        server
+            .handle_request(RequestId::from(0i64), create_init_request(), None)
+            .await;
+
+        // The store has no result for this id -> NotFound -> fall through.
+        let result_req = Request::Client(Box::new(ClientRequest::TasksResult(
+            GetTaskPayloadRequest {
+                task_id: "unknown-to-store".to_string(),
+            },
+        )));
+        let result = expect_result_payload(
+            server
+                .handle_request(RequestId::from(1i64), result_req, None)
+                .await,
+        );
+        assert_eq!(
+            result["content"][0]["text"], "from-router",
+            "tasks/result must fall through to the router on store miss"
+        );
     }
 
     #[tokio::test]

--- a/src/server/task_store.rs
+++ b/src/server/task_store.rs
@@ -22,6 +22,66 @@
 //! These PMCP extensions remain in `pmcp-tasks`. The SDK trait covers
 //! the core MCP spec operations only.
 //!
+//! # Recommended usage: expose a tool as an MCP Task
+//!
+//! The clean, correct-by-construction pattern (Phase 101) is: register a
+//! task-capable tool (a [`TypedTool`](crate::server::typed_tool::TypedTool)
+//! marked [`with_task_support(TaskSupport::Required)`](crate::types::ToolExecution::with_task_support))
+//! plus a [`TaskStore`](crate::server::task_store::TaskStore) on
+//! [`ServerCoreBuilder`](crate::server::builder::ServerCoreBuilder),
+//! then let the SDK serve `tasks/get`, `tasks/result`, `tasks/list`, and
+//! `tasks/cancel` typed. You never hand-write any `tasks/*` wire JSON — the SDK
+//! serializes from the typed structs — and the store mints the task id.
+//!
+//! Registering a store via [`task_store`](crate::server::builder::ServerCoreBuilder::task_store)
+//! also auto-advertises the `tasks` capability in `initialize` (a
+//! [`TaskSupport::Required`](crate::types::tools::TaskSupport::Required) tool
+//! with NO store makes [`build()`](crate::server::builder::ServerCoreBuilder::build)
+//! return an error, never a hollow capability).
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use pmcp::server::builder::ServerCoreBuilder;
+//! use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+//! use pmcp::server::typed_tool::TypedTool;
+//! use pmcp::types::{TaskSupport, ToolExecution};
+//!
+//! # fn build() -> pmcp::Result<()> {
+//! let task_tool = TypedTool::new_with_schema(
+//!     "summarize",
+//!     serde_json::json!({ "type": "object" }),
+//!     |_args: serde_json::Value, _extra| {
+//!         Box::pin(async { Ok(serde_json::json!({ "status": "completed" })) })
+//!     },
+//! )
+//! .with_description("Summarize asynchronously as an MCP Task")
+//! .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required));
+//!
+//! let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+//! let server = ServerCoreBuilder::new()
+//!     .name("my-server")
+//!     .version("1.0.0")
+//!     .tool("summarize", task_tool)
+//!     .task_store(store) // presence of a store auto-advertises the `tasks` capability
+//!     .build()?;
+//! # let _ = server;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The task path currently lives on
+//! [`ServerCoreBuilder`](crate::server::builder::ServerCoreBuilder) /
+//! [`ServerCore`](crate::server::core::ServerCore); the high-level
+//! `pmcp::Server` (and `StreamableHttpServer`) does not yet carry a
+//! [`TaskStore`](crate::server::task_store::TaskStore). See
+//! `examples/s45_tool_as_task_lifecycle.rs` for the full client round-trip
+//! (`initialize → call(task) → tasks/get poll → tasks/result`).
+//!
+//! Note: [`with_task_store(Arc<dyn TaskRouter>)`](crate::server::builder::ServerCoreBuilder::with_task_store)
+//! is the LEGACY experimental (`pmcp-tasks`) path — prefer
+//! [`task_store(...)`](crate::server::builder::ServerCoreBuilder::task_store) +
+//! `with_task_support`.
+//!
 //! # Examples
 //!
 //! ```no_run
@@ -39,6 +99,7 @@ use dashmap::DashMap;
 use std::time::Instant;
 
 use crate::types::tasks::{Task, TaskStatus};
+use crate::types::CallToolResult;
 
 // ---------------------------------------------------------------------------
 // TaskStoreError
@@ -160,6 +221,17 @@ impl Default for StoreConfig {
 /// Implementations must be `Send + Sync` for concurrent access from
 /// multiple request handlers.
 ///
+/// # Recommended usage
+///
+/// To expose a tool as an async MCP Task, register a task-capable
+/// [`TypedTool`](crate::server::typed_tool::TypedTool) plus an implementation
+/// of this trait (e.g. [`InMemoryTaskStore`]) on
+/// [`ServerCoreBuilder::task_store`](crate::server::builder::ServerCoreBuilder::task_store);
+/// the SDK then serves `tasks/get`, `tasks/result`, `tasks/list`, and
+/// `tasks/cancel` typed from the store — you never hand-write `tasks/*` wire
+/// JSON, and the store mints the task id. See the module-level docs and
+/// `examples/s45_tool_as_task_lifecycle.rs` for the full pattern.
+///
 /// # Owner Isolation
 ///
 /// All methods that access a specific task require an `owner_id`. If the
@@ -205,6 +277,117 @@ pub trait TaskStore: Send + Sync {
 
     /// Returns a reference to the store's configuration.
     fn config(&self) -> &StoreConfig;
+
+    /// Persist the terminal [`CallToolResult`](crate::types::CallToolResult)
+    /// for a completed task, scoped to `owner_id`.
+    ///
+    /// This is an **additive** trait method with a default implementation, so
+    /// existing out-of-tree [`TaskStore`] implementations keep compiling. The
+    /// default returns [`TaskStoreError::Internal`] to signal — explicitly,
+    /// never silently — that the store does not persist terminal results.
+    /// Stores that DO persist results (e.g. [`InMemoryTaskStore`]) override
+    /// this method and also override [`TaskStore::supports_results`] to return
+    /// `true`.
+    ///
+    /// Implementations MUST scope the write by `owner_id` (mirroring
+    /// [`TaskStore::get`] / [`TaskStore::cancel`]) so one owner cannot set a
+    /// result on another owner's task.
+    ///
+    /// # Errors
+    ///
+    /// The default implementation always returns [`TaskStoreError::Internal`]
+    /// ("store does not support terminal results"). Overriding implementations
+    /// return [`TaskStoreError::NotFound`] when the task does not exist or
+    /// belongs to a different owner.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+    /// use pmcp::types::CallToolResult;
+    /// use pmcp::types::Content;
+    ///
+    /// # async fn example() {
+    /// let store = InMemoryTaskStore::new();
+    /// let task = store.create("owner-1", None).await.unwrap();
+    /// let result = CallToolResult::new(vec![Content::text("done")]);
+    /// store
+    ///     .set_result(&task.task_id, "owner-1", result)
+    ///     .await
+    ///     .unwrap();
+    /// # }
+    /// ```
+    async fn set_result(
+        &self,
+        task_id: &str,
+        _owner_id: &str,
+        _result: crate::types::CallToolResult,
+    ) -> Result<(), TaskStoreError> {
+        let _ = task_id;
+        Err(TaskStoreError::Internal {
+            message: "store does not support terminal results".to_string(),
+        })
+    }
+
+    /// Retrieve the persisted terminal
+    /// [`CallToolResult`](crate::types::CallToolResult) for a task, scoped to
+    /// `owner_id`.
+    ///
+    /// This is an **additive** trait method with a default implementation. The
+    /// default returns [`TaskStoreError::NotFound`] — a store that does not
+    /// persist results has none to return. Stores that persist results
+    /// override this method.
+    ///
+    /// Implementations MUST return [`TaskStoreError::NotFound`] (never a
+    /// distinct error) on owner mismatch, so the existence of another owner's
+    /// task is never revealed. A task that exists but has no stored result yet
+    /// (still pending) also returns [`TaskStoreError::NotFound`]; the dispatch
+    /// layer turns that signal into a specified "not completed" error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TaskStoreError::NotFound`] when no result is available for the
+    /// task under the given owner (task absent, owner mismatch, or pending).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+    /// use pmcp::types::{CallToolResult, Content};
+    ///
+    /// # async fn example() {
+    /// let store = InMemoryTaskStore::new();
+    /// let task = store.create("owner-1", None).await.unwrap();
+    /// let result = CallToolResult::new(vec![Content::text("done")]);
+    /// store
+    ///     .set_result(&task.task_id, "owner-1", result)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let fetched = store.get_result(&task.task_id, "owner-1").await.unwrap();
+    /// assert_eq!(fetched.content.len(), 1);
+    /// # }
+    /// ```
+    async fn get_result(
+        &self,
+        task_id: &str,
+        _owner_id: &str,
+    ) -> Result<crate::types::CallToolResult, TaskStoreError> {
+        Err(TaskStoreError::NotFound {
+            task_id: task_id.to_string(),
+        })
+    }
+
+    /// Whether this store persists terminal results
+    /// (i.e. [`TaskStore::set_result`] / [`TaskStore::get_result`] are real).
+    ///
+    /// Defaults to `false`. The dispatch layer consults this before serving the
+    /// store-result path, so a store that cannot persist results falls through
+    /// to the [`TaskRouter`](crate::server::tasks::TaskRouter) instead of
+    /// silently dropping or serving empty results.
+    fn supports_results(&self) -> bool {
+        false
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -212,11 +395,17 @@ pub trait TaskStore: Send + Sync {
 // ---------------------------------------------------------------------------
 
 /// Internal record wrapping a [`Task`] with owner and expiration metadata.
+///
+/// The `result` field holds the terminal [`CallToolResult`] for a completed
+/// task. It lives on this INTERNAL record (never on the wire [`Task`], whose
+/// shape is locked) so it is purged together with the task by
+/// [`InMemoryTaskStore::cleanup_expired`] — no separate unexpiring map.
 #[derive(Debug)]
 struct TaskRecord {
     task: Task,
     owner_id: String,
     expires_at: Option<Instant>,
+    result: Option<CallToolResult>,
 }
 
 // ---------------------------------------------------------------------------
@@ -340,6 +529,7 @@ impl TaskStore for InMemoryTaskStore {
             task: task.clone(),
             owner_id: owner_id.to_string(),
             expires_at,
+            result: None,
         };
 
         self.records.insert(task_id, record);
@@ -442,6 +632,51 @@ impl TaskStore for InMemoryTaskStore {
 
     fn config(&self) -> &StoreConfig {
         &self.config
+    }
+
+    async fn set_result(
+        &self,
+        task_id: &str,
+        owner_id: &str,
+        result: CallToolResult,
+    ) -> Result<(), TaskStoreError> {
+        let mut entry = self
+            .records
+            .get_mut(task_id)
+            .ok_or_else(|| TaskStoreError::NotFound {
+                task_id: task_id.to_string(),
+            })?;
+        let record = entry.value_mut();
+        Self::validate_access(record, task_id, owner_id)?;
+        record.result = Some(result);
+        Ok(())
+    }
+
+    async fn get_result(
+        &self,
+        task_id: &str,
+        owner_id: &str,
+    ) -> Result<CallToolResult, TaskStoreError> {
+        let entry = self
+            .records
+            .get(task_id)
+            .ok_or_else(|| TaskStoreError::NotFound {
+                task_id: task_id.to_string(),
+            })?;
+        Self::validate_access(entry.value(), task_id, owner_id)?;
+        // A task that exists but has no stored result yet is "pending" — signal
+        // NotFound so the dispatch layer can map it to a specified error.
+        entry
+            .value()
+            .result
+            .clone()
+            .ok_or_else(|| TaskStoreError::NotFound {
+                task_id: task_id.to_string(),
+            })
+    }
+
+    fn supports_results(&self) -> bool {
+        true
     }
 }
 
@@ -828,5 +1063,154 @@ mod tests {
         // Owner B should still be able to create
         let result = store.create("owner-b", None).await;
         assert!(result.is_ok());
+    }
+
+    // -- Terminal result (set_result / get_result / supports_results) tests --
+
+    use crate::types::{CallToolResult, Content};
+
+    fn sample_result(text: &str) -> CallToolResult {
+        CallToolResult::new(vec![Content::text(text)])
+    }
+
+    #[tokio::test]
+    async fn set_then_get_result_round_trips() {
+        let store = InMemoryTaskStore::new();
+        let created = store.create("owner-1", None).await.unwrap();
+        store
+            .set_result(&created.task_id, "owner-1", sample_result("hello"))
+            .await
+            .unwrap();
+        let fetched = store.get_result(&created.task_id, "owner-1").await.unwrap();
+        assert_eq!(fetched.content.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn get_result_owner_mismatch_returns_not_found() {
+        let store = InMemoryTaskStore::new();
+        let created = store.create("owner-1", None).await.unwrap();
+        store
+            .set_result(&created.task_id, "owner-1", sample_result("secret"))
+            .await
+            .unwrap();
+        let result = store.get_result(&created.task_id, "owner-2").await;
+        assert!(
+            matches!(result, Err(TaskStoreError::NotFound { .. })),
+            "cross-owner read must be NotFound, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_result_owner_mismatch_returns_not_found() {
+        let store = InMemoryTaskStore::new();
+        let created = store.create("owner-1", None).await.unwrap();
+        let result = store
+            .set_result(&created.task_id, "owner-2", sample_result("x"))
+            .await;
+        assert!(
+            matches!(result, Err(TaskStoreError::NotFound { .. })),
+            "cross-owner set must be NotFound, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_result_existing_task_no_result_returns_not_found() {
+        let store = InMemoryTaskStore::new();
+        let created = store.create("owner-1", None).await.unwrap();
+        // Task exists but no result was ever set -> pending signal.
+        let result = store.get_result(&created.task_id, "owner-1").await;
+        assert!(
+            matches!(result, Err(TaskStoreError::NotFound { .. })),
+            "pending task (no result) must be NotFound, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_supports_results() {
+        let store = InMemoryTaskStore::new();
+        assert!(store.supports_results());
+    }
+
+    #[tokio::test]
+    async fn cleanup_expired_drops_result() {
+        let store = InMemoryTaskStore::with_config(StoreConfig {
+            default_ttl_ms: Some(1),
+            ..StoreConfig::default()
+        });
+        let created = store.create("owner-1", Some(1)).await.unwrap();
+        store
+            .set_result(&created.task_id, "owner-1", sample_result("ephemeral"))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let removed = store.cleanup_expired().await.unwrap();
+        assert_eq!(removed, 1);
+        // Result is gone along with the task (no separate unexpiring map).
+        let result = store.get_result(&created.task_id, "owner-1").await;
+        assert!(matches!(result, Err(TaskStoreError::NotFound { .. })));
+    }
+
+    /// A store that does NOT override the additive result methods — exercises
+    /// the explicit-unsupported defaults.
+    struct DefaultOnlyStore {
+        config: StoreConfig,
+    }
+
+    #[async_trait]
+    impl TaskStore for DefaultOnlyStore {
+        async fn create(&self, _owner_id: &str, _ttl: Option<u64>) -> Result<Task, TaskStoreError> {
+            Ok(Task::new("default-only", TaskStatus::Working))
+        }
+        async fn get(&self, task_id: &str, _owner_id: &str) -> Result<Task, TaskStoreError> {
+            Ok(Task::new(task_id, TaskStatus::Working))
+        }
+        async fn update_status(
+            &self,
+            task_id: &str,
+            _owner_id: &str,
+            status: TaskStatus,
+            _message: Option<String>,
+        ) -> Result<Task, TaskStoreError> {
+            Ok(Task::new(task_id, status))
+        }
+        async fn list(
+            &self,
+            _owner_id: &str,
+            _cursor: Option<&str>,
+        ) -> Result<(Vec<Task>, Option<String>), TaskStoreError> {
+            Ok((Vec::new(), None))
+        }
+        async fn cancel(&self, task_id: &str, _owner_id: &str) -> Result<Task, TaskStoreError> {
+            Ok(Task::new(task_id, TaskStatus::Cancelled))
+        }
+        async fn cleanup_expired(&self) -> Result<usize, TaskStoreError> {
+            Ok(0)
+        }
+        fn config(&self) -> &StoreConfig {
+            &self.config
+        }
+        // Deliberately does NOT override set_result/get_result/supports_results.
+    }
+
+    #[tokio::test]
+    async fn default_impl_store_reports_unsupported() {
+        let store = DefaultOnlyStore {
+            config: StoreConfig::default(),
+        };
+        assert!(!store.supports_results());
+
+        let set = store.set_result("t", "owner-1", sample_result("x")).await;
+        assert!(
+            matches!(set, Err(TaskStoreError::Internal { .. })),
+            "default set_result must be an explicit unsupported error, got: {set:?}"
+        );
+
+        let get = store.get_result("t", "owner-1").await;
+        assert!(
+            matches!(get, Err(TaskStoreError::NotFound { .. })),
+            "default get_result must be NotFound, got: {get:?}"
+        );
     }
 }

--- a/src/server/task_store.rs
+++ b/src/server/task_store.rs
@@ -278,7 +278,7 @@ pub trait TaskStore: Send + Sync {
     /// Returns a reference to the store's configuration.
     fn config(&self) -> &StoreConfig;
 
-    /// Persist the terminal [`CallToolResult`](crate::types::CallToolResult)
+    /// Persist the terminal [`CallToolResult`]
     /// for a completed task, scoped to `owner_id`.
     ///
     /// This is an **additive** trait method with a default implementation, so
@@ -330,7 +330,7 @@ pub trait TaskStore: Send + Sync {
     }
 
     /// Retrieve the persisted terminal
-    /// [`CallToolResult`](crate::types::CallToolResult) for a task, scoped to
+    /// [`CallToolResult`] for a task, scoped to
     /// `owner_id`.
     ///
     /// This is an **additive** trait method with a default implementation. The

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,0 +1,116 @@
+//! Conformance helpers for proving the `tasks/*` wire surface round-trips
+//! through the SDK's real client deserialization types.
+//!
+//! **Why this module exists.** The tools-as-tasks incident (Phase 101) was
+//! caused by hand-written `tasks/*` JSON diverging from the typed structs the
+//! client deserializes into. A regression test fed the helper an
+//! *author-written fixture* and passed green while the live wire path failed.
+//! The lesson, adopted as an acceptance gate: for protocol-shape requirements,
+//! "resolved" is gated on feeding the **actual server dispatch output** through
+//! the real client type, never a hand-built value.
+//!
+//! [`assert_roundtrips_through_client`] is the primitive that enforces this. It
+//! is feature-gated behind `testing` (folded into the `full` feature set) so it
+//! is available to the integration tests / examples and the quality gate, but
+//! omitted from lean default release builds.
+
+use serde::de::DeserializeOwned;
+
+/// Assert that real server dispatch output deserializes into the client type
+/// `T`, panicking with a diagnostic message if it does not.
+///
+/// Feed this the `serde_json::Value` carried by an actual
+/// `ResponsePayload::Result(..)` produced by
+/// [`ServerCore::handle_request`](crate::server::core::ProtocolHandler::handle_request)
+/// — **never** an author-written fixture. If `real_dispatch_output` does not
+/// deserialize into `T`, the call panics with a message naming `T`, the serde
+/// error, and the pretty-printed offending output.
+///
+/// # Type Parameters
+///
+/// - `T`: a client-facing wire type such as
+///   [`GetTaskResult`](crate::types::tasks::GetTaskResult),
+///   [`CallToolResult`](crate::types::CallToolResult), or
+///   [`CreateTaskResult`](crate::types::tasks::CreateTaskResult). Because serde
+///   ignores unknown fields by default, the extra `_meta` carried by the
+///   create envelope deserializes cleanly into `CreateTaskResult`.
+///
+/// # Panics
+///
+/// Panics if `real_dispatch_output` cannot be deserialized into `T`. This is
+/// the intended behavior in a test context: a deliberately-wrong wire shape
+/// (e.g. a flat `Task` where a `{ "task": ... }` wrapper is expected) makes the
+/// helper fail loudly.
+///
+/// # Examples
+///
+/// ```rust
+/// use pmcp::testing::assert_roundtrips_through_client;
+/// use pmcp::types::tasks::{GetTaskResult, Task, TaskStatus};
+///
+/// // A correctly-shaped `tasks/get` payload wraps the task under `task`.
+/// let task = Task::new("t-1", TaskStatus::Working)
+///     .with_timestamps("2026-06-21T00:00:00Z", "2026-06-21T00:00:00Z");
+/// let dispatch_output = serde_json::to_value(GetTaskResult::new(task)).unwrap();
+///
+/// // Deserializes cleanly into the client type — returns normally.
+/// assert_roundtrips_through_client::<GetTaskResult>(dispatch_output);
+/// ```
+pub fn assert_roundtrips_through_client<T>(real_dispatch_output: serde_json::Value)
+where
+    T: DeserializeOwned,
+{
+    // Pre-render the diagnostic before moving the owned value into `from_value`
+    // (the value is consumed by the deserialize, so it is genuinely owned — not
+    // merely borrowed).
+    let pretty = serde_json::to_string_pretty(&real_dispatch_output)
+        .unwrap_or_else(|_| real_dispatch_output.to_string());
+    if let Err(error) = serde_json::from_value::<T>(real_dispatch_output) {
+        panic!(
+            "dispatch output does not deserialize into `{}`: {error}\noffending output was:\n{pretty}",
+            std::any::type_name::<T>(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::assert_roundtrips_through_client;
+    use crate::types::tasks::{CreateTaskResult, GetTaskResult, Task, TaskStatus};
+
+    fn sample_task() -> Task {
+        Task::new("t-positive", TaskStatus::Working)
+            .with_timestamps("2026-06-21T00:00:00Z", "2026-06-21T00:00:00Z")
+    }
+
+    #[test]
+    fn passes_on_valid_get_task_result() {
+        let value = serde_json::to_value(GetTaskResult::new(sample_task())).unwrap();
+        assert_roundtrips_through_client::<GetTaskResult>(value);
+    }
+
+    #[test]
+    fn passes_on_valid_create_task_result() {
+        // The create envelope serializes as `{ "task": { .. } }`; serde ignores
+        // any extra `_meta` the live dispatch envelope also carries.
+        let mut value = serde_json::to_value(CreateTaskResult::new(sample_task())).unwrap();
+        value.as_object_mut().unwrap().insert(
+            "_meta".to_string(),
+            serde_json::json!({ "io.modelcontextprotocol/related-task": { "taskId": "t-positive" } }),
+        );
+        assert_roundtrips_through_client::<CreateTaskResult>(value);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not deserialize into")]
+    fn panics_on_exact_historical_flat_task_shape() {
+        // The EXACT historical bug: a serialized `Task` with top-level `taskId`
+        // / `status`, NOT wrapped in `{ "task": ... }`. Feeding this into
+        // `GetTaskResult` (which requires the `task` wrapper) must panic.
+        let flat_task = serde_json::to_value(Task::new("t-1", TaskStatus::Working)).unwrap();
+        // Sanity: the flat shape really does have a top-level `taskId`.
+        assert!(flat_task.get("taskId").is_some());
+        assert!(flat_task.get("task").is_none());
+        assert_roundtrips_through_client::<GetTaskResult>(flat_task);
+    }
+}

--- a/src/types/tools.rs
+++ b/src/types/tools.rs
@@ -151,6 +151,17 @@ impl ToolExecution {
     }
 
     /// Set the task support level.
+    ///
+    /// Marking a tool with [`TaskSupport::Required`] and registering a
+    /// [`TaskStore`](crate::server::task_store::TaskStore) on the server (via
+    /// [`ServerCoreBuilder::task_store`](crate::server::builder::ServerCoreBuilder::task_store))
+    /// is how you expose a tool as an async MCP Task: the SDK then serves
+    /// `tasks/get`, `tasks/result`, `tasks/list`, and `tasks/cancel` typed from
+    /// the store. See `examples/s45_tool_as_task_lifecycle.rs` for the full
+    /// pattern.
+    ///
+    /// A `Required` tool with no task backend makes the server's `build()`
+    /// return an error (never a hollow `tasks` capability).
     pub fn with_task_support(mut self, support: TaskSupport) -> Self {
         self.task_support = Some(support);
         self
@@ -158,6 +169,13 @@ impl ToolExecution {
 }
 
 /// Task support level for a tool.
+///
+/// Set this via
+/// [`ToolExecution::with_task_support`]. Pairing
+/// [`TaskSupport::Required`] with a
+/// [`TaskStore`](crate::server::task_store::TaskStore) on the server is the
+/// recommended way to expose a tool as an async MCP Task — see
+/// `examples/s45_tool_as_task_lifecycle.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TaskSupport {

--- a/tests/tool_as_task_lifecycle.rs
+++ b/tests/tool_as_task_lifecycle.rs
@@ -1,0 +1,485 @@
+//! Tools-as-Tasks live round-trip acceptance gate (Phase 101, TASKDX-04/05).
+//!
+//! This is the phase's acceptance gate: a LIVE in-process client round-trip
+//! through the real `pmcp::Client` deserialization types, plus the
+//! `pmcp::testing::assert_roundtrips_through_client` conformance helper fed
+//! ACTUAL `ServerCore::handle_request` dispatch output (never an author-written
+//! fixture). It proves all four original wire-shape bugs are impossible on the
+//! SDK path:
+//!
+//! - finding #1 — typed, non-empty `tasks/result` from a persisted terminal
+//!   `CallToolResult` (and a specified pending-result error before completion).
+//! - finding #3 — id consistency: `CreateTaskResult.task.taskId` ==
+//!   `tasks/get` task id == `_meta.relatedTask.taskId` (all the store-minted id).
+//! - finding #4 — `initialize` through the real client observes the
+//!   auto-advertised `tasks` capability.
+//!
+//! The high-level `pmcp::Server` (and thus `StreamableHttpServer`) does NOT
+//! carry a `TaskStore`; the task path lives on `ServerCore`. So the loopback
+//! harness here pairs a real `pmcp::Client` with a `ServerCore` over an
+//! in-process duplex transport (the equivalent of the HTTP loopback for the
+//! task-bearing dispatch path).
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use pmcp::server::builder::ServerCoreBuilder;
+use pmcp::server::core::ProtocolHandler;
+use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+use pmcp::server::typed_tool::TypedTool;
+use pmcp::shared::{Transport, TransportMessage};
+use pmcp::types::tasks::{CreateTaskResult, GetTaskResult, RELATED_TASK_META_KEY};
+use pmcp::types::{
+    CallToolRequest, CallToolResult, ClientCapabilities, ClientRequest, GetTaskPayloadRequest,
+    GetTaskRequest, InitializeRequest, Request, RequestId, TaskSupport, ToolExecution,
+};
+use pmcp::{Client, Error, ErrorCode};
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// In-process duplex transport (client <-> ServerCore), mpsc-backed.
+// ---------------------------------------------------------------------------
+
+/// One half of an in-process duplex transport. The client side sends Requests
+/// and receives Responses; the server side does the reverse. This is the
+/// minimal pump the `Client` request/response loop needs (send then receive).
+#[derive(Debug)]
+struct DuplexTransport {
+    tx: mpsc::UnboundedSender<TransportMessage>,
+    rx: mpsc::UnboundedReceiver<TransportMessage>,
+    connected: bool,
+}
+
+impl DuplexTransport {
+    /// Create a connected client/server transport pair.
+    fn pair() -> (Self, Self) {
+        let (client_tx, server_rx) = mpsc::unbounded_channel();
+        let (server_tx, client_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                tx: client_tx,
+                rx: client_rx,
+                connected: true,
+            },
+            Self {
+                tx: server_tx,
+                rx: server_rx,
+                connected: true,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl Transport for DuplexTransport {
+    async fn send(&mut self, message: TransportMessage) -> pmcp::Result<()> {
+        self.tx
+            .send(message)
+            .map_err(|_| Error::internal("duplex peer dropped"))
+    }
+
+    async fn receive(&mut self) -> pmcp::Result<TransportMessage> {
+        self.rx
+            .recv()
+            .await
+            .ok_or_else(|| Error::internal("duplex peer closed"))
+    }
+
+    async fn close(&mut self) -> pmcp::Result<()> {
+        self.connected = false;
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    fn transport_type(&self) -> &'static str {
+        "in-process-duplex"
+    }
+}
+
+/// Spawn a server pump that serves `handler` over the server side of a duplex
+/// transport: receive Request, dispatch, send Response. Runs until the client
+/// side is dropped.
+fn spawn_server_pump(mut server_transport: DuplexTransport, handler: Arc<dyn ProtocolHandler>) {
+    tokio::spawn(async move {
+        while let Ok(message) = server_transport.receive().await {
+            if let TransportMessage::Request { id, request } = message {
+                let response = handler.handle_request(id, request, None).await;
+                if server_transport
+                    .send(TransportMessage::Response(response))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tool builders.
+// ---------------------------------------------------------------------------
+
+/// A `with_task_support` tool whose handler returns a Task-shaped value that
+/// ALSO carries a nested `result` (the terminal `CallToolResult`). The dispatch
+/// task-detection requires `taskId` + `status` to enter the task path, and
+/// `extract_terminal_result` lifts the nested `result` so plan 01's
+/// synchronous-completion path records create + `set_result` + Completed before
+/// returning. Polling therefore observes `Completed` deterministically, and
+/// `tasks/result` serves a non-empty terminal `CallToolResult`.
+fn completing_task_tool() -> impl pmcp::ToolHandler {
+    TypedTool::new_with_schema(
+        "complete_now",
+        serde_json::json!({ "type": "object" }),
+        |_args: serde_json::Value, _extra| {
+            Box::pin(async {
+                Ok(serde_json::json!({
+                    "taskId": "tool-fabricated",
+                    "status": "completed",
+                    "ttl": 60000,
+                    "createdAt": "2026-06-21T00:00:00Z",
+                    "lastUpdatedAt": "2026-06-21T00:00:00Z",
+                    "result": {
+                        "content": [ { "type": "text", "text": "terminal result payload" } ]
+                    }
+                }))
+            })
+        },
+    )
+    .with_description("A task tool that completes synchronously with content")
+    .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required))
+}
+
+/// A `with_task_support` tool whose handler returns NO result content (only task
+/// metadata), so the task stays genuinely pending — used to prove the specified
+/// not-completed error from `tasks/result`.
+fn pending_task_tool() -> impl pmcp::ToolHandler {
+    TypedTool::new_with_schema(
+        "stay_pending",
+        serde_json::json!({ "type": "object" }),
+        |_args: serde_json::Value, _extra| {
+            Box::pin(async {
+                Ok(serde_json::json!({
+                    "taskId": "tool-fabricated",
+                    "status": "working",
+                    "ttl": 60000,
+                    "createdAt": "2026-06-21T00:00:00Z",
+                    "lastUpdatedAt": "2026-06-21T00:00:00Z"
+                }))
+            })
+        },
+    )
+    .with_description("A task tool that stays pending (no terminal content)")
+    .with_execution(ToolExecution::new().with_task_support(TaskSupport::Required))
+}
+
+fn init_request() -> Request {
+    Request::Client(Box::new(ClientRequest::Initialize(InitializeRequest::new(
+        pmcp::types::Implementation::new("test-client", "1.0.0"),
+        ClientCapabilities::default(),
+    ))))
+}
+
+fn build_completing_server() -> Arc<dyn ProtocolHandler> {
+    let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+    Arc::new(
+        ServerCoreBuilder::new()
+            .name("task-lifecycle-server")
+            .version("1.0.0")
+            .tool("complete_now", completing_task_tool())
+            .task_store(store)
+            .build()
+            .expect("server builds"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Live client round-trip (findings #1, #3, #4) over the duplex transport.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_round_trip_typed_lifecycle_id_consistency_and_capability() {
+    let server = build_completing_server();
+    let (client_transport, server_transport) = DuplexTransport::pair();
+    spawn_server_pump(server_transport, server);
+
+    let mut client = Client::new(client_transport);
+
+    // finding #4: initialize through the real client sees the advertised `tasks`
+    // capability (TASKDX-02 end-to-end via an endpoint-backed server).
+    let init = client
+        .initialize(ClientCapabilities::default())
+        .await
+        .expect("initialize succeeds");
+    assert!(
+        init.capabilities.tasks.is_some(),
+        "server must auto-advertise the `tasks` capability (TASKDX-02)"
+    );
+
+    // call(tool with task) -> CreateTaskResult with the store-minted id.
+    let response = client
+        .call_tool_with_task("complete_now".to_string(), serde_json::json!({}))
+        .await
+        .expect("task-augmented call succeeds");
+    let client_task_id = match response {
+        pmcp::ToolCallResponse::Task(task) => task.task_id,
+        pmcp::ToolCallResponse::Result(_) => panic!("expected a created task, got a sync result"),
+    };
+    assert_ne!(
+        client_task_id, "tool-fabricated",
+        "wire id must be the store-minted id, not a tool-fabricated one"
+    );
+
+    // Poll tasks/get until terminal; the polled id must equal the client id
+    // (finding #3 — proves it is the store-minted, pollable id, not a 404).
+    let mut polled = client.tasks_get(&client_task_id).await.expect("tasks/get");
+    for _ in 0..50 {
+        assert_eq!(
+            polled.task_id, client_task_id,
+            "polled task id must equal the client-observed (store-minted) id"
+        );
+        if polled.status.is_terminal() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        polled = client.tasks_get(&client_task_id).await.expect("tasks/get");
+    }
+    assert!(
+        polled.status.is_terminal(),
+        "task should reach a terminal status (synchronous completion)"
+    );
+
+    // finding #1: typed, non-empty CallToolResult from tasks/result.
+    let result = client
+        .tasks_result(&client_task_id)
+        .await
+        .expect("tasks/result succeeds");
+    assert!(
+        !result.content.is_empty(),
+        "tasks/result must carry the persisted non-empty terminal content"
+    );
+}
+
+/// finding #3 (the `_meta` leg): the create envelope's
+/// `_meta.relatedTask.taskId` equals the wire `task.taskId` (the store-minted
+/// id). The client's `call_tool_with_task` discards `_meta`, so this leg is
+/// asserted against the REAL `handle_request` envelope.
+#[tokio::test]
+async fn create_envelope_meta_related_task_id_matches_wire_task_id() {
+    let server = build_completing_server();
+    server
+        .handle_request(RequestId::from(0i64), init_request(), None)
+        .await;
+
+    let mut call = CallToolRequest::new("complete_now", serde_json::json!({}));
+    call.task = Some(serde_json::json!({}));
+    let response = server
+        .handle_request(
+            RequestId::from(1i64),
+            Request::Client(Box::new(ClientRequest::CallTool(call))),
+            None,
+        )
+        .await;
+
+    let value = expect_result(response);
+    let wire_id = value["task"]["taskId"]
+        .as_str()
+        .expect("task.taskId is a string");
+    let meta_id = value["_meta"][RELATED_TASK_META_KEY]["taskId"]
+        .as_str()
+        .expect("_meta.relatedTask.taskId is a string");
+    assert_eq!(
+        wire_id, meta_id,
+        "_meta.relatedTask.taskId must equal the wire task.taskId (store-minted)"
+    );
+}
+
+/// finding #1 (MED): `tasks/result` on a not-yet-Completed task returns the
+/// SPECIFIED not-completed error (`-32002`), surfaced through the live client —
+/// distinct from `NotFound`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pending_task_result_returns_specified_not_completed_error() {
+    let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+    let server: Arc<dyn ProtocolHandler> = Arc::new(
+        ServerCoreBuilder::new()
+            .name("pending-server")
+            .version("1.0.0")
+            .tool("stay_pending", pending_task_tool())
+            .task_store(store)
+            .build()
+            .expect("server builds"),
+    );
+
+    let (client_transport, server_transport) = DuplexTransport::pair();
+    spawn_server_pump(server_transport, server);
+    let mut client = Client::new(client_transport);
+    client
+        .initialize(ClientCapabilities::default())
+        .await
+        .expect("initialize");
+
+    let response = client
+        .call_tool_with_task("stay_pending".to_string(), serde_json::json!({}))
+        .await
+        .expect("task-augmented call");
+    let task_id = match response {
+        pmcp::ToolCallResponse::Task(task) => task.task_id,
+        pmcp::ToolCallResponse::Result(_) => panic!("expected a created (pending) task"),
+    };
+
+    let err = client
+        .tasks_result(&task_id)
+        .await
+        .expect_err("pending task result must be an error, not Ok");
+    assert_eq!(
+        err.error_code(),
+        Some(ErrorCode(-32002)),
+        "pending tasks/result must return the specified -32002 not-completed error, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Conformance helper on REAL dispatch output (TASKDX-04, finding repudiation).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn conformance_helper_consumes_real_dispatch_output_for_all_three_types() {
+    let server = build_completing_server();
+    server
+        .handle_request(RequestId::from(0i64), init_request(), None)
+        .await;
+
+    // create -> CreateTaskResult envelope (serde ignores the extra _meta).
+    let mut call = CallToolRequest::new("complete_now", serde_json::json!({}));
+    call.task = Some(serde_json::json!({}));
+    let create_value = expect_result(
+        server
+            .handle_request(
+                RequestId::from(1i64),
+                Request::Client(Box::new(ClientRequest::CallTool(call))),
+                None,
+            )
+            .await,
+    );
+    pmcp::testing::assert_roundtrips_through_client::<CreateTaskResult>(create_value.clone());
+
+    let task_id = create_value["task"]["taskId"]
+        .as_str()
+        .expect("task id")
+        .to_string();
+
+    // tasks/get -> GetTaskResult.
+    let get_value = expect_result(
+        server
+            .handle_request(
+                RequestId::from(2i64),
+                Request::Client(Box::new(ClientRequest::TasksGet(GetTaskRequest {
+                    task_id: task_id.clone(),
+                }))),
+                None,
+            )
+            .await,
+    );
+    pmcp::testing::assert_roundtrips_through_client::<GetTaskResult>(get_value);
+
+    // tasks/result -> CallToolResult.
+    let result_value = expect_result(
+        server
+            .handle_request(
+                RequestId::from(3i64),
+                Request::Client(Box::new(ClientRequest::TasksResult(
+                    GetTaskPayloadRequest { task_id },
+                ))),
+                None,
+            )
+            .await,
+    );
+    pmcp::testing::assert_roundtrips_through_client::<CallToolResult>(result_value);
+}
+
+fn expect_result(response: pmcp::types::JSONRPCResponse) -> serde_json::Value {
+    match response.payload {
+        pmcp::types::jsonrpc::ResponsePayload::Result(value) => value,
+        pmcp::types::jsonrpc::ResponsePayload::Error(error) => {
+            panic!("expected a result payload, got error: {error:?}")
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constrained property round-trips (NOT arbitrary full protocol values).
+// ---------------------------------------------------------------------------
+
+mod property {
+    use pmcp::server::task_store::{InMemoryTaskStore, TaskStore};
+    use pmcp::types::tasks::TaskStatus;
+    use pmcp::types::{CallToolResult, Content};
+    use proptest::prelude::*;
+
+    /// A bounded `TaskStatus` strategy — a small enum, not arbitrary values.
+    fn task_status_strategy() -> impl Strategy<Value = TaskStatus> {
+        prop_oneof![
+            Just(TaskStatus::Working),
+            Just(TaskStatus::Completed),
+            Just(TaskStatus::Failed),
+            Just(TaskStatus::Cancelled),
+        ]
+    }
+
+    /// A bounded `CallToolResult` strategy: 0..=3 short text-content items.
+    fn call_tool_result_strategy() -> impl Strategy<Value = CallToolResult> {
+        proptest::collection::vec("[a-z ]{0,16}", 0..=3)
+            .prop_map(|texts| CallToolResult::new(texts.into_iter().map(Content::text).collect()))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(48))]
+
+        /// CallToolResult survives serde_json::to_value -> from_value unchanged
+        /// in content arity (the exact transform the wire path performs).
+        #[test]
+        fn call_tool_result_serde_round_trip(result in call_tool_result_strategy()) {
+            let value = serde_json::to_value(&result).expect("serialize");
+            let back: CallToolResult = serde_json::from_value(value).expect("deserialize");
+            prop_assert_eq!(back.content.len(), result.content.len());
+        }
+
+        /// TaskStatus survives serde round-trip and terminal classification is stable.
+        #[test]
+        fn task_status_serde_round_trip(status in task_status_strategy()) {
+            let value = serde_json::to_value(status).expect("serialize");
+            let back: TaskStatus = serde_json::from_value(value).expect("deserialize");
+            prop_assert_eq!(back.is_terminal(), status.is_terminal());
+        }
+
+        /// A persisted CallToolResult round-trips through store set_result ->
+        /// get_result (owner-scoped) for a bounded set of generated values.
+        #[test]
+        fn store_set_get_result_round_trip(result in call_tool_result_strategy()) {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let store = InMemoryTaskStore::new();
+                let task = store.create("owner-1", Some(60_000)).await.expect("create");
+                store
+                    .set_result(&task.task_id, "owner-1", result.clone())
+                    .await
+                    .expect("set_result");
+                let fetched = store
+                    .get_result(&task.task_id, "owner-1")
+                    .await
+                    .expect("get_result");
+                prop_assert_eq!(fetched.content.len(), result.content.len());
+                Ok(())
+            })
+            .unwrap();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Tools-as-Tasks server DX — correct-by-construction task lifecycle** (pmcp `2.9.0 → 2.10.0`, minor).

Make a server that exposes a tool as an MCP **Task** (async, pollable) correct-by-construction: the entire `tasks/*` wire surface is served from the SDK's typed structs, so a server and the client agree by construction. This eliminates the class of silent shape-mismatch bugs that came from hand-writing the `tasks/*` protocol (the failure mode reported by the pmcp.run team, who hit four such bugs hand-rolling `_meta` placement, the `tasks` capability, flat `tasks/get`, and the `tasks/result` shape). **Additive — no breaking changes**; extends the existing `TaskStore` path.

**Status:** Verified ✓ (goal-backward verification passed 5/5 against the live tests, not just task completion). `make quality-gate` green.

## Changes

- **`tasks/result` served typed from the `TaskStore`** (`CallToolResult`), with `TaskRouter` fall-through for the legacy path. A tool-created task is now actually pollable: the store mints the task id, written to **both** the wire `task.taskId` and the `_meta` related-task link (previously the create path reused the tool's fabricated id, so `tasks/get` returned `NotFound`).
- **Additive `TaskStore` methods** — `set_result` / `get_result` / `supports_results`, all with default impls (existing stores keep compiling). A not-yet-completed `tasks/result` returns a *specified* error rather than an accidental `NotFound`.
- **Endpoint-backed capability** — registering a `TaskStore` (or a `with_task_support` tool) auto-advertises the server-level `tasks` capability; a `TaskSupport::Required` tool with no backing store/router makes `build()` return an error instead of advertising a hollow capability.
- **Client WARN on `tasks/*` deserialize failure** (method + transport identity + serde error) instead of silently folding it into the result.
- **`pmcp::testing` conformance helper** — `assert_roundtrips_through_client` feeds **real** server dispatch output through the client deserialization types (feature-gated `testing`, folded into `full`, omitted from `default`).
- **Worked example** `s45_tool_as_task_lifecycle` + a **live in-process round-trip acceptance test** driving `initialize → call(task) → tasks/get → tasks/result`, asserting non-empty typed content, three-way id consistency, capability advertisement, and the pending-result error.
- **Docs** — book / course / design task chapters and rustdoc now lead with the recommended `task_store` + `with_task_support` pattern; the hand-rolled `TaskRouter` / hand-written task-JSON path is reframed as **legacy**. (Also corrected pre-existing drift: a course example used the non-existent `Server::builder().task_store()`, and capability docs showed `experimental.tasks` as the standard shape.)
- **Internal refactor** — the four client `tasks/*` methods collapse onto one `parse_task_payload` helper.

## Requirements Addressed

- **TASKDX-01** — typed `tasks/result` from the store + create-path fix (store-minted id, persisted terminal result)
- **TASKDX-02** — endpoint-backed `tasks` capability auto-advertisement
- **TASKDX-03** — client WARN on task deserialize failure
- **TASKDX-04** — conformance helper consuming real dispatch output
- **TASKDX-05** — live round-trip example + ALWAYS coverage

## Verification

- [x] Goal-backward verification **passed 5/5** (verifier ran the real tests, not SUMMARY claims)
- [x] `make quality-gate` green (fmt, pedantic+nursery clippy, build, tests, doctests, audit, purity gates)
- [x] Live acceptance integration test (`tests/tool_as_task_lifecycle.rs`) — 7/7
- [x] `TaskRouter` regression preserved (server `tasks` tests green); no wire-shape change to `Task`/`GetTaskResult`/`CallToolResult`/`ServerCapabilities`
- [x] Cross-AI (Codex) review incorporated — 5 findings folded in and re-verified

## Versioning

Only the root **`pmcp`** crate changed (all code is under `src/`), so this is the only version bump: **`2.9.0 → 2.10.0`** (minor — additive features). The `mcp-tester` (`^2.8.1`) and `cargo-pmcp` (`^2.9.0`) pins accept `2.10.0` via caret semver and have no task changes, so they are intentionally not bumped here.

## Known follow-up (out of scope)

Task dispatch + `TaskStore` currently live on `ServerCoreBuilder` / `ServerCore`; the high-level `pmcp::Server` (and `StreamableHttpServer`) does not yet carry a `TaskStore`. HTTP-hosted servers need to wire `ServerCore` directly until a follow-up lifts task dispatch onto the high-level path. This is documented accurately throughout the new docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
