### PR TITLE
chore: release pmcp v2.14.0 — Task.diagnosticDetail PMCP extension (D-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] - 2026-07-08
+
+`Task.diagnostic_detail` — a PMCP extension field for two-voice task status.
+One additive, wire-neutral change (no breaking changes): `Task` gains an
+optional second status voice so producers can carry a business-friendly
+`status_message` and a full operator/developer diagnostic independently.
+Motivated by a pmcp.run dev-team request (their task servers need a redacted,
+end-user message plus an expandable operator detail behind a "details"
+affordance).
+
+### Added — `Task.diagnostic_detail` (`src/types/tasks.rs`)
+
+- **`Task.diagnostic_detail: Option<String>`** (wire key `diagnosticDetail`, D-17)
+  — a **PMCP extension, not an MCP-spec field**. The MCP `Task` type carries a
+  single `status_message` voice, which PMCP treats as the business-friendly,
+  user-facing voice; `diagnostic_detail` is a separate operator/developer voice
+  (step ids, URLs, internal error text) meant for an expandable-detail UI.
+  Producers MUST redact secrets/tokens before setting it (documented on the
+  field).
+- **`Task::with_diagnostic_detail(detail)`** builder — mirrors
+  `with_status_message` exactly.
+- Additive and non-breaking: `Task` is `#[non_exhaustive]` and built via
+  `Task::new()` + builders (no struct-literal breakage), the field is
+  `skip_serializing_if = "Option::is_none"` (callers that never set it produce
+  byte-identical JSON to 2.13.0), and `Task` has no `deny_unknown_fields` so
+  strict/older consumers ignore the extra key. Covered by three serde tests
+  (absent-when-`None`, `Some(..)` round-trip, and consumer-tolerance of the new
+  key plus an unrelated unknown field).
+- **Future migration note:** if the MCP spec grows a `_meta` extension slot on
+  `Task`, this field is a candidate to move under it rather than staying a
+  top-level struct field.
+
 ## [2.13.0] - 2026-07-05
 
 Loop-free task poll-decision classifier + durable/replay-consumer docs. One

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "2.13.0"
+version = "2.14.0"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/cargo-pmcp/CHANGELOG.md
+++ b/cargo-pmcp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `cargo-pmcp` crate will be documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2026-07-08
+
+### Changed
+
+- Bumped the `workbook-server` scaffold's hardcoded `PMCP_VERSION` pin from
+  `2.13.0` to `2.14.0` to track the workspace-root `pmcp` release (the
+  `emitted_pmcp_version_matches_workspace_pin` drift guard enforces this). The
+  emitted `Cargo.toml` now declares `pmcp = "2.14.0"`; older-pin scaffolds still
+  resolved via caret, so this is a cosmetic sync, not a behavior fix.
+
 ## [0.16.0] - 2026-06-08
 
 ### Added

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/cargo-pmcp/src/templates/workbook_server.rs
+++ b/cargo-pmcp/src/templates/workbook_server.rs
@@ -50,7 +50,7 @@ static EMBEDDED_XLSX: &[u8] = include_bytes!("workbook_bundle/tax-calc.xlsx");
 /// The pinned `pmcp` version the emitted `Cargo.toml` declares. A test asserts
 /// this equals the workspace-root `pmcp` version so the hardcoded pin cannot
 /// silently drift from the released crate (Codex MEDIUM).
-const PMCP_VERSION: &str = "2.13.0";
+const PMCP_VERSION: &str = "2.14.0";
 
 /// The pinned `pmcp-server-toolkit` version the emitted `Cargo.toml` declares. A
 /// test asserts this equals the workspace `pmcp-server-toolkit` package version so

--- a/src/types/tasks.rs
+++ b/src/types/tasks.rs
@@ -228,6 +228,33 @@ pub struct Task {
     /// Human-readable status message
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_message: Option<String>,
+    /// Full operator-facing diagnostic detail (step ids, URLs, internal error
+    /// text) for this task.
+    ///
+    /// **PMCP EXTENSION — not an MCP-spec field (D-17).** The MCP `Task` type
+    /// carries a single [`status_message`](Task::status_message) voice, which
+    /// PMCP treats as the business-friendly, user-facing voice (D-17/D-18).
+    /// `diagnostic_detail` is a second, separate voice this SDK adds for
+    /// operator/developer consumption — full detail that would be
+    /// inappropriate to show a business user by default (see the
+    /// Information-Disclosure disposition on this field: producers MUST
+    /// redact secrets/tokens before setting it). Consuming UIs typically
+    /// render it behind an expandable "details" affordance.
+    ///
+    /// Because `Task` has no `deny_unknown_fields` (see the module's serde
+    /// round-trip and consumer-tolerance tests), existing/strict consumers
+    /// that don't know this field simply ignore the extra `diagnosticDetail`
+    /// key on the wire — this is additive and non-breaking. When absent
+    /// (`None`), it is skip-serialized, so callers that never set it produce
+    /// byte-identical JSON to before this field existed.
+    ///
+    /// **Future migration note:** if/when the MCP spec grows a `_meta`
+    /// extension slot on `Task` (mirroring `CallToolResult._meta` /
+    /// [`RELATED_TASK_META_KEY`]), this field is a candidate to migrate under
+    /// that slot instead of a top-level struct field, to keep `Task` itself
+    /// spec-pure. Until then, this is the pragmatic wire slot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic_detail: Option<String>,
 }
 
 impl Task {
@@ -244,6 +271,7 @@ impl Task {
             last_updated_at: String::new(),
             poll_interval: None,
             status_message: None,
+            diagnostic_detail: None,
         }
     }
 
@@ -273,6 +301,13 @@ impl Task {
     /// Set a human-readable status message.
     pub fn with_status_message(mut self, message: impl Into<String>) -> Self {
         self.status_message = Some(message.into());
+        self
+    }
+
+    /// Set the full operator-facing diagnostic detail (PMCP extension — D-17;
+    /// see the field doc comment on [`Task::diagnostic_detail`]).
+    pub fn with_diagnostic_detail(mut self, detail: impl Into<String>) -> Self {
+        self.diagnostic_detail = Some(detail.into());
         self
     }
 
@@ -762,6 +797,84 @@ mod tests {
             .with_ttl(60000);
         let json = serde_json::to_value(&task).unwrap();
         assert_eq!(json["ttl"], 60000);
+    }
+
+    #[test]
+    fn task_diagnostic_detail_absent_when_none() {
+        // D-17 PMCP extension: diagnostic_detail defaults to None and MUST be
+        // skip-serialized — byte-identical to pre-field JSON for callers that
+        // never set it.
+        let task = Task::new("t-diag-none", TaskStatus::Working)
+            .with_timestamps("2025-11-25T00:00:00Z", "2025-11-25T00:01:00Z");
+        assert_eq!(task.diagnostic_detail, None);
+        let json = serde_json::to_value(&task).unwrap();
+        assert!(
+            json.get("diagnosticDetail").is_none(),
+            "diagnosticDetail must be omitted from JSON when None"
+        );
+    }
+
+    #[test]
+    fn task_diagnostic_detail_round_trip() {
+        // D-17 PMCP extension serde round-trip: Some(...) serializes under the
+        // camelCase `diagnosticDetail` key and deserializes back unchanged.
+        let task = Task::new("t-diag-some", TaskStatus::Failed)
+            .with_timestamps("2025-11-25T00:00:00Z", "2025-11-25T00:01:00Z")
+            .with_status_message("The AI service was temporarily unavailable")
+            .with_diagnostic_detail(
+                "step=call_tool op=propose_schema url=https://api.example/v1/x error=timeout",
+            );
+        let json = serde_json::to_value(&task).unwrap();
+        assert_eq!(
+            json["diagnosticDetail"],
+            "step=call_tool op=propose_schema url=https://api.example/v1/x error=timeout"
+        );
+        // Both voices ride independently — statusMessage stays the friendly one.
+        assert_eq!(
+            json["statusMessage"],
+            "The AI service was temporarily unavailable"
+        );
+
+        let roundtrip: Task = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            roundtrip.diagnostic_detail.as_deref(),
+            Some("step=call_tool op=propose_schema url=https://api.example/v1/x error=timeout")
+        );
+        assert_eq!(
+            roundtrip.status_message.as_deref(),
+            Some("The AI service was temporarily unavailable")
+        );
+    }
+
+    #[test]
+    fn task_diagnostic_detail_consumer_tolerance() {
+        // Review concern #3 / T-162-05-COMPAT: a Task JSON carrying the NEW
+        // diagnosticDetail key (plus a hypothetical extra unknown key a
+        // strict/older consumer wouldn't recognize) deserializes cleanly into
+        // `Task` — proving Task does NOT use deny_unknown_fields and existing
+        // consumers tolerate additive wire fields.
+        let wire_json = json!({
+            "taskId": "task-tolerant",
+            "status": "failed",
+            "ttl": null,
+            "createdAt": "2025-11-25T12:00:00.000Z",
+            "lastUpdatedAt": "2025-11-25T12:01:00.000Z",
+            "statusMessage": "The AI service was temporarily unavailable",
+            "diagnosticDetail": "step=call_tool op=propose_schema error=timeout",
+            "someFutureUnknownField": { "nested": "value" }
+        });
+        let task: Task = serde_json::from_value(wire_json)
+            .expect("Task must tolerate diagnosticDetail + an unrelated unknown field");
+        assert_eq!(task.task_id, "task-tolerant");
+        assert_eq!(task.status, TaskStatus::Failed);
+        assert_eq!(
+            task.diagnostic_detail.as_deref(),
+            Some("step=call_tool op=propose_schema error=timeout")
+        );
+        assert_eq!(
+            task.status_message.as_deref(),
+            Some("The AI service was temporarily unavailable")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Releases **pmcp v2.14.0** with one additive, wire-neutral feature: `Task.diagnostic_detail` (wire key `diagnosticDetail`), a **PMCP extension** (not an MCP-spec field, D-17). It gives `Task` a second, operator/developer status voice alongside the existing business-friendly `status_message`, for an expandable "details" UI.

Requested by the pmcp.run dev team, who consume it today via a local `[patch.crates-io]` override; this cuts it as a first-class published field.

## What's in this PR (2 commits, off `main`)

- `feat(tasks): add diagnosticDetail as PMCP extension on Task (D-17)` — the field, `with_diagnostic_detail()` builder, doc comment, and 3 serde tests.
- `chore: bump pmcp v2.14.0` — version bump + CHANGELOG entry.

## Why it's non-breaking (SemVer-minor)

- `Task` is `#[non_exhaustive]` and built via `Task::new()` + builders → no struct-literal breakage for external callers.
- Field is `#[serde(skip_serializing_if = "Option::is_none")]` → callers that never set it emit **byte-identical** JSON to 2.13.0.
- `Task` has no `deny_unknown_fields` → strict/older consumers ignore the extra key. A `consumer_tolerance` test pins this.
- Mirrors the existing `status_message` field exactly.

## Tests

`cargo test --lib types::tasks` → 23/23 pass. Three new tests: absent-when-`None`, `Some(..)` round-trip under `diagnosticDetail`, and consumer-tolerance of the new key + an unrelated unknown field.

## Quality gate

`make quality-gate` passes locally (fmt, clippy full/pedantic/nursery, examples, build, test, audit).

## Producer responsibility

`diagnostic_detail` may carry internal error text/URLs — producers MUST redact secrets/tokens before setting it (documented on the field). Migration note in the doc comment: candidate to move under a `Task._meta` slot if the spec grows one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)