### PR TITLE
chore: release pmcp v2.15.0 — typed tool output: declared outputSchema now emits structuredContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] - 2026-07-10
+
+Typed tool output on the wire — a declared `outputSchema` now automatically
+produces `structuredContent`. Per the MCP spec, a tool that declares an
+`outputSchema` SHOULD return `structuredContent` conforming to it; previously
+the SDK published the schema in `tools/list` but stringified every result into
+`content[0].text`, setting `structured_content` only for UI widget tools.
+Structured-output consumers (web apps, durable agents, codegen clients) had to
+`JSON.parse` an undocumented text blob. Motivated by a pmcp.run dev-team
+filing (their web-channel typed-results track was blocked on results actually
+carrying `structuredContent`).
+
+### Added
+
+- **`CallToolResult::structured(value)`** (`src/types/tools.rs`) — the
+  success-side counterpart of `CallToolResult::rejected`: one value, one call,
+  both voices. `structuredContent` carries the value verbatim;
+  `content[0].text` carries its canonical JSON serialization for text-only
+  clients. **`CallToolResult::structured_with_text(value, text)`** keeps a
+  distinct human-readable text voice. Intended for handlers that own their
+  full envelope (the verbatim `ToolOutput::Result` path, hand-rolled servers).
+- **Warn-only output validation** (`src/server/output_validation.rs`, gated on
+  the existing `validation` feature) — when a tool declares an `outputSchema`
+  and the dispatcher emits `structuredContent`, the value is validated against
+  the schema and mismatches log a `tracing` WARNING (never an error result).
+  Compiled validators are cached per schema; conforming values take an
+  `is_valid` short-circuit. Catches schema drift in dev/CI with no production
+  failure mode.
+- Docs: "Typed Output on the Wire" section in pmcp-book ch05; shared duplex
+  test harness extracted to `tests/common/duplex.rs`.
+
+### Changed (behavior, non-breaking API)
+
+- **Both native dispatchers** (high-level `Server` and `ServerCore`, so
+  stdio/HTTP/WASM deployments alike) now bridge a declared `outputSchema` to
+  the wire: Payload-path results from tools with an `outputSchema` (e.g.
+  `TypedToolWithOutput`, `tool_typed_with_output`, `#[mcp_tool]` functions
+  returning typed `Result<T>`) are dual-emitted — the serialized text voice
+  plus `structuredContent`. Tools without a declared schema keep the
+  text-only envelope, byte-for-byte unchanged. Widget enrichment precedence
+  is preserved.
+- **Heads-up for drifted schemas**: clients that validate `structuredContent`
+  against the declared schema will now see mismatches that were previously
+  hidden by text-only emission. That is the spec-correct outcome; enable the
+  `validation` feature in dev/CI to catch drift server-side first.
+- `ServerCore`'s text voice for schema-declaring tools is now compact JSON
+  (was pretty-printed), matching the high-level `Server` dispatcher and
+  shrinking dual-emit payloads.
+
 ## [2.14.0] - 2026-07-08
 
 `Task.diagnostic_detail` — a PMCP extension field for two-voice task status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ carrying `structuredContent`).
   failure mode.
 - Docs: "Typed Output on the Wire" section in pmcp-book ch05; shared duplex
   test harness extracted to `tests/common/duplex.rs`.
+- `cargo-pmcp` 0.17.2 → 0.17.3: workbook scaffold's emitted `pmcp` pin bumped
+  to 2.15.0 (tripwire-enforced against the workspace root version).
 
 ### Changed (behavior, non-breaking API)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "2.14.0"
+version = "2.15.0"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.17.2"
+version = "0.17.3"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/cargo-pmcp/src/templates/workbook_server.rs
+++ b/cargo-pmcp/src/templates/workbook_server.rs
@@ -50,7 +50,7 @@ static EMBEDDED_XLSX: &[u8] = include_bytes!("workbook_bundle/tax-calc.xlsx");
 /// The pinned `pmcp` version the emitted `Cargo.toml` declares. A test asserts
 /// this equals the workspace-root `pmcp` version so the hardcoded pin cannot
 /// silently drift from the released crate (Codex MEDIUM).
-const PMCP_VERSION: &str = "2.14.0";
+const PMCP_VERSION: &str = "2.15.0";
 
 /// The pinned `pmcp-server-toolkit` version the emitted `Cargo.toml` declares. A
 /// test asserts this equals the workspace `pmcp-server-toolkit` package version so

--- a/examples/s20_typed_tool_v2.rs
+++ b/examples/s20_typed_tool_v2.rs
@@ -4,6 +4,11 @@
 //! for tools with both input and output type safety. It also demonstrates
 //! the new description variants for better tool documentation.
 //!
+//! Because these tools declare an `outputSchema` (derived from the Rust output
+//! type), the server automatically emits each result value as
+//! `structuredContent` alongside the serialized text voice — structured-aware
+//! clients read the typed value directly, text-only clients keep working.
+//!
 //! Available description methods:
 //! - `.tool_typed_with_description(name, desc, handler)` - For input typing only
 //! - `.tool_typed_sync_with_description(name, desc, handler)` - For sync input typing

--- a/pmcp-book/src/ch05-tools.md
+++ b/pmcp-book/src/ch05-tools.md
@@ -263,6 +263,52 @@ Ok(serde_json::to_value(CalculatorResult { result: 15.0, ... })?)
 
 Your code stays simple—just return your data structure. PMCP handles protocol details.
 
+### Typed Output on the Wire: `outputSchema` → `structuredContent`
+
+Per the MCP spec, a tool that declares an `outputSchema` SHOULD return
+`structuredContent` conforming to it. PMCP bridges this automatically: when a
+tool's `ToolInfo` declares an `outputSchema` (e.g. registered via
+`tool_typed_with_output`, `TypedToolWithOutput`, or an `#[mcp_tool]` function
+returning a typed `Result<T>`), the server emits the handler's value **twice**
+on success:
+
+```rust
+// Your handler returns:
+Ok(CalculatorResult { result: 15.0, /* ... */ })
+
+// The wire result carries BOTH voices:
+// {
+//   "content": [{ "type": "text", "text": "{\"result\":15.0,...}" }],  // text-only clients
+//   "structuredContent": { "result": 15.0, ... },                       // typed clients
+//   "isError": false
+// }
+```
+
+Structured-aware clients (web apps, durable agents) read
+`result.structured_content` directly — no `JSON.parse` of an undocumented text
+blob. Text-only hosts keep working from `content`. Tools *without* a declared
+`outputSchema` keep the text-only envelope, so existing servers are unchanged.
+
+Handlers that own their full `CallToolResult` envelope (returning
+`ToolOutput::Result`) can dual-emit in one call with the success-side
+counterpart of `CallToolResult::rejected`:
+
+```rust
+use pmcp::types::CallToolResult;
+use serde_json::json;
+
+// One value, one call, both voices:
+CallToolResult::structured(json!({ "rows": [1, 2, 3] }));
+
+// Or with a distinct human-readable voice:
+CallToolResult::structured_with_text(json!({ "matches": 42 }), "Found 42 matches.");
+```
+
+**Catching schema drift**: with the `validation` feature enabled, the server
+validates each bridged value against the declared `outputSchema` at emit time
+and logs a **warning** (never an error result) on mismatch — surfacing drift
+in dev/CI without adding a production failure mode.
+
 ### Step 4: Validation
 
 Validate inputs before processing:

--- a/src/server/core.rs
+++ b/src/server/core.rs
@@ -678,11 +678,24 @@ impl ServerCore {
             self.suppress_double_wrap.contains(req.name.as_str()),
         );
 
+        // A declared outputSchema means structuredContent is emitted below
+        // (via widget enrichment or the schema bridge) — validate the value
+        // against it regardless of which branch does the emitting.
+        if let Some(schema) = tool_info.and_then(|i| i.output_schema.as_ref()) {
+            crate::server::output_validation::warn_on_schema_mismatch(&req.name, schema, &value);
+        }
+
         let call_result = if let Some(info) = tool_info.filter(|i| i.widget_meta().is_some()) {
             // Widget tool: structured data goes in structuredContent,
             // text is a brief summary to avoid duplication in `ChatGPT`
             let summary = summarize_structured_output(&value);
             CallToolResult::new(vec![Content::text(summary)]).with_widget_enrichment(info, value)
+        } else if tool_info.is_some_and(|i| i.output_schema.is_some()) {
+            // Declared outputSchema: bridge it to the wire (MCP spec — a tool
+            // that declares an outputSchema SHOULD return structuredContent
+            // conforming to it). Dual-emit (compact text voice, matching the
+            // high-level `Server` dispatcher) keeps text-only clients working.
+            CallToolResult::structured(value)
         } else {
             let text = serde_json::to_string_pretty(&value)?;
             CallToolResult::new(vec![Content::text(text)])

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -55,6 +55,9 @@ pub mod http_middleware;
 /// Middleware executor abstraction for consistent tool execution.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod middleware_executor;
+/// Warn-only emit-time validation of `structuredContent` against a declared
+/// `outputSchema` (no-op unless the `validation` feature is enabled).
+pub(crate) mod output_validation;
 /// Concrete `PeerHandle` implementation delegating to the
 /// `ServerRequestDispatcher`.
 #[cfg(not(target_arch = "wasm32"))]
@@ -1612,12 +1615,26 @@ impl Server {
             self.suppress_double_wrap.contains(req.name.as_str()),
         );
 
-        // Build CallToolResult, adding structured_content for widget tools
+        // Build CallToolResult, adding structured_content for widget tools and
+        // for tools with a declared outputSchema (MCP spec: a tool that
+        // declares an outputSchema SHOULD return structuredContent conforming
+        // to it). The text voice always carries the serialized value so
+        // text-only clients keep working.
         let text = result.to_string();
         let mut call_result = CallToolResult::new(vec![crate::types::Content::text(text)]);
 
         if let Some(info) = self.tool_infos.get(&req.name) {
-            call_result = call_result.with_widget_enrichment(info, result);
+            // A declared outputSchema means structuredContent is emitted below
+            // (via widget enrichment or the schema bridge) — validate the value
+            // against it regardless of which branch does the emitting.
+            if let Some(schema) = &info.output_schema {
+                output_validation::warn_on_schema_mismatch(&req.name, schema, &result);
+            }
+            if info.widget_meta().is_some() {
+                call_result = call_result.with_widget_enrichment(info, result);
+            } else if info.output_schema.is_some() {
+                call_result = call_result.with_structured_content(result);
+            }
         }
 
         // D-03.3: drain any handler-set result `_meta` (via extra.set_result_meta)

--- a/src/server/notification_debouncer.rs
+++ b/src/server/notification_debouncer.rs
@@ -299,7 +299,7 @@ async fn flush_all(
 ) {
     let pending_map = pending.write().await;
 
-    for (_, pending_notif) in pending_map.iter() {
+    for pending_notif in pending_map.values() {
         // Send the main notification
         let _ = output_tx.send(pending_notif.notification.clone()).await;
 

--- a/src/server/output_validation.rs
+++ b/src/server/output_validation.rs
@@ -1,0 +1,161 @@
+//! Emit-time validation of `structuredContent` against a declared `outputSchema`.
+//!
+//! When a tool declares an `outputSchema` and the dispatcher bridges the
+//! handler's value into `structuredContent`, this module checks the value
+//! against the schema and logs a WARNING (never an error result) on mismatch —
+//! catching schema drift in dev/CI without adding a production failure mode.
+//!
+//! The module compiles unconditionally so dispatcher call sites stay plain
+//! one-liners; the `validation` feature gate lives INSIDE
+//! [`warn_on_schema_mismatch`], which is a no-op without the feature.
+//! Compiled validators are cached per schema (keyed by the schema's canonical
+//! JSON text), so steady-state cost per call is one lookup plus a short-circuit
+//! `is_valid` check — the error-message pass runs only on actual mismatch.
+
+// Why: same tug-of-war as `task_dispatch` — rustc's `unreachable_pub` demands
+// pub(crate) on items in a crate-internal module, while clippy's
+// `redundant_pub_crate` flags that as redundant inside a pub(crate) module.
+// rustc wins; silence the clippy side.
+#![allow(clippy::redundant_pub_crate)]
+
+use serde_json::Value;
+
+/// Warn (via `tracing`) when `value` does not conform to the tool's declared
+/// `outputSchema`. Never fails the call. No-op unless the `validation`
+/// feature is enabled.
+pub(crate) fn warn_on_schema_mismatch(tool: &str, schema: &Value, value: &Value) {
+    #[cfg(feature = "validation")]
+    {
+        if !tracing::enabled!(tracing::Level::WARN) {
+            return;
+        }
+        if let Some(mismatch) = schema_mismatch(schema, value) {
+            tracing::warn!(
+                tool,
+                "structuredContent does not conform to the declared outputSchema: {mismatch}"
+            );
+        }
+    }
+    #[cfg(not(feature = "validation"))]
+    let _ = (tool, schema, value);
+}
+
+/// Check `value` against `schema`, returning a human-readable description of
+/// every violation, or `None` when the value conforms.
+///
+/// A schema that is itself invalid (fails to compile as JSON Schema) also
+/// yields `Some` — a drifted declaration is exactly what this check exists
+/// to surface.
+#[cfg(feature = "validation")]
+pub(crate) fn schema_mismatch(schema: &Value, value: &Value) -> Option<String> {
+    match cached_validator(schema) {
+        Ok(validator) => {
+            // Fast path: the conforming case is the common one and `is_valid`
+            // short-circuits; build messages only on actual mismatch.
+            if validator.is_valid(value) {
+                return None;
+            }
+            let errors: Vec<String> = validator
+                .iter_errors(value)
+                .map(|e| format!("{} (at {})", e, e.instance_path()))
+                .collect();
+            Some(errors.join("; "))
+        },
+        Err(e) => Some(format!(
+            "declared outputSchema is not a valid JSON Schema: {e}"
+        )),
+    }
+}
+
+/// Fetch (or compile and cache) the validator for `schema`.
+///
+/// Keyed by the schema's canonical JSON text: correct across servers sharing
+/// the process (unlike a tool-name key), and bounded by the number of distinct
+/// declared schemas. Compilation errors are cached too, as the error string.
+#[cfg(feature = "validation")]
+fn cached_validator(
+    schema: &Value,
+) -> Result<std::sync::Arc<jsonschema::Validator>, std::sync::Arc<str>> {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    type Cache = Mutex<HashMap<String, Result<Arc<jsonschema::Validator>, Arc<str>>>>;
+    static CACHE: OnceLock<Cache> = OnceLock::new();
+
+    let key = schema.to_string();
+    let cache = CACHE.get_or_init(Cache::default);
+    // Why: a poisoned mutex here only means another thread panicked while
+    // inserting; the map itself is still usable — recover rather than
+    // propagate a panic out of a warn-only diagnostics path.
+    let mut map = cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    map.entry(key)
+        .or_insert_with(|| {
+            jsonschema::validator_for(schema)
+                .map(Arc::new)
+                .map_err(|e| Arc::from(e.to_string().as_str()))
+        })
+        .clone()
+}
+
+#[cfg(all(test, feature = "validation"))]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn person_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "age": { "type": "integer" }
+            },
+            "required": ["name"]
+        })
+    }
+
+    #[test]
+    fn conforming_value_yields_none() {
+        let value = json!({ "name": "Ada", "age": 36 });
+        assert_eq!(schema_mismatch(&person_schema(), &value), None);
+    }
+
+    #[test]
+    fn non_conforming_value_yields_message() {
+        let value = json!({ "age": "not-a-number" });
+        let mismatch = schema_mismatch(&person_schema(), &value)
+            .expect("missing required field + wrong type must be reported");
+        assert!(
+            mismatch.contains("name"),
+            "message names the missing required field: {mismatch}"
+        );
+    }
+
+    #[test]
+    fn invalid_schema_yields_message() {
+        let bad_schema = json!({ "type": 42 });
+        let mismatch = schema_mismatch(&bad_schema, &json!({}))
+            .expect("an uncompilable schema must be reported, not ignored");
+        assert!(
+            mismatch.contains("outputSchema"),
+            "message says the schema itself is at fault: {mismatch}"
+        );
+    }
+
+    #[test]
+    fn repeated_checks_reuse_the_cached_validator() {
+        // Same schema, many values: exercises the cache path both ways.
+        let schema = person_schema();
+        for i in 0..8 {
+            let ok = json!({ "name": format!("p{i}") });
+            assert_eq!(schema_mismatch(&schema, &ok), None);
+            assert!(schema_mismatch(&schema, &json!({ "age": i })).is_some());
+        }
+    }
+
+    #[test]
+    fn warn_never_panics_on_mismatch() {
+        warn_on_schema_mismatch("demo_tool", &person_schema(), &json!({ "age": 1 }));
+    }
+}

--- a/src/server/typed_tool.rs
+++ b/src/server/typed_tool.rs
@@ -514,8 +514,11 @@ where
 /// A typed tool with both input and output type safety
 ///
 /// This variant provides type safety for both input arguments and return values.
-/// While output schemas are not part of the MCP protocol, they're useful for
-/// testing, documentation, and API contracts.
+/// The derived output schema is published as the tool's `outputSchema` in
+/// `tools/list`, and the server dispatchers bridge it onto the wire: a tool
+/// with a declared `outputSchema` has its result value emitted as
+/// `structuredContent` (alongside the serialized text voice), per the MCP
+/// spec's "SHOULD return structuredContent conforming to it".
 pub struct TypedToolWithOutput<TIn, TOut, F>
 where
     TIn: DeserializeOwned + Send + Sync + 'static,

--- a/src/types/tools.rs
+++ b/src/types/tools.rs
@@ -594,6 +594,64 @@ impl CallToolResult {
         }
     }
 
+    /// Create a structured success result — the success-side counterpart of
+    /// [`rejected`](Self::rejected).
+    ///
+    /// One value, one call, both voices: `structuredContent` carries `value`
+    /// verbatim for structured-aware clients, and `content` carries the
+    /// canonical JSON serialization of the same value as text, so text-only
+    /// clients (older hosts, log pipelines) keep working. Per the MCP spec, a
+    /// tool that declares an `outputSchema` SHOULD return `structuredContent`
+    /// conforming to it — this constructor is the one-call way to do that
+    /// from handlers that own their [`CallToolResult`] envelope.
+    ///
+    /// Use [`structured_with_text`](Self::structured_with_text) when the
+    /// human-readable voice should differ from the raw serialization.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pmcp::types::CallToolResult;
+    /// use serde_json::json;
+    ///
+    /// let value = json!({ "rows": [1, 2, 3] });
+    /// let result = CallToolResult::structured(value.clone());
+    ///
+    /// assert!(!result.is_error);
+    /// assert_eq!(result.structured_content, Some(value.clone()));
+    /// // The text voice round-trips to the same value.
+    /// let pmcp::types::Content::Text { text } = &result.content[0] else {
+    ///     unreachable!()
+    /// };
+    /// assert_eq!(serde_json::from_str::<serde_json::Value>(text).unwrap(), value);
+    /// ```
+    pub fn structured(value: Value) -> Self {
+        let text = value.to_string();
+        Self::new(vec![Content::text(text)]).with_structured_content(value)
+    }
+
+    /// Create a structured success result with a distinct human-readable voice.
+    ///
+    /// Like [`structured`](Self::structured), but `content` carries `text`
+    /// instead of the raw JSON serialization — mirroring the two-voice
+    /// separation [`rejected`](Self::rejected) has on the error side.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pmcp::types::CallToolResult;
+    /// use serde_json::json;
+    ///
+    /// let result = CallToolResult::structured_with_text(
+    ///     json!({ "matches": 42 }),
+    ///     "Found 42 matches.",
+    /// );
+    /// assert_eq!(result.structured_content, Some(json!({ "matches": 42 })));
+    /// ```
+    pub fn structured_with_text(value: Value, text: impl Into<String>) -> Self {
+        Self::new(vec![Content::text(text.into())]).with_structured_content(value)
+    }
+
     /// Add structured content for both model and widget.
     pub fn with_structured_content(mut self, content: Value) -> Self {
         self.structured_content = Some(content);

--- a/tests/common/duplex.rs
+++ b/tests/common/duplex.rs
@@ -1,0 +1,133 @@
+//! Shared in-process duplex transport + call helpers for dispatcher tests.
+//!
+//! Extracted from the (previously copy-pasted) harness in
+//! `tests/tool_output_passthrough.rs` / `tests/tool_with_result.rs` et al.:
+//! an mpsc-backed client<->server [`Transport`] pair, plus helpers that drive
+//! a `tools/call` through a real [`Client`] against either a high-level
+//! [`Server`] (own transport loop) or a `ServerCore` [`ProtocolHandler`]
+//! (request/response pump).
+//!
+//! Each file in `tests/` is compiled as a separate integration crate; include
+//! this module per-crate via `#[path = "common/duplex.rs"] mod duplex;`.
+
+#![allow(dead_code)]
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use pmcp::server::core::ProtocolHandler;
+use pmcp::shared::{Transport, TransportMessage};
+use pmcp::types::{CallToolResult, ClientCapabilities};
+use pmcp::{Client, Error, Result, Server};
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+/// One half of an in-process duplex transport. The client side sends Requests
+/// and receives Responses; the server side does the reverse.
+#[derive(Debug)]
+pub struct DuplexTransport {
+    tx: mpsc::UnboundedSender<TransportMessage>,
+    rx: mpsc::UnboundedReceiver<TransportMessage>,
+    connected: bool,
+}
+
+impl DuplexTransport {
+    /// Create a connected client/server transport pair.
+    pub fn pair() -> (Self, Self) {
+        let (client_tx, server_rx) = mpsc::unbounded_channel();
+        let (server_tx, client_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                tx: client_tx,
+                rx: client_rx,
+                connected: true,
+            },
+            Self {
+                tx: server_tx,
+                rx: server_rx,
+                connected: true,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl Transport for DuplexTransport {
+    async fn send(&mut self, message: TransportMessage) -> Result<()> {
+        self.tx
+            .send(message)
+            .map_err(|_| Error::internal("duplex peer dropped"))
+    }
+
+    async fn receive(&mut self) -> Result<TransportMessage> {
+        self.rx
+            .recv()
+            .await
+            .ok_or_else(|| Error::internal("duplex peer closed"))
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.connected = false;
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    fn transport_type(&self) -> &'static str {
+        "in-process-duplex"
+    }
+}
+
+/// Drive a `tools/call` through a real [`Client`] against a high-level
+/// [`Server`] running its own transport loop.
+pub async fn call_via_server(server: Server, name: &str, args: Value) -> CallToolResult {
+    let (client_t, server_t) = DuplexTransport::pair();
+    tokio::spawn(async move {
+        let _ = server.run(server_t).await;
+    });
+    let mut client = Client::new(client_t);
+    client
+        .initialize(ClientCapabilities::default())
+        .await
+        .expect("client initializes against server");
+    client
+        .call_tool(name.to_string(), args)
+        .await
+        .expect("tools/call succeeds against server")
+}
+
+/// Drive a `tools/call` through a real [`Client`] against a `ServerCore`
+/// served by a request/response pump over the duplex transport.
+pub async fn call_via_core(
+    core: Arc<dyn ProtocolHandler>,
+    name: &str,
+    args: Value,
+) -> CallToolResult {
+    let (client_t, mut server_t) = DuplexTransport::pair();
+    tokio::spawn(async move {
+        while let Ok(message) = server_t.receive().await {
+            if let TransportMessage::Request { id, request } = message {
+                let response = core.handle_request(id, request, None).await;
+                if server_t
+                    .send(TransportMessage::Response(response))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    });
+    let mut client = Client::new(client_t);
+    client
+        .initialize(ClientCapabilities::default())
+        .await
+        .expect("client initializes against core");
+    client
+        .call_tool(name.to_string(), args)
+        .await
+        .expect("tools/call succeeds against core")
+}

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -655,3 +655,68 @@ mod list_all_pagination_properties {
         }
     }
 }
+
+#[cfg(test)]
+mod structured_output_invariants {
+    use super::*;
+
+    /// Arbitrary JSON value (no floats — NaN/precision break equality
+    /// round-trips and the invariant under test is structural, not numeric).
+    fn arb_json() -> impl Strategy<Value = serde_json::Value> {
+        let leaf = prop_oneof![
+            Just(serde_json::Value::Null),
+            any::<bool>().prop_map(serde_json::Value::Bool),
+            any::<i64>().prop_map(|n| serde_json::json!(n)),
+            "[a-zA-Z0-9 _-]{0,12}".prop_map(serde_json::Value::String),
+        ];
+        leaf.prop_recursive(3, 32, 4, |inner| {
+            prop_oneof![
+                prop::collection::vec(inner.clone(), 0..4).prop_map(serde_json::Value::Array),
+                prop::collection::hash_map("[a-zA-Z_][a-zA-Z0-9_]{0,8}", inner, 0..4)
+                    .prop_map(|m| serde_json::Value::Object(m.into_iter().collect())),
+            ]
+        })
+    }
+
+    proptest! {
+        /// Property: `CallToolResult::structured(v)` dual-emits ONE value in
+        /// both voices — `structuredContent` carries `v` verbatim, the text
+        /// voice parses back to `v`, and the wire (serde) shape exposes the
+        /// camelCase `structuredContent` field with the same value.
+        #[test]
+        fn property_structured_dual_emit_roundtrip(value in arb_json()) {
+            let result = CallToolResult::structured(value.clone());
+
+            prop_assert!(!result.is_error);
+            prop_assert_eq!(result.structured_content.as_ref(), Some(&value));
+
+            let Content::Text { text } = &result.content[0] else {
+                return Err(TestCaseError::fail("structured() must emit a text voice"));
+            };
+            let parsed: serde_json::Value = serde_json::from_str(text)
+                .map_err(|e| TestCaseError::fail(format!("text voice must be valid JSON: {e}")))?;
+            prop_assert_eq!(&parsed, &value);
+
+            let wire = serde_json::to_value(&result)
+                .map_err(|e| TestCaseError::fail(format!("result must serialize: {e}")))?;
+            prop_assert_eq!(wire.get("structuredContent"), Some(&value));
+        }
+
+        /// Property: `structured_with_text` keeps the human voice verbatim and
+        /// never leaks it into `structuredContent`.
+        #[test]
+        fn property_structured_with_text_two_voices(
+            value in arb_json(),
+            human in "[a-zA-Z0-9 .,!?-]{1,40}"
+        ) {
+            let result = CallToolResult::structured_with_text(value.clone(), human.clone());
+
+            prop_assert!(!result.is_error);
+            prop_assert_eq!(result.structured_content.as_ref(), Some(&value));
+            let Content::Text { text } = &result.content[0] else {
+                return Err(TestCaseError::fail("structured_with_text must emit a text voice"));
+            };
+            prop_assert_eq!(text, &human);
+        }
+    }
+}

--- a/tests/structured_tool_output.rs
+++ b/tests/structured_tool_output.rs
@@ -1,0 +1,220 @@
+//! Structured tool output bridge acceptance gate.
+//!
+//! Per the MCP spec, a tool that declares an `outputSchema` SHOULD return
+//! `structuredContent` conforming to it. Before this gate, the SDK had both
+//! halves of the vocabulary and no bridge: `ToolInfo::output_schema` was
+//! published in `tools/list`, but the Payload-path dispatchers stringified
+//! every result into `content[0].text` and only set `structured_content` for
+//! widget tools.
+//!
+//! These tests prove:
+//! 1. `CallToolResult::structured` / `structured_with_text` — the success-side
+//!    counterparts of `CallToolResult::rejected`: one value, one call, both
+//!    voices (text for text-only clients, `structuredContent` for
+//!    structured-aware clients).
+//! 2. Both native dispatchers (high-level `Server` over an in-process duplex
+//!    transport, and `ServerCore` via a server pump) auto-emit
+//!    `structuredContent` for Payload-path tools whose cached `ToolInfo`
+//!    declares an `output_schema` (e.g. `TypedToolWithOutput`), round-tripping
+//!    the exact handler value in BOTH voices.
+//! 3. Tools without a declared `output_schema` keep today's text-only
+//!    envelope on both dispatchers (no behavior change for existing code).
+
+#![cfg(all(not(target_arch = "wasm32"), feature = "schema-generation"))]
+
+#[path = "common/duplex.rs"]
+mod duplex;
+
+use std::sync::Arc;
+
+use duplex::{call_via_core, call_via_server};
+use pmcp::server::builder::ServerCoreBuilder;
+use pmcp::server::core::ProtocolHandler;
+use pmcp::server::typed_tool::{TypedTool, TypedToolWithOutput};
+use pmcp::types::{CallToolResult, Content};
+use pmcp::{Server, ToolHandler};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Extract the single text block from a result's content.
+fn text_of(result: &CallToolResult) -> &str {
+    match result
+        .content
+        .first()
+        .expect("result carries at least one content block")
+    {
+        Content::Text { text } => text,
+        other => panic!("expected text content, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Typed fixture tool: declares an outputSchema via TypedToolWithOutput.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProposeArgs {
+    /// Corpus to propose a schema for.
+    corpus: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct ProposedSchema {
+    /// Entity type names discovered in the corpus.
+    entities: Vec<String>,
+    /// Total entity count.
+    count: u32,
+}
+
+fn propose_schema_tool() -> impl ToolHandler {
+    TypedToolWithOutput::new("propose_schema", |args: ProposeArgs, _extra| {
+        Box::pin(async move {
+            let _ = args.corpus;
+            Ok(ProposedSchema {
+                entities: vec!["Person".to_string(), "Company".to_string()],
+                count: 2,
+            })
+        })
+    })
+    .with_description("Propose a graph schema for a corpus")
+}
+
+/// The exact JSON value `propose_schema_tool` emits, for round-trip asserts.
+fn expected_proposed_schema() -> Value {
+    json!({ "entities": ["Person", "Company"], "count": 2 })
+}
+
+/// A schema-less tool (input typing only) — the regression control.
+fn text_only_tool() -> impl ToolHandler {
+    TypedTool::new("text_only", |args: ProposeArgs, _extra| {
+        Box::pin(async move {
+            let _ = args.corpus;
+            Ok(json!({ "plain": true }))
+        })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// 1. Constructors: structured / structured_with_text.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn structured_dual_emits_one_value_in_both_voices() {
+    let value = expected_proposed_schema();
+    let result = CallToolResult::structured(value.clone());
+
+    assert!(!result.is_error, "structured() is a success result");
+    assert_eq!(
+        result.structured_content,
+        Some(value.clone()),
+        "structuredContent carries the value verbatim"
+    );
+    let parsed: Value =
+        serde_json::from_str(text_of(&result)).expect("text voice is valid JSON of the value");
+    assert_eq!(parsed, value, "text voice round-trips to the same value");
+}
+
+#[test]
+fn structured_with_text_separates_the_two_voices() {
+    let value = expected_proposed_schema();
+    let result = CallToolResult::structured_with_text(value.clone(), "Proposed 2 entity types.");
+
+    assert!(!result.is_error);
+    assert_eq!(result.structured_content, Some(value));
+    assert_eq!(
+        text_of(&result),
+        "Proposed 2 entity types.",
+        "human voice differs from the raw serialization"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Dispatcher auto-emit: declared outputSchema => structuredContent.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_auto_emits_structured_content_for_declared_output_schema() {
+    let server = Server::builder()
+        .name("structured-output-server")
+        .version("1.0.0")
+        .tool("propose_schema", propose_schema_tool())
+        .build()
+        .expect("server builds");
+
+    let result = call_via_server(server, "propose_schema", json!({ "corpus": "docs" })).await;
+
+    assert_eq!(
+        result.structured_content,
+        Some(expected_proposed_schema()),
+        "high-level Server bridges declared outputSchema to structuredContent"
+    );
+    let parsed: Value = serde_json::from_str(text_of(&result)).expect("text voice is JSON");
+    assert_eq!(
+        parsed,
+        expected_proposed_schema(),
+        "text voice still round-trips for text-only clients"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_core_auto_emits_structured_content_for_declared_output_schema() {
+    let core: Arc<dyn ProtocolHandler> = Arc::new(
+        ServerCoreBuilder::new()
+            .name("structured-output-core")
+            .version("1.0.0")
+            .tool("propose_schema", propose_schema_tool())
+            .build()
+            .expect("core builds"),
+    );
+
+    let result = call_via_core(core, "propose_schema", json!({ "corpus": "docs" })).await;
+
+    assert_eq!(
+        result.structured_content,
+        Some(expected_proposed_schema()),
+        "ServerCore bridges declared outputSchema to structuredContent"
+    );
+    let parsed: Value = serde_json::from_str(text_of(&result)).expect("text voice is JSON");
+    assert_eq!(parsed, expected_proposed_schema());
+}
+
+// ---------------------------------------------------------------------------
+// 3. Regression: no declared outputSchema => text-only envelope, both paths.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_keeps_text_only_envelope_without_output_schema() {
+    let server = Server::builder()
+        .name("text-only-server")
+        .version("1.0.0")
+        .tool("text_only", text_only_tool())
+        .build()
+        .expect("server builds");
+
+    let result = call_via_server(server, "text_only", json!({ "corpus": "docs" })).await;
+
+    assert_eq!(
+        result.structured_content, None,
+        "no declared outputSchema: high-level Server emits text only"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_core_keeps_text_only_envelope_without_output_schema() {
+    let core: Arc<dyn ProtocolHandler> = Arc::new(
+        ServerCoreBuilder::new()
+            .name("text-only-core")
+            .version("1.0.0")
+            .tool("text_only", text_only_tool())
+            .build()
+            .expect("core builds"),
+    );
+
+    let result = call_via_core(core, "text_only", json!({ "corpus": "docs" })).await;
+
+    assert_eq!(
+        result.structured_content, None,
+        "no declared outputSchema: ServerCore emits text only"
+    );
+}


### PR DESCRIPTION
## Summary

Per the MCP spec, a tool that declares an `outputSchema` SHOULD return `structuredContent` conforming to it. Until now the SDK had both halves and no bridge: `TypedToolWithOutput` / `tool_typed_with_output` / `#[mcp_tool]` derived and published the schema in `tools/list`, but every Payload result was stringified into `content[0].text` — only UI widget tools got `structuredContent`. Structured-output consumers had to `JSON.parse` an undocumented text blob.

**pmcp 2.14.0 → 2.15.0** (minor):

- **`CallToolResult::structured(value)` / `structured_with_text(value, text)`** — success-side counterparts of `rejected`: one value, one call, both voices. For handlers that own their envelope (verbatim `ToolOutput::Result` path).
- **Dispatcher bridge** — both native dispatchers (high-level `Server` and `ServerCore`, so stdio/HTTP/WASM alike) dual-emit Payload results for tools with a declared `outputSchema`: serialized text voice + `structuredContent`. Zero code change for server authors — declare a typed output, spec-correct structured results come out.
- **Warn-only output validation** (existing `validation` feature) — bridged values are validated against the declared schema (cached validators, `is_valid` fast path); mismatches log a `tracing` WARNING, never an error result.
- Docs: pmcp-book ch05 "Typed Output on the Wire"; shared duplex test harness extracted to `tests/common/duplex.rs`.

## Visible behavior changes (called out in CHANGELOG)

1. Tools with a declared `outputSchema` now actually emit `structuredContent` — clients that validate will see schema drift that text-only emission previously hid. Enable the `validation` feature in dev/CI to catch it server-side first.
2. `ServerCore`'s text voice for schema-declaring tools is compact JSON (was pretty-printed), matching the high-level `Server` and shrinking dual-emit payloads.
3. Tools **without** a declared schema keep the text-only envelope, byte-for-byte unchanged.

## Testing

- Round-trip integration tests through BOTH dispatchers (real `Client` over in-process duplex): auto-emit with schema, text-only regression without, constructor round-trips.
- Property tests over arbitrary JSON values (dual-emit invariant, two-voice separation).
- Validator unit tests incl. cache path; full suite 1942+ passing.
- `make quality-gate` green on rust 1.97 (includes a fix for the new `clippy::for_kv_map` lint in pre-existing `notification_debouncer.rs`, which would otherwise block CI's latest-stable toolchain).

First consumer: pmcp.run's web-channel typed-results track (typed `structured<T>()` accessor + tools/list→TypeScript codegen), blocked on results carrying `structuredContent`.

After merge + green CI: tag `v2.15.0` on main to trigger the release workflow (crates.io + MCP registry publish). Only the root `pmcp` crate ships; downstream crates' caret ranges already accept 2.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)