### PR TITLE
feat(cargo-pmcp): v0.19.0 — remote package verbs + capture contract seam

### DIFF
--- a/cargo-pmcp/CHANGELOG.md
+++ b/cargo-pmcp/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to the `cargo-pmcp` crate will be documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-07-20
+
+### Added
+
+- **Remote package-lifecycle verbs** — `cargo pmcp package capture` (plus its
+  `import` / `approve` siblings). These are **thin clients** of pmcp.run's
+  remote, already-deployed platform API: `capture` submits a team's workflow
+  dependency graph as an async job (`submitPackageCapture`) and polls
+  `getPackageCaptureStatus` to a terminal status, printing the resulting
+  `pmcp-package` manifest digest. All substantive work (graph walk, config-slot
+  extraction, OCI pack, ECR push) runs server-side; the CLI never performs the
+  walk. Verified end-to-end against the dev platform (deterministic manifest
+  digest across re-runs).
+- **Package-capture contract seam** — a versioned, platform-owned GraphQL
+  contract (`contracts/pmcp-run/capture-v1.graphql`, exported from the live
+  platform schema) plus an **offline blocking contract test**
+  (`tests/package_capture_contract.rs`, `apollo-compiler` dev-dependency) that
+  validates the CLI's two capture operations and their response structs against
+  the vendored SDL. A future platform schema change that the CLI hasn't tracked
+  fails the SDK build, so the thin client can never silently drift from the
+  platform API (the Phase-110 failure class). The online drift check is
+  platform-owned (the platform re-exports and PRs the SDL on change).
+
+### Changed
+
+- **`capture_contract` internal introspection tool is now feature-gated** behind
+  a non-default `capture-contract-tool` feature, so `cargo install cargo-pmcp`
+  no longer installs it onto users' `PATH`. Its pure SDL-extraction logic + unit
+  tests moved into the library so they still run under the default test gate.
+
+### Fixed
+
+- **`package capture <TEAM_ID>` help text** no longer claims the id is a UUID.
+  The argument is an AgentTeam **slug** id (e.g. `day-trip-planner-team`); the
+  corrected `--help` / `long_help` say so.
+
 ## [0.17.2] - 2026-07-08
 
 ### Changed

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"
@@ -31,6 +31,18 @@ path = "tests/fixtures/mock_test_binary.rs"
 test = false
 bench = false
 doctest = false
+
+# Package-capture contract seam (Finding 1, final-review fix wave): internal
+# M2M-auth introspection dev tool, NOT meant to ship to end users. Without an
+# explicit [[bin]] + `required-features`, Cargo auto-discovers every file
+# under src/bin/ as a default [[bin]], so `cargo install cargo-pmcp` would
+# install this onto users' PATH. `required-features` makes the default build
+# (and thus `cargo install` with default features) skip it entirely; it only
+# builds with `--features capture-contract-tool`.
+[[bin]]
+name = "capture_contract"
+path = "src/bin/capture_contract.rs"
+required-features = ["capture-contract-tool"]
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
@@ -121,7 +133,12 @@ proptest = "1"
 serial_test = "3"
 assert_cmd = "2"
 predicates = "3"
+apollo-compiler = "1"
 
 [features]
 default = []
 aws-secrets = ["aws-config", "aws-sdk-secretsmanager"]
+# Gates the `capture_contract` internal dev binary (see its [[bin]] entry
+# above and its module doc) — a manual M2M-auth GraphQL introspection aid,
+# not intended for end-user installs.
+capture-contract-tool = []

--- a/cargo-pmcp/src/bin/capture_contract.rs
+++ b/cargo-pmcp/src/bin/capture_contract.rs
@@ -1,0 +1,425 @@
+//! `capture_contract` — shared introspect + extract-subset tool for the
+//! pmcp.run package-capture GraphQL contract (Task 2 of the package-capture
+//! contract seam).
+//!
+//! Two modes:
+//! - `capture_contract emit` — introspects the live **source data API**
+//!   (the amplifyData API behind `api_url`, NOT the merged
+//!   `PMCP_RUN_GRAPHQL_URL`/`DEFAULT_GRAPHQL_URL`), extracts just the
+//!   capture-subset (`submitPackageCapture` + `getPackageCaptureStatus` and
+//!   their return types), and prints the resulting SDL to stdout.
+//! - `capture_contract check <path>` — does the same live introspection,
+//!   then diffs the extracted SDL against the vendored contract file at
+//!   `<path>` (after stripping its provenance header comment), exiting
+//!   non-zero on drift.
+//!
+//! Deliberately kept as a `cargo-pmcp`-subcommand-free internal binary
+//! (`src/bin/capture_contract.rs`) rather than a public CLI subcommand. It is
+//! a MANUAL dev/introspection aid, run by someone with source-API access
+//! (M2M `PMCP_CLIENT_ID`/`PMCP_CLIENT_SECRET` credentials) — it is NOT
+//! invoked by SDK CI, which cannot reach the source `amplifyData` API (see
+//! `docs/superpowers/plans/2026-07-20-package-capture-contract-seam.md` Task 4:
+//! the online drift check is platform-owned). Because end users installing
+//! `cargo-pmcp` have no use for this tool, it requires the non-default
+//! `capture-contract-tool` feature (see the `[[bin]]` entry in `Cargo.toml`),
+//! so a default `cargo install cargo-pmcp` does not build or install it.
+//!
+//! ## Why this does NOT call `auth::get_credentials()` directly
+//!
+//! The brief for this tool describes reusing
+//! `cargo-pmcp/src/deployment/targets/pmcp_run/auth.rs`'s `get_credentials()`
+//! M2M (`client_credentials`) path. In practice this isn't reachable from a
+//! `src/bin/*.rs` binary: those link only the `cargo_pmcp` **library** crate
+//! (see `src/lib.rs`), and `auth.rs` lives in the bin-only module tree
+//! declared in `src/main.rs`. Worse, `get_credentials()`'s config-discovery
+//! fallback (`configured_api_base_url()`) transitively needs
+//! `commands::configure::resolver`, which the Phase 77 HIGH-1 fix
+//! (`.planning/phases/77-cargo-pmcp-configure-commands/77-03-PLAN.md`,
+//! `commands/configure/name_validation.rs` doc comment) deliberately keeps
+//! bin-only — `commands::*` is never mounted into the lib surface, and
+//! integration tests that need real CLI behavior invoke the built binary as
+//! a subprocess instead. Pulling that whole tree into the lib crate for this
+//! one M2M call would violate that documented boundary.
+//!
+//! So this file reimplements just the M2M branch directly against
+//! `PMCP_CLIENT_ID`/`PMCP_CLIENT_SECRET` (mirroring
+//! `auth::get_credentials_via_client_credentials`'s discovery + token
+//! exchange), self-contained, with no dependency on the bin-only `deployment`
+//! module tree. It DOES depend on the `cargo_pmcp` lib crate's
+//! `#[doc(hidden)] pmcp_run_graphql` seam for the pure SDL-extraction helpers
+//! (`extract_capture_sdl`, `assert_capture_ops_present`,
+//! `strip_provenance_header`), which live there so their unit tests run
+//! under the default `cargo test -p cargo-pmcp`.
+
+use anyhow::{Context, Result};
+use cargo_pmcp::pmcp_run_graphql::{
+    assert_capture_ops_present, extract_capture_sdl, strip_provenance_header,
+};
+use clap::{Parser, Subcommand};
+use serde_json::Value;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// `capture_contract <command>`
+#[derive(Debug, Parser)]
+#[command(name = "capture_contract")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Introspect the live source data API and print the capture-subset SDL.
+    Emit,
+    /// Introspect live, extract the capture-subset SDL, and diff it against
+    /// the SDL file at `<path>`. Exits non-zero on drift.
+    Check {
+        /// Path to the vendored contract SDL (e.g. `contracts/pmcp-run/capture-v1.graphql`).
+        path: PathBuf,
+    },
+}
+
+/// The standard full `IntrospectionQuery` document (introspects `__schema`:
+/// query/mutation root type names, all `types[]` with fields/args/enum
+/// values, and directives). Sent as-is to the source data API.
+const INTROSPECTION_QUERY: &str = r#"
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Emit => {
+            let sdl = introspect_and_extract().await?;
+            print!("{sdl}");
+        },
+        Command::Check { path } => {
+            let live_sdl = introspect_and_extract().await?;
+            let vendored_raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            let vendored_body = strip_provenance_header(&vendored_raw);
+
+            if normalize_body(&vendored_body) == normalize_body(&live_sdl) {
+                println!("OK: {} matches the live source schema", path.display());
+            } else {
+                eprintln!(
+                    "DRIFT DETECTED: {} no longer matches the live source schema",
+                    path.display()
+                );
+                print_line_diff(&vendored_body, &live_sdl);
+                std::process::exit(1);
+            }
+        },
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Live path: auth + introspection + endpoint guard + extraction
+// ============================================================================
+
+/// Full live flow: resolve the source endpoint, get an M2M token, introspect,
+/// assert it's the right endpoint, and extract the capture-subset SDL.
+async fn introspect_and_extract() -> Result<String> {
+    let source_url = resolve_source_url()?;
+    let token = get_m2m_token().await?;
+    let schema_data = introspect_source_schema(&source_url, &token).await?;
+    assert_capture_ops_present(&schema_data, &source_url)?;
+    extract_capture_sdl(&schema_data)
+}
+
+/// Read `PMCP_SOURCE_GRAPHQL_URL` — the source data API (amplifyData) behind
+/// `api_url`, distinct from the merged `PMCP_RUN_GRAPHQL_URL`/`DEFAULT_GRAPHQL_URL`.
+fn resolve_source_url() -> Result<String> {
+    std::env::var("PMCP_SOURCE_GRAPHQL_URL").context(
+        "PMCP_SOURCE_GRAPHQL_URL is not set — required: the source data API (amplifyData) \
+         endpoint behind api_url, distinct from the merged DEFAULT_GRAPHQL_URL",
+    )
+}
+
+/// Fetch an M2M access token via the OAuth2 `client_credentials` grant.
+/// Mirrors `auth::get_credentials_via_client_credentials` (see module docs
+/// above for why this isn't a direct call).
+async fn get_m2m_token() -> Result<String> {
+    let client_id = std::env::var("PMCP_CLIENT_ID")
+        .context("PMCP_CLIENT_ID is not set — required for M2M auth (client_credentials)")?;
+    let client_secret = std::env::var("PMCP_CLIENT_SECRET")
+        .context("PMCP_CLIENT_SECRET is not set — required for M2M auth (client_credentials)")?;
+
+    let cognito_domain = resolve_cognito_domain().await?;
+    let token_url = format!("https://{cognito_domain}/oauth2/token");
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&token_url)
+        .basic_auth(&client_id, Some(&client_secret))
+        .form(&[("grant_type", "client_credentials")])
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .context("failed to request access token via client_credentials")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("client_credentials token request failed: {status}\n{body}");
+    }
+
+    #[derive(serde::Deserialize)]
+    struct TokenResponse {
+        access_token: String,
+    }
+
+    let token: TokenResponse = response
+        .json()
+        .await
+        .context("failed to parse client_credentials token response")?;
+    Ok(token.access_token)
+}
+
+/// Resolve the Cognito auth domain: `PMCP_RUN_COGNITO_DOMAIN` override, else
+/// discovery via `.well-known/pmcp-config` at `PMCP_API_URL`/`PMCP_RUN_API_URL`
+/// (default `https://api.pmcp.run`).
+async fn resolve_cognito_domain() -> Result<String> {
+    if let Ok(domain) = std::env::var("PMCP_RUN_COGNITO_DOMAIN") {
+        let trimmed = domain.trim();
+        if !trimmed.is_empty() {
+            return Ok(strip_scheme(trimmed));
+        }
+    }
+
+    let api_url = std::env::var("PMCP_API_URL")
+        .or_else(|_| std::env::var("PMCP_RUN_API_URL"))
+        .unwrap_or_else(|_| "https://api.pmcp.run".to_string());
+    let discovery_url = format!("{}/.well-known/pmcp-config", api_url.trim_end_matches('/'));
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(&discovery_url)
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await
+        .with_context(|| format!("failed to reach discovery endpoint {discovery_url}"))?;
+
+    if !response.status().is_success() {
+        anyhow::bail!(
+            "discovery endpoint {discovery_url} returned status {}",
+            response.status()
+        );
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Discovery {
+        cognito_domain: String,
+    }
+
+    let discovered: Discovery = response
+        .json()
+        .await
+        .context("failed to parse pmcp-config discovery response")?;
+    Ok(strip_scheme(&discovered.cognito_domain))
+}
+
+/// Strip a leading `https://`/`http://` scheme and trailing `/`.
+fn strip_scheme(s: &str) -> String {
+    s.strip_prefix("https://")
+        .or_else(|| s.strip_prefix("http://"))
+        .unwrap_or(s)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// POST the standard introspection query to the source data API with the M2M
+/// bearer token. Returns the `data` object of the GraphQL response (i.e. the
+/// value carrying the `__schema` key), NOT `data.__schema` directly — matches
+/// what [`extract_capture_sdl`] expects.
+async fn introspect_source_schema(source_url: &str, token: &str) -> Result<Value> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "query": INTROSPECTION_QUERY,
+        "variables": {},
+    });
+
+    let response = client
+        .post(source_url)
+        .bearer_auth(token)
+        .json(&body)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .with_context(|| format!("failed to POST introspection query to {source_url}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        anyhow::bail!("introspection request to {source_url} failed: {status}\n{text}");
+    }
+
+    let raw: Value = response
+        .json()
+        .await
+        .context("failed to parse introspection response as JSON")?;
+
+    if let Some(errors) = raw.get("errors") {
+        anyhow::bail!("GraphQL errors introspecting {source_url}: {errors}");
+    }
+
+    raw.get("data")
+        .cloned()
+        .with_context(|| format!("introspection response from {source_url} has no `data` field"))
+}
+
+// ============================================================================
+// `check` mode helpers
+// ============================================================================
+//
+// NOTE: `assert_capture_ops_present`, `extract_capture_sdl`, and
+// `strip_provenance_header` moved to
+// `cargo-pmcp/src/deployment/targets/pmcp_run/graphql_contract.rs` (the
+// already-dual-mounted shared leaf) along with their pure helpers
+// (`find_type`, `find_field`, `render_type_ref`, `unwrap_named_type`,
+// `render_args`, `render_object_type`) and their unit tests, so those tests
+// run under the default `cargo test -p cargo-pmcp` even though this binary
+// is now feature-gated behind `capture-contract-tool`. Imported above via
+// `cargo_pmcp::pmcp_run_graphql::*`.
+
+/// Normalize an SDL body for comparison: trim trailing whitespace per line,
+/// trim leading/trailing blank lines. Still a plain string/line comparison —
+/// no GraphQL parsing.
+fn normalize_body(s: &str) -> String {
+    s.lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+/// Print a line-level unified-ish diff between the vendored and live SDL
+/// bodies (`-` vendored-only/changed, `+` live-only/changed).
+fn print_line_diff(vendored: &str, live: &str) {
+    let vendored_norm = normalize_body(vendored);
+    let live_norm = normalize_body(live);
+    let vendored_lines: Vec<&str> = vendored_norm.lines().collect();
+    let live_lines: Vec<&str> = live_norm.lines().collect();
+    let max = vendored_lines.len().max(live_lines.len());
+    for i in 0..max {
+        let v = vendored_lines.get(i).copied();
+        let l = live_lines.get(i).copied();
+        match (v, l) {
+            (Some(a), Some(b)) if a == b => {},
+            (Some(a), Some(b)) => {
+                println!("- {a}");
+                println!("+ {b}");
+            },
+            (Some(a), None) => println!("- {a}"),
+            (None, Some(b)) => println!("+ {b}"),
+            (None, None) => {},
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+//
+// The unit tests that used to live here (covering `extract_capture_sdl` /
+// `assert_capture_ops_present` / `strip_provenance_header`) moved along with
+// those functions to
+// `cargo-pmcp/src/deployment/targets/pmcp_run/graphql_contract.rs` — see the
+// note above `check`-mode helpers. This keeps that coverage running under
+// the default `cargo test -p cargo-pmcp` (lib target) even though this
+// binary itself now requires the non-default `capture-contract-tool`
+// feature.

--- a/cargo-pmcp/src/commands/package/approve.rs
+++ b/cargo-pmcp/src/commands/package/approve.rs
@@ -1,0 +1,66 @@
+//! `cargo pmcp package approve` — write an approval for a workflow package by
+//! REFERENCE only (D-05/D-06/D-08). One-shot mutation, no polling — the
+//! server resolves BOTH digests from the source `WorkflowPackage` row; the
+//! CLI never derives or sends a digest (Codex #1 / T-171-25b). Approval is a
+//! governance act: gated by the platform's admin-group claim AND an
+//! in-handler organization match (D-05 — Cognito groups are pool-wide, not
+//! org-scoped).
+
+use anyhow::{Context, Result};
+use clap::Args;
+use colored::Colorize;
+
+use crate::commands::GlobalFlags;
+use crate::deployment::targets::pmcp_run::{auth, graphql};
+
+use super::parse_reference;
+
+/// Arguments for `cargo pmcp package approve`.
+#[derive(Debug, Args)]
+pub struct ApproveArgs {
+    /// Workflow reference in `name@X.Y.Z` form (e.g. `day-trip-planner-team@1.0.0`).
+    pub reference: String,
+
+    /// Organization id the approval applies to.
+    ///
+    /// Required by the platform's `approvePackage` mutation — the server
+    /// independently re-verifies this matches the caller's own
+    /// `custom:organizationId` claim (D-05's org-match half), so a
+    /// mismatched value is rejected outright, never silently approved for
+    /// the wrong org. Falls back to the `PMCP_ORGANIZATION_ID` env var if
+    /// set, matching this CLI's existing env-var convention.
+    #[arg(long, env = "PMCP_ORGANIZATION_ID")]
+    pub organization_id: String,
+
+    /// Optional freeform evidence link/note (D-07) — e.g. a test-run trace URL.
+    #[arg(long)]
+    pub evidence: Option<String>,
+}
+
+/// Write the approval. One-shot: no polling — unlike `capture`/`import`'s
+/// async-job shape, `approvePackage` is a synchronous, immediate mutation.
+pub async fn execute(args: ApproveArgs, global_flags: &GlobalFlags) -> Result<()> {
+    let (name, version) = parse_reference(&args.reference)?;
+
+    let credentials = auth::get_credentials()
+        .await
+        .context("Not authenticated. Run: cargo pmcp login")?;
+
+    let approval = graphql::approve_package(
+        &credentials.access_token,
+        &args.organization_id,
+        name,
+        version,
+        args.evidence.as_deref(),
+    )
+    .await
+    .with_context(|| format!("Failed to approve package {name}@{version}"))?;
+
+    if global_flags.should_output() {
+        println!("{} {}", "Approved".green().bold(), args.reference);
+        println!("  id: {}", approval.id);
+        println!("  approvedAt: {}", approval.approved_at);
+    }
+
+    Ok(())
+}

--- a/cargo-pmcp/src/commands/package/capture.rs
+++ b/cargo-pmcp/src/commands/package/capture.rs
@@ -1,0 +1,326 @@
+//! `cargo pmcp package capture` — submit + poll an async workflow capture job
+//! against the pmcp.run platform (D-A/D-B). Remote, platform-side: the
+//! dependency-graph walk itself runs in the platform's capture worker, never
+//! in this CLI (D-10).
+
+use std::io::{self, IsTerminal, Write as _};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use clap::Args;
+use colored::Colorize;
+
+use crate::commands::GlobalFlags;
+use crate::deployment::targets::pmcp_run::{auth, graphql};
+
+/// `rootComponentType` — v1 only supports capturing a team's workflow graph.
+const ROOT_COMPONENT_TYPE_TEAM: &str = "team";
+
+/// Sleep between capture-status polls (matches `poll_deployment_status`).
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Bounded max total wait for a capture job to reach a terminal status —
+/// must exceed the platform capture Lambda's 15-min timeout (plus queue/retry
+/// slack): queue/retry time precedes the Lambda's clock, so an equal ceiling
+/// would time the CLI out on jobs that then complete.
+const MAX_POLL_WAIT: Duration = Duration::from_secs(20 * 60);
+
+/// Max consecutive TRANSPORT-level failures tolerated while polling before
+/// giving up. A `"failed"` job STATUS from a successful GraphQL call is
+/// terminal (not transient) and is handled separately — this only guards
+/// network/GraphQL-request errors.
+const MAX_TRANSIENT_RETRIES: u32 = 5;
+
+const BUMP_LEVELS: [&str; 3] = ["major", "minor", "patch"];
+
+/// Arguments for `cargo pmcp package capture`.
+#[derive(Debug, Args)]
+pub struct CaptureArgs {
+    /// AgentTeam id — a slug like `day-trip-planner-team`, not the display
+    /// name (and not a UUID).
+    ///
+    /// v1 requires the exact AgentTeam id: `submitPackageCapture` performs a
+    /// DynamoDB `GetItem` by primary key against the `AgentTeam` table, so a
+    /// display name will not resolve. A server-side name -> id lookup is a
+    /// documented deferral, not supported in v1.
+    #[arg(
+        value_name = "TEAM_ID",
+        long_help = "AgentTeam id — a slug like `day-trip-planner-team`, not the display name \
+                      (and not a UUID). v1 requires the exact AgentTeam id (submitPackageCapture \
+                      does a GetItem by primary key); a name-to-id lookup is a documented \
+                      deferral, not supported here."
+    )]
+    pub team_id: String,
+
+    /// Semver version to capture the workflow package as (e.g. 1.2.3).
+    #[arg(long, value_name = "X.Y.Z")]
+    pub version: String,
+
+    /// Bump level applied to every component whose deployed bytes changed
+    /// since the last capture (major|minor|patch — the single level applies
+    /// uniformly across all divergent components; there is no per-component
+    /// override). Only consulted when the platform reports
+    /// `errorCode=BUMP_REQUIRED`; supply it up front to skip the interactive
+    /// TTY prompt (required in non-interactive/CI contexts, where an
+    /// unresolved bump-required job fails loud rather than hanging).
+    #[arg(long, value_parser = ["major", "minor", "patch"])]
+    pub bump: Option<String>,
+}
+
+/// Submit a capture job and poll it to a terminal status, resolving
+/// `--bump` interactively over a TTY (or failing loud non-interactively).
+pub async fn execute(args: CaptureArgs, global_flags: &GlobalFlags) -> Result<()> {
+    let output = global_flags.should_output();
+    let credentials = auth::get_credentials()
+        .await
+        .context("Not authenticated. Run: cargo pmcp login")?;
+    let access_token = credentials.access_token;
+
+    let mut bump = args.bump.clone();
+
+    loop {
+        let submitted = submit(&access_token, &args, bump.as_deref(), output).await?;
+        let status = poll_capture_status(&access_token, &submitted.capture_id, output).await?;
+
+        match status.status.as_str() {
+            "completed" => {
+                report_success(&status, output);
+                return Ok(());
+            },
+            "failed" => {
+                bump = Some(handle_capture_failure(&status)?);
+                continue;
+            },
+            other => bail!("Unexpected terminal capture status: {other}"),
+        }
+    }
+}
+
+/// Submit the capture job, printing a short status line when output is
+/// enabled.
+async fn submit(
+    access_token: &str,
+    args: &CaptureArgs,
+    bump: Option<&str>,
+    output: bool,
+) -> Result<graphql::CaptureInfo> {
+    if output {
+        println!(
+            "Submitting capture: team={} version={}{}",
+            args.team_id,
+            args.version,
+            bump.map(|b| format!(" bump={b}")).unwrap_or_default()
+        );
+    }
+
+    graphql::submit_package_capture(
+        access_token,
+        ROOT_COMPONENT_TYPE_TEAM,
+        &args.team_id,
+        &args.version,
+        bump,
+    )
+    .await
+    .context("Failed to submit package capture")
+}
+
+/// Print the terminal success summary.
+fn report_success(status: &graphql::CaptureStatus, output: bool) {
+    if !output {
+        return;
+    }
+    println!("{}", "✅ Capture complete".green().bold());
+    if let Some(digest) = &status.manifest_digest {
+        println!("   Manifest digest: {digest}");
+    }
+}
+
+/// Inspect a `"failed"` terminal status and decide what to do next.
+///
+/// Switches on the STRUCTURED `error_code` (D-B) — NEVER parses `message` to
+/// detect `BUMP_REQUIRED` or any other condition. On `BUMP_REQUIRED`: prompts
+/// once over an interactive TTY and returns the bump level to re-submit with;
+/// non-interactively, bails listing every divergent component and pointing
+/// at `--bump`. Any other error code (or none) bails with the message.
+fn handle_capture_failure(status: &graphql::CaptureStatus) -> Result<String> {
+    match status.error_code.as_deref() {
+        Some("BUMP_REQUIRED") => {
+            let divergent = status.divergent_components.clone().unwrap_or_default();
+            if io::stdin().is_terminal() && io::stdout().is_terminal() {
+                prompt_bump_level(&divergent)
+            } else {
+                bail!(
+                    "Capture failed: bump required for {} divergent component(s): {}. \
+                     Re-run with --bump <major|minor|patch> (applies uniformly to all).",
+                    divergent.len(),
+                    divergent.join(", ")
+                );
+            }
+        },
+        Some(code) => bail!(
+            "Capture failed ({code}): {}",
+            status.message.as_deref().unwrap_or("no message")
+        ),
+        None => bail!(
+            "Capture failed: {}",
+            status.message.as_deref().unwrap_or("unknown error")
+        ),
+    }
+}
+
+/// Prompt (once) for a bump level on an interactive TTY, re-prompting only
+/// on invalid input.
+fn prompt_bump_level(divergent: &[String]) -> Result<String> {
+    eprintln!("The following component(s) changed and need a version bump:");
+    for component in divergent {
+        eprintln!("  - {component}");
+    }
+    loop {
+        eprint!("Choose a bump level ({}): ", BUMP_LEVELS.join("/"));
+        io::stderr().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let choice = input.trim().to_lowercase();
+        if BUMP_LEVELS.contains(&choice.as_str()) {
+            return Ok(choice);
+        }
+        eprintln!(
+            "Invalid choice '{choice}' — must be one of: {}",
+            BUMP_LEVELS.join(", ")
+        );
+    }
+}
+
+/// Fetch one capture-status sample, folding in transient-failure handling.
+/// Returns `Ok(Some(status))` on success, `Ok(None)` when a transient
+/// transport error was tolerated (the caller retries; this already slept
+/// [`POLL_INTERVAL`]), or `Err` once [`MAX_TRANSIENT_RETRIES`] is exceeded.
+/// Extracted from [`poll_capture_status`] to keep it within the complexity gate.
+async fn fetch_capture_status_once(
+    access_token: &str,
+    capture_id: &str,
+    transient_failures: &mut u32,
+    output: bool,
+) -> Result<Option<graphql::CaptureStatus>> {
+    match graphql::get_package_capture_status(access_token, capture_id).await {
+        Ok(status) => {
+            *transient_failures = 0;
+            Ok(Some(status))
+        },
+        Err(err) => {
+            *transient_failures += 1;
+            if *transient_failures > MAX_TRANSIENT_RETRIES {
+                return Err(err).context("Exceeded max retries polling capture status");
+            }
+            if output {
+                eprintln!(
+                    "   transient error polling capture status ({transient_failures}/{MAX_TRANSIENT_RETRIES}): {err}"
+                );
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+            Ok(None)
+        },
+    }
+}
+
+/// Handle one in-progress (non-terminal) capture poll tick: warn once for a
+/// genuinely unrecognized status (newer platform), print a progress dot, and
+/// flush. Extracted from [`poll_capture_status`] to keep it within the
+/// complexity gate.
+fn note_capture_in_progress(
+    status: &str,
+    warned_statuses: &mut std::collections::HashSet<String>,
+    dots: &mut u32,
+    output: bool,
+) -> Result<()> {
+    // Terminal detection stays exact ("completed"/"failed") — any other status
+    // is treated as in-progress so an older CLI keeps working when the platform
+    // adds intermediate statuses. Warn once per unrecognized status.
+    let recognized = matches!(status, "queued" | "walking" | "extracting" | "publishing");
+    if !recognized && warned_statuses.insert(status.to_string()) {
+        if output && *dots > 0 {
+            println!();
+            *dots = 0;
+        }
+        eprintln!("   warning: unrecognized capture status '{status}' — treating as in-progress");
+    }
+    if output {
+        print!(".");
+        *dots += 1;
+        if *dots >= 60 {
+            println!();
+            *dots = 0;
+        }
+        io::stdout().flush()?;
+    }
+    Ok(())
+}
+
+/// Dispatch a fetched capture status: `Ok(Some(status))` when terminal
+/// (`completed` / `failed`), `Err` on `not_found`, or `Ok(None)` when still in
+/// progress (a progress tick is noted here). Extracted from
+/// [`poll_capture_status`] to keep it within the complexity gate.
+fn classify_capture_status(
+    status: graphql::CaptureStatus,
+    capture_id: &str,
+    warned_statuses: &mut std::collections::HashSet<String>,
+    dots: &mut u32,
+    output: bool,
+) -> Result<Option<graphql::CaptureStatus>> {
+    match status.status.as_str() {
+        "completed" | "failed" => {
+            if output && *dots > 0 {
+                println!();
+            }
+            Ok(Some(status))
+        },
+        "not_found" => bail!("Capture job {capture_id} not found"),
+        in_progress => {
+            note_capture_in_progress(in_progress, warned_statuses, dots, output)?;
+            Ok(None)
+        },
+    }
+}
+
+/// Poll `getPackageCaptureStatus` until a terminal status (`completed` /
+/// `failed`), bounded by [`MAX_POLL_WAIT`] and tolerating up to
+/// [`MAX_TRANSIENT_RETRIES`] consecutive transport-level failures.
+async fn poll_capture_status(
+    access_token: &str,
+    capture_id: &str,
+    output: bool,
+) -> Result<graphql::CaptureStatus> {
+    if output {
+        println!("⏳ Waiting for capture to complete...");
+    }
+
+    let start = Instant::now();
+    let mut transient_failures = 0u32;
+    let mut dots = 0u32;
+    // Statuses we've already warned about — unknown (likely newer-platform)
+    // statuses are treated as in-progress, warned once each, never fatal.
+    let mut warned_statuses: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    loop {
+        if start.elapsed() > MAX_POLL_WAIT {
+            bail!(
+                "Timed out waiting for capture {capture_id} to complete after {}s",
+                MAX_POLL_WAIT.as_secs()
+            );
+        }
+
+        let Some(status) =
+            fetch_capture_status_once(access_token, capture_id, &mut transient_failures, output)
+                .await?
+        else {
+            continue;
+        };
+
+        if let Some(done) =
+            classify_capture_status(status, capture_id, &mut warned_statuses, &mut dots, output)?
+        {
+            return Ok(done);
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}

--- a/cargo-pmcp/src/commands/package/import.rs
+++ b/cargo-pmcp/src/commands/package/import.rs
@@ -1,0 +1,470 @@
+//! `cargo pmcp package import` — submit + poll an async dry-run pre-flight
+//! import job against the pmcp.run platform (D-02/D-04). Dry-run is the ONLY
+//! supported mode this phase — there is no `--execute` flag; the client
+//! always sends `dryRun: true` and the server rejects anything else (real
+//! execution is Phase 172's concern). Remote, platform-side: admit / pull &
+//! verify / resolve / pre-flight all run in the platform's import worker,
+//! never in this CLI (D-10).
+
+use std::io::{self, Write as _};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use clap::Args;
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::GlobalFlags;
+use crate::deployment::targets::pmcp_run::{auth, graphql};
+
+use super::parse_reference;
+
+/// Sleep between import-status polls (mirrors `capture.rs`'s `POLL_INTERVAL`).
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Bounded max total wait for an import job to reach a terminal status —
+/// mirrors `capture.rs`'s `MAX_POLL_WAIT` (the import Lambda shares the same
+/// 15-min timeout class as the capture Lambda, plus queue/retry slack).
+const MAX_POLL_WAIT: Duration = Duration::from_secs(20 * 60);
+
+/// Max consecutive TRANSPORT-level failures tolerated while polling before
+/// giving up (mirrors `capture.rs`'s `MAX_TRANSIENT_RETRIES`). A `"failed"`
+/// job STATUS from a successful GraphQL call is terminal, not transient —
+/// this only guards network/GraphQL-request errors.
+const MAX_TRANSIENT_RETRIES: u32 = 5;
+
+/// Arguments for `cargo pmcp package import`.
+///
+/// Dry-run pre-flight is the ONLY supported mode this phase (D-02) — there is
+/// no `--execute` flag and no way to request real execution; the CLI always
+/// sends `dryRun: true` and the server rejects any other value. Real
+/// execution modes are Phase 172's concern.
+#[derive(Debug, Args)]
+pub struct ImportArgs {
+    /// Workflow reference in `name@X.Y.Z` form (e.g. `day-trip-planner-team@1.0.0`).
+    #[arg(
+        value_name = "WORKFLOW@VERSION",
+        long_help = "Workflow reference in `name@X.Y.Z` form. Submits an async \
+                      dry-run pre-flight import job (admit -> pull & verify -> \
+                      resolve -> pre-flight) and polls it to a terminal status, \
+                      then renders the pre-flight report. Dry-run is the ONLY \
+                      mode this phase — there is no way to request real \
+                      execution (deferred to Phase 172)."
+    )]
+    pub reference: String,
+
+    /// Emit stable JSON instead of the human-readable pre-flight tree.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Submit a dry-run import job and poll it to a terminal status, rendering
+/// the pre-flight report.
+pub async fn execute(args: ImportArgs, global_flags: &GlobalFlags) -> Result<()> {
+    // Progress/status chatter only in human mode — `--json` must yield a
+    // clean stdout stream for scripting, mirroring `show.rs`'s
+    // json-takes-priority-over-quiet precedent.
+    let human_output = global_flags.should_output() && !args.json;
+
+    // Validate the reference shape up front (fail fast, same UX as `show`) —
+    // the parsed halves aren't needed beyond validation since the mutation
+    // takes the whole reference as a single string.
+    parse_reference(&args.reference)?;
+
+    let credentials = auth::get_credentials()
+        .await
+        .context("Not authenticated. Run: cargo pmcp login")?;
+    let access_token = credentials.access_token;
+
+    if human_output {
+        println!("Submitting dry-run import: reference={}", args.reference);
+    }
+
+    let submitted = graphql::submit_package_import(&access_token, &args.reference)
+        .await
+        .context("Failed to submit package import")?;
+
+    let status = poll_import_status(&access_token, &submitted.import_id, human_output).await?;
+
+    // ALL of these are terminal — never loop past a terminal status (Codex
+    // #13). `failed` surfaces the structured `errorCode`, NEVER a parsed
+    // `errorMessage` (T-171-26).
+    match status.status.as_str() {
+        "completed_dry_run" => {
+            render_preflight_report(&status, args.json, human_output)?;
+            Ok(())
+        },
+        "blocked" => {
+            render_preflight_report(&status, args.json, human_output)?;
+            bail!("Pre-flight blocked — see the disposition table above for the blocking row(s)");
+        },
+        "awaiting_bind" => {
+            render_preflight_report(&status, args.json, human_output)?;
+            if human_output {
+                println!(
+                    "\n{}",
+                    "Next step: bind the unbound slot(s) listed above (setPackageBinding), then re-run."
+                        .bright_black()
+                );
+            }
+            Ok(())
+        },
+        "failed" => bail_with_structured_error_code(&status),
+        other => bail!("Unexpected non-terminal import status after timeout: {other}"),
+    }
+}
+
+/// Bail on a `"failed"` terminal status, surfacing the STRUCTURED `errorCode`
+/// — NEVER the freeform `errorMessage` (T-171-26).
+fn bail_with_structured_error_code(status: &graphql::ImportStatus) -> Result<()> {
+    match status.error_code.as_deref() {
+        Some(code) => bail!("Import failed (errorCode: {code})"),
+        None => bail!("Import failed with no structured errorCode — check pmcp.run service logs"),
+    }
+}
+
+/// Fetch one import-status sample, folding in transient-failure handling.
+/// Returns `Ok(Some(status))` on success, `Ok(None)` when a transient
+/// transport error was tolerated (the caller retries; this already slept
+/// [`POLL_INTERVAL`]), or `Err` once [`MAX_TRANSIENT_RETRIES`] is exceeded.
+/// Extracted from [`poll_import_status`] to keep it within the complexity gate.
+async fn fetch_import_status_once(
+    access_token: &str,
+    import_id: &str,
+    transient_failures: &mut u32,
+    human_output: bool,
+) -> Result<Option<graphql::ImportStatus>> {
+    match graphql::get_import_status(access_token, import_id).await {
+        Ok(status) => {
+            *transient_failures = 0;
+            Ok(Some(status))
+        },
+        Err(err) => {
+            *transient_failures += 1;
+            if *transient_failures > MAX_TRANSIENT_RETRIES {
+                return Err(err).context("Exceeded max retries polling import status");
+            }
+            if human_output {
+                eprintln!(
+                    "   transient error polling import status ({transient_failures}/{MAX_TRANSIENT_RETRIES}): {err}"
+                );
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+            Ok(None)
+        },
+    }
+}
+
+/// Handle one in-progress (non-terminal) import poll tick: warn once for a
+/// genuinely unrecognized status (newer platform), print a progress dot, and
+/// flush. Extracted from [`poll_import_status`] to keep it within the
+/// complexity gate.
+fn note_import_in_progress(
+    status: &str,
+    warned_statuses: &mut std::collections::HashSet<String>,
+    dots: &mut u32,
+    human_output: bool,
+) -> Result<()> {
+    // Terminal detection stays exact — any other status is treated as
+    // in-progress so an older CLI keeps working when the platform adds
+    // intermediate statuses. Warn once per unrecognized status.
+    let recognized = matches!(
+        status,
+        "queued" | "admitting" | "pulling" | "resolving" | "preflighting" | "binding"
+    );
+    if !recognized && warned_statuses.insert(status.to_string()) {
+        if human_output && *dots > 0 {
+            println!();
+            *dots = 0;
+        }
+        eprintln!("   warning: unrecognized import status '{status}' — treating as in-progress");
+    }
+    if human_output {
+        print!(".");
+        *dots += 1;
+        if *dots >= 60 {
+            println!();
+            *dots = 0;
+        }
+        io::stdout().flush()?;
+    }
+    Ok(())
+}
+
+/// Dispatch a fetched import status: `Ok(Some(status))` when terminal (any of
+/// `completed_dry_run` / `blocked` / `awaiting_bind` / `failed` — Codex #13),
+/// `Err` on `not_found`, or `Ok(None)` when still in progress (a progress tick
+/// is noted here). Extracted from [`poll_import_status`] to keep it within the
+/// complexity gate.
+fn classify_import_status(
+    status: graphql::ImportStatus,
+    import_id: &str,
+    warned_statuses: &mut std::collections::HashSet<String>,
+    dots: &mut u32,
+    human_output: bool,
+) -> Result<Option<graphql::ImportStatus>> {
+    match status.status.as_str() {
+        "completed_dry_run" | "blocked" | "awaiting_bind" | "failed" => {
+            if human_output && *dots > 0 {
+                println!();
+            }
+            Ok(Some(status))
+        },
+        "not_found" => bail!("Import job {import_id} not found"),
+        in_progress => {
+            note_import_in_progress(in_progress, warned_statuses, dots, human_output)?;
+            Ok(None)
+        },
+    }
+}
+
+/// Poll `getImportStatus` until a terminal status is reached. ALL of
+/// `completed_dry_run` / `blocked` / `awaiting_bind` / `failed` are terminal
+/// (Codex #13) — the loop returns immediately on any of them and never waits
+/// out `MAX_POLL_WAIT` for a status that has already resolved.
+async fn poll_import_status(
+    access_token: &str,
+    import_id: &str,
+    human_output: bool,
+) -> Result<graphql::ImportStatus> {
+    if human_output {
+        println!("⏳ Waiting for import pre-flight to complete...");
+    }
+
+    let start = Instant::now();
+    let mut transient_failures = 0u32;
+    let mut dots = 0u32;
+    // Statuses we've already warned about — unknown (likely newer-platform)
+    // statuses are treated as in-progress, warned once each, never fatal.
+    let mut warned_statuses: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    loop {
+        if start.elapsed() > MAX_POLL_WAIT {
+            bail!(
+                "Timed out waiting for import {import_id} to reach a terminal status after {}s",
+                MAX_POLL_WAIT.as_secs()
+            );
+        }
+
+        let Some(status) = fetch_import_status_once(
+            access_token,
+            import_id,
+            &mut transient_failures,
+            human_output,
+        )
+        .await?
+        else {
+            continue;
+        };
+
+        if let Some(done) = classify_import_status(
+            status,
+            import_id,
+            &mut warned_statuses,
+            &mut dots,
+            human_output,
+        )? {
+            return Ok(done);
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+// ============================================================================
+// Pre-flight report rendering (171-05's persisted JSON schema — see
+// 171-05-SUMMARY.md "Pre-flight Report JSON Schema"). These types are a
+// CLI-side rendering DTO only — the canonical `PreflightReport` type lives in
+// the import Lambda's `model.rs` (a separate crate this CLI does not depend
+// on), so the field shape is mirrored here deliberately rather than shared.
+// ============================================================================
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Disposition {
+    #[serde(rename = "componentName")]
+    component_name: String,
+    disposition: String,
+    blocking: bool,
+    diagnostics: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct UnboundSlot {
+    #[serde(rename = "componentName")]
+    component_name: String,
+    #[serde(rename = "slotKind")]
+    slot_kind: String,
+    #[serde(rename = "slotName")]
+    slot_name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Deviation {
+    #[serde(rename = "componentName")]
+    component_name: String,
+    #[serde(rename = "slotName")]
+    slot_name: String,
+    #[serde(rename = "testedValue")]
+    tested_value: String,
+    #[serde(rename = "proposedValue")]
+    proposed_value: String,
+    acknowledged: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AllowlistResult {
+    #[serde(rename = "componentName")]
+    component_name: String,
+    violation: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ImpactEntry {
+    #[serde(rename = "componentName")]
+    component_name: String,
+    #[serde(rename = "referencingWorkflows")]
+    referencing_workflows: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PreflightReport {
+    dispositions: Vec<Disposition>,
+    #[serde(rename = "unboundSlots")]
+    unbound_slots: Vec<UnboundSlot>,
+    deviations: Vec<Deviation>,
+    #[serde(rename = "allowlistResults")]
+    allowlist_results: Vec<AllowlistResult>,
+    #[serde(rename = "impactList")]
+    impact_list: Vec<ImpactEntry>,
+    blocked: bool,
+}
+
+/// Parse and render the pre-flight report carried on a terminal
+/// `ImportStatus` — human tree by default (D-D), stable `--json` on request
+/// (json takes priority over quiet, mirroring `show.rs`). Never re-sorts
+/// anything: the Lambda's own `to_canonical_json()` already guarantees
+/// stable ordering.
+fn render_preflight_report(
+    status: &graphql::ImportStatus,
+    json: bool,
+    human_output: bool,
+) -> Result<()> {
+    let Some(raw) = status.preflight_report_json.as_deref() else {
+        if human_output {
+            eprintln!("(no pre-flight report available for this status)");
+        }
+        return Ok(());
+    };
+
+    let report: PreflightReport = serde_json::from_str(raw)
+        .context("Failed to parse pre-flight report JSON returned by the platform")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else if human_output {
+        render_tree(&report, &status.status);
+    }
+    Ok(())
+}
+
+/// Render the default human-readable pre-flight tree.
+fn render_tree(report: &PreflightReport, job_status: &str) {
+    println!(
+        "\n{} {}",
+        "Import pre-flight:".bright_cyan().bold(),
+        job_status
+    );
+
+    println!("\n  {}", "Dispositions:".bright_black());
+    if report.dispositions.is_empty() {
+        println!("    (none)");
+    }
+    for row in &report.dispositions {
+        render_disposition(row);
+    }
+
+    if !report.unbound_slots.is_empty() {
+        println!("\n  {}", "Unbound slots:".bright_black());
+        for slot in &report.unbound_slots {
+            println!(
+                "    - [{}] {} :: {}",
+                slot.slot_kind, slot.component_name, slot.slot_name
+            );
+        }
+    }
+
+    if !report.deviations.is_empty() {
+        println!("\n  {}", "Deviations:".bright_black());
+        for deviation in &report.deviations {
+            let ack = if deviation.acknowledged {
+                "acknowledged".green()
+            } else {
+                "UNACKNOWLEDGED".yellow().bold()
+            };
+            println!(
+                "    - {} :: {}  tested={} proposed={}  [{}]",
+                deviation.component_name,
+                deviation.slot_name,
+                deviation.tested_value,
+                deviation.proposed_value,
+                ack
+            );
+        }
+    }
+
+    let violations: Vec<&AllowlistResult> = report
+        .allowlist_results
+        .iter()
+        .filter(|r| r.violation.is_some())
+        .collect();
+    if !violations.is_empty() {
+        println!("\n  {}", "Allowlist violations:".red().bold());
+        for result in violations {
+            println!(
+                "    - {}: {}",
+                result.component_name,
+                result.violation.as_deref().unwrap_or("")
+            );
+        }
+    }
+
+    if !report.impact_list.is_empty() {
+        println!("\n  {}", "Impact (upgrade affects):".bright_black());
+        for entry in &report.impact_list {
+            println!(
+                "    - {} <- {}",
+                entry.component_name,
+                entry.referencing_workflows.join(", ")
+            );
+        }
+    }
+
+    println!();
+    if report.blocked {
+        println!("  {}", "BLOCKED".red().bold());
+    } else {
+        println!("  {}", "Not blocked".green());
+    }
+    println!();
+}
+
+/// One `Dispositions:` line, color-coded by disposition/blocking state.
+fn render_disposition(row: &Disposition) {
+    let label = if row.blocking {
+        row.disposition.red().bold()
+    } else {
+        match row.disposition.as_str() {
+            "reuse" => row.disposition.green(),
+            "install" => row.disposition.bright_blue(),
+            "upgrade" => row.disposition.yellow(),
+            _ => row.disposition.normal(),
+        }
+    };
+    match &row.diagnostics {
+        Some(diag) => println!(
+            "    - [{label}] {}  {}",
+            row.component_name,
+            diag.bright_black()
+        ),
+        None => println!("    - [{label}] {}", row.component_name),
+    }
+}

--- a/cargo-pmcp/src/commands/package/mod.rs
+++ b/cargo-pmcp/src/commands/package/mod.rs
@@ -1,16 +1,27 @@
-//! `cargo pmcp package <subcommand>` — inspect local AI-Package bundles.
+//! `cargo pmcp package <subcommand>` — inspect local AI-Package bundles, and
+//! capture/show/import/approve remote workflow packages against the pmcp.run
+//! platform.
 //!
 //! Mirrors the `workbook` command-group shape (D-01) with an ASYNC `execute`.
-//! `inspect` is a LOCAL, offline OCI-layout inspector. The verbs `show` and
-//! `capture` are deliberately NOT defined here — they are reserved for the
-//! platform's REMOTE capture service (remote manifest fetch / dependency-graph
-//! capture), which has opposite (remote) semantics and will land as a
-//! coordinated thin client against the platform's contract.
+//! `inspect` is a LOCAL, offline OCI-layout inspector (unchanged by this
+//! module). `capture`/`show`/`import`/`approve` are the platform's REMOTE
+//! thin client (D-10 — no agent-runtime semantics live in the CLI): `capture`
+//! submits an async dependency-graph-walk job for a team and polls it to
+//! completion; `show` fetches and renders an already published
+//! `WorkflowManifest` by `name@version`; `import` submits an async dry-run
+//! pre-flight import job and polls/renders the report (D-02 — dry-run is the
+//! ONLY supported mode this phase, no execute flag); `approve` writes an
+//! approval by workflow REFERENCE only (D-05/D-06/D-08 — the server resolves
+//! both digests, never a caller-supplied one).
 
+pub mod approve;
+pub mod capture;
+pub mod import;
 pub mod inspect;
 pub mod kind;
+pub mod show;
 
-use anyhow::Result;
+use anyhow::{anyhow, bail, Context, Result};
 use clap::Subcommand;
 
 use super::GlobalFlags;
@@ -20,6 +31,17 @@ use super::GlobalFlags;
 pub enum PackageCommand {
     /// Inspect the kind and key fields of a local AI-Package, fully offline
     Inspect(inspect::InspectArgs),
+    /// Submit an async capture job for a team's workflow dependency graph
+    /// (remote, platform-side — polls to a terminal status)
+    Capture(capture::CaptureArgs),
+    /// Fetch and render a published workflow manifest (remote, platform-side)
+    Show(show::ShowArgs),
+    /// Submit an async dry-run pre-flight import job and render the report
+    /// (remote, platform-side — dry-run is the ONLY mode this phase)
+    Import(import::ImportArgs),
+    /// Approve a workflow package by reference (admin-group + org-match
+    /// gated; the server resolves both digests — never a caller-supplied one)
+    Approve(approve::ApproveArgs),
 }
 
 impl PackageCommand {
@@ -27,6 +49,31 @@ impl PackageCommand {
     pub async fn execute(self, global_flags: &GlobalFlags) -> Result<()> {
         match self {
             PackageCommand::Inspect(args) => inspect::execute(args, global_flags),
+            PackageCommand::Capture(args) => capture::execute(args, global_flags).await,
+            PackageCommand::Show(args) => show::execute(args, global_flags).await,
+            PackageCommand::Import(args) => import::execute(args, global_flags).await,
+            PackageCommand::Approve(args) => approve::execute(args, global_flags).await,
         }
     }
+}
+
+/// Split a `name@X.Y.Z` reference on the LAST `@` (a component name may
+/// legitimately contain `@`), validating both halves are non-empty and the
+/// version half parses as semver. Shared by `import`/`approve` (mirrors
+/// `show.rs`'s own private copy of this exact logic, kept there unchanged
+/// since `show.rs` is outside this plan's `files_modified` scope).
+pub(super) fn parse_reference(reference: &str) -> Result<(&str, &str)> {
+    let (name, version) = reference
+        .rsplit_once('@')
+        .ok_or_else(|| anyhow!("invalid workflow reference '{reference}' — expected NAME@X.Y.Z"))?;
+    if name.is_empty() {
+        bail!("invalid workflow reference '{reference}' — component name is empty");
+    }
+    if version.is_empty() {
+        bail!("invalid workflow reference '{reference}' — version is empty");
+    }
+    semver::Version::parse(version).with_context(|| {
+        format!("invalid workflow reference '{reference}' — '{version}' is not valid semver")
+    })?;
+    Ok((name, version))
 }

--- a/cargo-pmcp/src/commands/package/show.rs
+++ b/cargo-pmcp/src/commands/package/show.rs
@@ -1,0 +1,152 @@
+//! `cargo pmcp package show` — fetch and render a published `WorkflowManifest`
+//! by `name@version` from the pmcp.run platform (D-D). Remote, platform-side
+//! read-only client — renders only, never re-sorts (the crate already
+//! guarantees stable `(component_type, name)` / slot-key ordering).
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Args;
+use colored::Colorize;
+use pmcp_package::reference::ComponentType;
+use pmcp_package::{ComponentRef, ConfigSlot, WorkflowManifest};
+
+use crate::commands::GlobalFlags;
+use crate::deployment::targets::pmcp_run::{auth, graphql};
+
+/// Arguments for `cargo pmcp package show`.
+#[derive(Debug, Args)]
+pub struct ShowArgs {
+    /// Workflow reference in `name@X.Y.Z` form (e.g. `support-triage@1.2.0`).
+    pub reference: String,
+
+    /// Emit stable diff JSON instead of the default human-readable tree.
+    ///
+    /// This is STABLE PRESENTATION JSON for `diff`-ing two `show` outputs —
+    /// it is NOT necessarily the canonical digest-serialization bytes used by
+    /// `WorkflowManifest::manifest_digest()`.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Fetch and render a published workflow manifest.
+pub async fn execute(args: ShowArgs, global_flags: &GlobalFlags) -> Result<()> {
+    let (name, version) = parse_reference(&args.reference)?;
+
+    let credentials = auth::get_credentials()
+        .await
+        .context("Not authenticated. Run: cargo pmcp login")?;
+
+    let response = graphql::get_workflow_package(&credentials.access_token, name, version)
+        .await
+        .with_context(|| format!("Failed to fetch workflow package {name}@{version}"))?;
+
+    // Deserialize the canonical WorkflowManifest JSON as-is — never re-sorted,
+    // the crate already guarantees `(component_type, name)` / slot-key order.
+    let manifest: WorkflowManifest = serde_json::from_str(&response.manifest_json)
+        .context("Failed to parse WorkflowManifest JSON returned by the platform")?;
+
+    if args.json {
+        // Stable diff JSON (D-D) — NOT necessarily the canonical digest bytes.
+        println!("{}", serde_json::to_string_pretty(&manifest)?);
+    } else if global_flags.should_output() {
+        render_tree(&manifest, &response.manifest_digest);
+    }
+
+    Ok(())
+}
+
+/// Split a `name@X.Y.Z` reference on the LAST `@` (a component name may
+/// legitimately contain `@`), validating both halves are non-empty and the
+/// version half parses as semver.
+fn parse_reference(reference: &str) -> Result<(&str, &str)> {
+    let (name, version) = reference
+        .rsplit_once('@')
+        .ok_or_else(|| anyhow!("invalid workflow reference '{reference}' — expected NAME@X.Y.Z"))?;
+    if name.is_empty() {
+        bail!("invalid workflow reference '{reference}' — component name is empty");
+    }
+    if version.is_empty() {
+        bail!("invalid workflow reference '{reference}' — version is empty");
+    }
+    semver::Version::parse(version).with_context(|| {
+        format!("invalid workflow reference '{reference}' — '{version}' is not valid semver")
+    })?;
+    Ok((name, version))
+}
+
+/// Render the default human-readable tree. Components and slots are printed
+/// in the ORDER the crate already produced (canonical `(component_type,
+/// name)` / slot-key sort) — this fn never sorts anything itself.
+fn render_tree(manifest: &WorkflowManifest, manifest_digest: &str) {
+    println!(
+        "\n{} {} @ {}",
+        "Workflow".bright_cyan().bold(),
+        manifest.name.bright_green().bold(),
+        manifest.version
+    );
+    println!("  {} {}", "Digest:".bright_black(), manifest_digest);
+    println!(
+        "  {} {} ({})",
+        "Captured:".bright_black(),
+        manifest.provenance.timestamp,
+        manifest.provenance.source_environment
+    );
+
+    println!("\n  {}", "Components:".bright_black());
+    if manifest.components.is_empty() {
+        println!("    (none)");
+    }
+    for component in &manifest.components {
+        render_component(component);
+    }
+
+    if !manifest.aggregated_slots.is_empty() {
+        println!("\n  {}", "Config slots:".bright_black());
+        for slot in &manifest.aggregated_slots {
+            render_slot(slot);
+        }
+    }
+    println!();
+}
+
+/// One `Components:` line — pins show version + digest; a stray unpinned
+/// range (should never happen in a published `WorkflowManifest`, but this is
+/// a display path, not the validation boundary) is called out explicitly
+/// rather than panicking.
+fn render_component(component: &ComponentRef) {
+    let type_label = component_type_label(component.component_type());
+    match component {
+        ComponentRef::Pinned(pinned) => {
+            println!(
+                "    - [{}] {} @ {}  {}",
+                type_label,
+                pinned.name,
+                pinned.version,
+                pinned.digest.as_str().bright_black()
+            );
+        },
+        ComponentRef::Range { name, range, .. } => {
+            println!("    - [{type_label}] {name} @ {range} (unpinned range)");
+        },
+    }
+}
+
+/// Lowercase display label for a `ComponentType`.
+fn component_type_label(component_type: ComponentType) -> &'static str {
+    match component_type {
+        ComponentType::Server => "server",
+        ComponentType::Agent => "agent",
+        ComponentType::Team => "team",
+    }
+}
+
+/// One `Config slots:` line. Behavior-relevant slots (`LlmProvider`,
+/// `BudgetOverride`) show their `tested_value`; identity-bearing slots
+/// (`Secret`, `OauthClient`, `ChannelBinding`, `HumanRole`) show only their
+/// name — the type structurally has no value field to leak.
+fn render_slot(slot: &ConfigSlot) {
+    let (kind, name) = slot.slot.key();
+    match slot.slot.tested_value() {
+        Some(value) => println!("    - {kind}:{name} = {value}"),
+        None => println!("    - {kind}:{name}"),
+    }
+}

--- a/cargo-pmcp/src/deployment/targets/pmcp_run/graphql.rs
+++ b/cargo-pmcp/src/deployment/targets/pmcp_run/graphql.rs
@@ -396,7 +396,10 @@ async fn execute_graphql<T>(
 where
     T: for<'de> Deserialize<'de>,
 {
-    let client = reqwest::Client::new();
+    // Process-wide client: reuses connections across calls (the capture poll
+    // loop hits this every 2s — a per-call client would redo TCP+TLS each time).
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    let client = CLIENT.get_or_init(reqwest::Client::new);
     let graphql_url = get_graphql_url();
 
     let request = GraphQLRequest {
@@ -1247,4 +1250,457 @@ pub async fn upload_loadtest_scenario(
         execute_graphql(access_token, query, variables).await?;
 
     Ok(response.upload_loadtest_scenario)
+}
+
+// ============================================================================
+// Package capture service (170-08 D-A/D-B/D-D) — the `cargo pmcp package
+// capture|show` remote thin client. Mirrors the create_deployment_from_s3 /
+// get_deployment async-job idiom above for a second job type.
+// ============================================================================
+
+/// Response from `submitPackageCapture` mutation (170-08 D-A).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct CaptureInfo {
+    #[serde(rename = "captureId")]
+    pub capture_id: String,
+    pub status: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+/// Status from `getPackageCaptureStatus` query — the STRUCTURED D-B error
+/// contract (170-02's landed platform contract). The caller switches on
+/// `error_code` and reads `divergent_components` directly; `message` is
+/// display-only and MUST NEVER be parsed to detect `BUMP_REQUIRED` or any
+/// other error condition.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct CaptureStatus {
+    pub id: String,
+    pub status: String,
+    pub message: Option<String>,
+    #[serde(rename = "errorCode")]
+    pub error_code: Option<String>,
+    #[serde(rename = "divergentComponents")]
+    pub divergent_components: Option<Vec<String>>,
+    #[serde(rename = "manifestDigest")]
+    pub manifest_digest: Option<String>,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: Option<String>,
+}
+
+/// Response from `getWorkflowPackageManifest` query — a published `WorkflowManifest`
+/// looked up by `name`+`version` (org-scoped server-side by the caller's own
+/// claim; the CLI never supplies an org id).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct WorkflowPackageResp {
+    pub name: String,
+    pub version: String,
+    #[serde(rename = "manifestJson")]
+    pub manifest_json: String,
+    #[serde(rename = "manifestDigest")]
+    pub manifest_digest: String,
+}
+
+// The two runtime queries below live in `graphql_contract.rs` — a
+// dependency-light leaf that's also mounted directly into the `cargo-pmcp`
+// lib target (via `#[path]` in `lib.rs`) so the offline blocking contract
+// test (`tests/package_capture_contract.rs`) can validate them against the
+// vendored SDL without pulling this file's `reqwest`/auth/deploy tree into
+// the lib target. Re-exported here so the rest of this file (and any other
+// `pmcp_run` code) can keep referring to them unqualified.
+pub(crate) use super::graphql_contract::{
+    GET_PACKAGE_CAPTURE_STATUS_QUERY, SUBMIT_PACKAGE_CAPTURE_QUERY,
+};
+
+/// Submit an async package-capture job for a team's workflow dependency graph
+/// (170-08 D-A). `root_type` is always `"team"` in v1; `root_id` is the
+/// `AgentTeam` UUID. Never awaits the walk — returns the queued job id.
+pub async fn submit_package_capture(
+    access_token: &str,
+    root_type: &str,
+    root_id: &str,
+    version: &str,
+    bump: Option<&str>,
+) -> Result<CaptureInfo> {
+    let query = SUBMIT_PACKAGE_CAPTURE_QUERY;
+
+    let variables = serde_json::json!({
+        "rootComponentType": root_type,
+        "rootComponentId": root_id,
+        "version": version,
+        "bump": bump,
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct SubmitPackageCaptureResponse {
+        #[serde(rename = "submitPackageCapture")]
+        submit_package_capture: Option<CaptureInfo>,
+    }
+
+    let response: SubmitPackageCaptureResponse =
+        execute_graphql(access_token, query, variables).await?;
+
+    response
+        .submit_package_capture
+        .context("submitPackageCapture returned null - check pmcp.run service logs")
+}
+
+/// Poll a package-capture job's status once (170-08 D-A/D-B). The caller is
+/// responsible for looping/sleeping between calls — this fn does a single
+/// consistent-read-backed fetch.
+pub async fn get_package_capture_status(
+    access_token: &str,
+    capture_id: &str,
+) -> Result<CaptureStatus> {
+    let query = GET_PACKAGE_CAPTURE_STATUS_QUERY;
+
+    let variables = serde_json::json!({
+        "id": capture_id
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct GetPackageCaptureStatusResponse {
+        #[serde(rename = "getPackageCaptureStatus")]
+        get_package_capture_status: Option<CaptureStatus>,
+    }
+
+    let response: GetPackageCaptureStatusResponse =
+        execute_graphql(access_token, query, variables).await?;
+
+    response
+        .get_package_capture_status
+        .context("Capture job not found")
+}
+
+/// Fetch a published workflow manifest by `name`+`version` (170-08 D-D
+/// `package show`) — a plain org-scoped DDB read server-side, NOT ECR.
+pub async fn get_workflow_package(
+    access_token: &str,
+    name: &str,
+    version: &str,
+) -> Result<WorkflowPackageResp> {
+    let query = r#"
+        query GetWorkflowPackage($name: String!, $version: String!) {
+            getWorkflowPackageManifest(name: $name, version: $version) {
+                name
+                version
+                manifestJson
+                manifestDigest
+            }
+        }
+    "#;
+
+    let variables = serde_json::json!({
+        "name": name,
+        "version": version,
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct GetWorkflowPackageResponse {
+        #[serde(rename = "getWorkflowPackageManifest")]
+        get_workflow_package: Option<WorkflowPackageResp>,
+    }
+
+    let response: GetWorkflowPackageResponse =
+        execute_graphql(access_token, query, variables).await?;
+
+    response
+        .get_workflow_package
+        .with_context(|| format!("WorkflowPackage not found: {name}@{version}"))
+}
+
+// ============================================================================
+// AI-Package import control plane (Phase 171 D-02/D-04/D-05) — the
+// `cargo pmcp package import|approve` remote thin client. Mirrors the
+// capture/show idiom above for a second async job type (`ImportJob`) plus
+// one-shot governance mutations. Reference-based ONLY: the caller supplies a
+// workflow `name@version` reference (or an `organizationId`+`name`+`version`
+// triple for the governance mutations) — NEVER a payload/OCI digest (Codex
+// #1 / T-171-25b). The server resolves both digests server-side.
+// ============================================================================
+
+/// Response from `submitImport` mutation (D-04). `status` is always
+/// `"queued"` on success.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct ImportInfo {
+    #[serde(rename = "importId")]
+    pub import_id: String,
+    pub status: String,
+}
+
+/// Status from `getImportStatus` query. `preflight_report_json` carries the
+/// full Codex #7 disposition/deviation/allowlist/impact report once a
+/// terminal status is reached (`completed_dry_run` / `blocked` /
+/// `awaiting_bind`). `error_code` (NEVER `error_message`) is the only field
+/// the CLI switches on for a `"failed"` terminal status (T-171-26).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct ImportStatus {
+    pub status: String,
+    #[serde(rename = "errorCode")]
+    pub error_code: Option<String>,
+    #[serde(rename = "errorMessage")]
+    pub error_message: Option<String>,
+    #[serde(rename = "preflightReportJson")]
+    pub preflight_report_json: Option<String>,
+}
+
+/// Response from the `approvePackage` mutation (D-06/D-08).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct ApprovalInfo {
+    pub id: String,
+    #[serde(rename = "approvedAt")]
+    pub approved_at: String,
+}
+
+/// Response from the `revokeApprovedPackage` mutation (D-08 — append-only;
+/// the server flips a `revoked` flag rather than deleting the row).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct RevocationInfo {
+    pub id: String,
+    #[serde(rename = "revokedAt")]
+    pub revoked_at: String,
+}
+
+/// Response from the `setPackageBinding` mutation (D-09/D-12). `status` is
+/// always `"binding"` on success — the job resumes asynchronously; the
+/// caller must poll `getImportStatus` to observe the real outcome.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct BindingInfo {
+    #[serde(rename = "importId")]
+    pub import_id: String,
+    pub status: String,
+}
+
+/// Submit an async dry-run pre-flight import job for a workflow REFERENCE
+/// (D-02/D-04). ALWAYS sends `dryRun: true` — the server rejects any submit
+/// where `dryRun` is not explicitly `true` (171-07); there is no client-side
+/// way to request real execution this phase (deferred to Phase 172).
+pub async fn submit_package_import(access_token: &str, reference: &str) -> Result<ImportInfo> {
+    let query = r#"
+        mutation SubmitImport($reference: String!, $dryRun: Boolean) {
+            submitImport(reference: $reference, dryRun: $dryRun) {
+                importId
+                status
+            }
+        }
+    "#;
+
+    let variables = serde_json::json!({
+        "reference": reference,
+        "dryRun": true,
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct SubmitImportResponse {
+        #[serde(rename = "submitImport")]
+        submit_import: Option<ImportInfo>,
+    }
+
+    let response: SubmitImportResponse = execute_graphql(access_token, query, variables).await?;
+
+    response
+        .submit_import
+        .context("submitImport returned null - check pmcp.run service logs")
+}
+
+/// Poll an import job's status once (D-04). The caller is responsible for
+/// looping/sleeping between calls — this fn does a single
+/// consistent-read-backed fetch.
+pub async fn get_import_status(access_token: &str, import_id: &str) -> Result<ImportStatus> {
+    let query = r#"
+        query GetImportStatus($importId: String!) {
+            getImportStatus(importId: $importId) {
+                status
+                errorCode
+                errorMessage
+                preflightReportJson
+            }
+        }
+    "#;
+
+    let variables = serde_json::json!({
+        "importId": import_id,
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct GetImportStatusResponse {
+        #[serde(rename = "getImportStatus")]
+        get_import_status: Option<ImportStatus>,
+    }
+
+    let response: GetImportStatusResponse = execute_graphql(access_token, query, variables).await?;
+
+    response.get_import_status.context("Import job not found")
+}
+
+/// Approve a workflow package by REFERENCE only (D-05/D-06/D-08) — the
+/// server resolves BOTH digests from the source `WorkflowPackage` row; the
+/// CLI never derives or sends a digest (Codex #1 / T-171-25b). `evidence` is
+/// an optional freeform link/note (D-07).
+pub async fn approve_package(
+    access_token: &str,
+    organization_id: &str,
+    workflow_name: &str,
+    workflow_version: &str,
+    evidence: Option<&str>,
+) -> Result<ApprovalInfo> {
+    let query = r#"
+        mutation ApprovePackage(
+            $organizationId: String!,
+            $workflowName: String!,
+            $workflowVersion: String!,
+            $evidence: String
+        ) {
+            approvePackage(
+                organizationId: $organizationId,
+                workflowName: $workflowName,
+                workflowVersion: $workflowVersion,
+                evidence: $evidence
+            ) {
+                id
+                approvedAt
+            }
+        }
+    "#;
+
+    let variables = serde_json::json!({
+        "organizationId": organization_id,
+        "workflowName": workflow_name,
+        "workflowVersion": workflow_version,
+        "evidence": evidence,
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct ApprovePackageResponse {
+        #[serde(rename = "approvePackage")]
+        approve_package: Option<ApprovalInfo>,
+    }
+
+    let response: ApprovePackageResponse = execute_graphql(access_token, query, variables).await?;
+
+    response
+        .approve_package
+        .context("approvePackage returned null - check pmcp.run service logs")
+}
+
+/// Revoke a previously-approved workflow package by REFERENCE only (D-08).
+/// Not yet wired to a CLI verb (Plan 09 exposes `import`/`approve`, not
+/// `revoke`) — provided now so a future CLI verb or admin UI never needs a
+/// second, divergent client implementation of this mutation.
+#[allow(dead_code)]
+pub async fn revoke_approved_package(
+    access_token: &str,
+    organization_id: &str,
+    workflow_name: &str,
+    workflow_version: &str,
+) -> Result<RevocationInfo> {
+    let query = r#"
+        mutation RevokeApprovedPackage(
+            $organizationId: String!,
+            $workflowName: String!,
+            $workflowVersion: String!
+        ) {
+            revokeApprovedPackage(
+                organizationId: $organizationId,
+                workflowName: $workflowName,
+                workflowVersion: $workflowVersion
+            ) {
+                id
+                revokedAt
+            }
+        }
+    "#;
+
+    let variables = serde_json::json!({
+        "organizationId": organization_id,
+        "workflowName": workflow_name,
+        "workflowVersion": workflow_version,
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct RevokeApprovedPackageResponse {
+        #[serde(rename = "revokeApprovedPackage")]
+        revoke_approved_package: Option<RevocationInfo>,
+    }
+
+    let response: RevokeApprovedPackageResponse =
+        execute_graphql(access_token, query, variables).await?;
+
+    response
+        .revoke_approved_package
+        .context("revokeApprovedPackage returned null - check pmcp.run service logs")
+}
+
+/// Stage a binding (+optional per-deviation acknowledgments) onto an import
+/// job and resume it (D-09/D-12). `status` is always `"binding"` on success —
+/// bindings are NOT visible immediately; poll `getImportStatus` for the real
+/// outcome (`completed_dry_run` / `blocked` / another `awaiting_bind`). Not
+/// yet wired to a CLI verb this phase — provided for the same forward-looking
+/// reason as `revoke_approved_package` above.
+#[allow(dead_code)]
+pub async fn set_package_binding(
+    access_token: &str,
+    import_id: &str,
+    organization_id: &str,
+    component_name: &str,
+    slot_kind: &str,
+    slot_name: &str,
+    bound_value: &str,
+    acknowledgments: Option<serde_json::Value>,
+) -> Result<BindingInfo> {
+    let query = r#"
+        mutation SetPackageBinding(
+            $importId: String!,
+            $organizationId: String!,
+            $componentName: String!,
+            $slotKind: String!,
+            $slotName: String!,
+            $boundValue: String!,
+            $acknowledgments: AWSJSON
+        ) {
+            setPackageBinding(
+                importId: $importId,
+                organizationId: $organizationId,
+                componentName: $componentName,
+                slotKind: $slotKind,
+                slotName: $slotName,
+                boundValue: $boundValue,
+                acknowledgments: $acknowledgments
+            ) {
+                importId
+                status
+            }
+        }
+    "#;
+
+    let variables = serde_json::json!({
+        "importId": import_id,
+        "organizationId": organization_id,
+        "componentName": component_name,
+        "slotKind": slot_kind,
+        "slotName": slot_name,
+        "boundValue": bound_value,
+        "acknowledgments": acknowledgments,
+    });
+
+    #[derive(Debug, Deserialize)]
+    struct SetPackageBindingResponse {
+        #[serde(rename = "setPackageBinding")]
+        set_package_binding: Option<BindingInfo>,
+    }
+
+    let response: SetPackageBindingResponse =
+        execute_graphql(access_token, query, variables).await?;
+
+    response
+        .set_package_binding
+        .context("setPackageBinding returned null - check pmcp.run service logs")
 }

--- a/cargo-pmcp/src/deployment/targets/pmcp_run/graphql_contract.rs
+++ b/cargo-pmcp/src/deployment/targets/pmcp_run/graphql_contract.rs
@@ -1,0 +1,468 @@
+//! The exact runtime GraphQL operations sent by the package-capture client
+//! (`graphql.rs`'s `submit_package_capture` / `get_package_capture_status`),
+//! factored into their own dependency-light leaf. Also hosts the PURE,
+//! IO-free SDL-extraction helpers shared with the `capture_contract` dev
+//! binary (`src/bin/capture_contract.rs`) — see the "Shared pure SDL
+//! extraction" section below.
+//!
+//! This file exists ONLY so the offline blocking contract test
+//! (`tests/package_capture_contract.rs`) can validate the real runtime
+//! queries against the vendored SDL (`contracts/pmcp-run/capture-v1.graphql`)
+//! without pulling `pmcp_run`'s auth/deploy/reqwest tree into the `cargo-pmcp`
+//! lib target. It is mounted into the lib target via `#[path]` in `lib.rs`
+//! (mirrors the `templates_workbook_server` / `agent_run` / `package_kind`
+//! narrow-leaf convention already used there) and re-exported as
+//! `crate::pmcp_run_graphql` — `#[doc(hidden)]`, not a stable public API.
+//!
+//! `graphql.rs` re-exports these same consts via `super::graphql_contract::*`
+//! so there is exactly one source of truth for both operations.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+/// The exact `submitPackageCapture` operation the CLI sends. Shared with the
+/// offline contract test (`tests/package_capture_contract.rs`) so the test
+/// validates the real runtime query against the vendored SDL.
+pub const SUBMIT_PACKAGE_CAPTURE_QUERY: &str = r#"
+        mutation SubmitPackageCapture(
+            $rootComponentType: String!,
+            $rootComponentId: String!,
+            $version: String!,
+            $bump: String
+        ) {
+            submitPackageCapture(
+                rootComponentType: $rootComponentType,
+                rootComponentId: $rootComponentId,
+                version: $version,
+                bump: $bump
+            ) {
+                captureId
+                status
+                createdAt
+            }
+        }
+    "#;
+
+/// The exact `getPackageCaptureStatus` operation the CLI sends. Shared with the
+/// offline contract test.
+pub const GET_PACKAGE_CAPTURE_STATUS_QUERY: &str = r#"
+        query GetPackageCaptureStatus($id: ID!) {
+            getPackageCaptureStatus(id: $id) {
+                id
+                status
+                message
+                errorCode
+                divergentComponents
+                manifestDigest
+                updatedAt
+            }
+        }
+    "#;
+
+// ============================================================================
+// Shared pure SDL extraction (moved from `src/bin/capture_contract.rs`)
+// ============================================================================
+//
+// These functions are PURE and IO-free (no network, no auth, no `main`/CLI
+// parsing — that stays in the `capture_contract` bin). They are mounted here,
+// in the already-dual-mounted `graphql_contract` leaf, so their unit tests
+// run under the default `cargo test -p cargo-pmcp` (the lib target) even
+// though the `capture_contract` binary itself is now gated behind the
+// non-default `capture-contract-tool` feature and is NOT built by a default
+// `cargo install cargo-pmcp`. The `capture_contract` bin imports these via
+// `cargo_pmcp::pmcp_run_graphql::{...}` (it links only the `cargo_pmcp` lib
+// crate, not the bin-only `deployment` module tree — see that file's module
+// docs for why).
+//
+// `#[allow(dead_code)]` below: this same file is ALSO privately mounted (via
+// `#[path]`) into the `cargo-pmcp` BIN target's own module tree
+// (`deployment/targets/pmcp_run/mod.rs`), where `graphql.rs` only reaches the
+// two query consts above — none of `cargo-pmcp`'s own `main()` call graph
+// invokes these SDL-extraction helpers, so `cargo build -p cargo-pmcp`
+// (which does NOT build the feature-gated `capture_contract` bin) would
+// otherwise flag them dead in that target. They ARE live: used by this
+// file's own tests (both mount points) and, in the LIB target, by the
+// `capture_contract` bin via `cargo_pmcp::pmcp_run_graphql::*`.
+
+/// From an introspected schema (`schema_json["__schema"]`), select ONLY the
+/// `Mutation.submitPackageCapture` and `Query.getPackageCaptureStatus`
+/// fields, their argument types, and the two OBJECT types they return, and
+/// render the result as SDL.
+///
+/// Pure and offline-testable — no network, no auth. `status` fields render
+/// as whatever SCALAR the schema says (always `String` in practice) — this
+/// function never invents an enum.
+#[allow(dead_code)]
+pub fn extract_capture_sdl(schema_json: &Value) -> Result<String> {
+    let schema = schema_json
+        .get("__schema")
+        .context("introspection response missing __schema key")?;
+    let types = schema
+        .get("types")
+        .and_then(Value::as_array)
+        .context("__schema missing types[]")?;
+
+    let mutation_type_name = schema
+        .get("mutationType")
+        .and_then(|m| m.get("name"))
+        .and_then(Value::as_str)
+        .context("__schema missing mutationType.name")?;
+    let query_type_name = schema
+        .get("queryType")
+        .and_then(|q| q.get("name"))
+        .and_then(Value::as_str)
+        .context("__schema missing queryType.name")?;
+
+    let mutation_type = find_type(types, mutation_type_name)
+        .with_context(|| format!("Mutation type '{mutation_type_name}' not found in types[]"))?;
+    let query_type = find_type(types, query_type_name)
+        .with_context(|| format!("Query type '{query_type_name}' not found in types[]"))?;
+
+    let submit_field = find_field(mutation_type, "submitPackageCapture")
+        .context("submitPackageCapture field not found on the Mutation type — wrong endpoint?")?;
+    let status_field = find_field(query_type, "getPackageCaptureStatus")
+        .context("getPackageCaptureStatus field not found on the Query type — wrong endpoint?")?;
+
+    let submit_type_ref = submit_field.get("type").unwrap_or(&Value::Null);
+    let status_type_ref = status_field.get("type").unwrap_or(&Value::Null);
+
+    let submit_ret_name = unwrap_named_type(submit_type_ref)
+        .context("submitPackageCapture return type could not be resolved to a named type")?;
+    let status_ret_name = unwrap_named_type(status_type_ref)
+        .context("getPackageCaptureStatus return type could not be resolved to a named type")?;
+
+    let submit_ret_type = find_type(types, submit_ret_name)
+        .with_context(|| format!("return type '{submit_ret_name}' not found in types[]"))?;
+    let status_ret_type = find_type(types, status_ret_name)
+        .with_context(|| format!("return type '{status_ret_name}' not found in types[]"))?;
+
+    let mut sdl = String::new();
+    sdl.push_str(&render_object_type(submit_ret_type));
+    sdl.push('\n');
+    sdl.push_str(&render_object_type(status_ret_type));
+    sdl.push('\n');
+    sdl.push_str(&format!(
+        "type {mutation_type_name} {{\n  submitPackageCapture({}): {}\n}}\n",
+        render_args(submit_field),
+        render_type_ref(submit_type_ref)
+    ));
+    sdl.push('\n');
+    sdl.push_str(&format!(
+        "type {query_type_name} {{\n  getPackageCaptureStatus({}): {}\n}}\n",
+        render_args(status_field),
+        render_type_ref(status_type_ref)
+    ));
+
+    Ok(sdl)
+}
+
+/// Guard against introspecting the wrong (merged) endpoint: assert the
+/// introspected schema actually contains both capture ops.
+#[allow(dead_code)]
+pub fn assert_capture_ops_present(schema_data: &Value, source_url: &str) -> Result<()> {
+    if schema_has_capture_ops(schema_data) {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "error: introspected schema has no capture ops — wrong endpoint? expected the \
+             source data API (amplifyData) behind api_url, got {source_url}"
+        )
+    }
+}
+
+/// Pure check: does `schema_data["__schema"]` contain both
+/// `Mutation.submitPackageCapture` and `Query.getPackageCaptureStatus`?
+#[allow(dead_code)]
+fn schema_has_capture_ops(schema_data: &Value) -> bool {
+    (|| -> Option<bool> {
+        let schema = schema_data.get("__schema")?;
+        let types = schema.get("types")?.as_array()?;
+        let mutation_name = schema.get("mutationType")?.get("name")?.as_str()?;
+        let query_name = schema.get("queryType")?.get("name")?.as_str()?;
+        let mutation_type = find_type(types, mutation_name)?;
+        let query_type = find_type(types, query_name)?;
+        let has_submit = find_field(mutation_type, "submitPackageCapture").is_some();
+        let has_status = find_field(query_type, "getPackageCaptureStatus").is_some();
+        Some(has_submit && has_status)
+    })()
+    .unwrap_or(false)
+}
+
+/// Find a type by name in `__schema.types[]`.
+#[allow(dead_code)]
+fn find_type<'a>(types: &'a [Value], name: &str) -> Option<&'a Value> {
+    types
+        .iter()
+        .find(|t| t.get("name").and_then(Value::as_str) == Some(name))
+}
+
+/// Find a field by name on a type's `fields[]`.
+#[allow(dead_code)]
+fn find_field<'a>(type_obj: &'a Value, field_name: &str) -> Option<&'a Value> {
+    type_obj
+        .get("fields")?
+        .as_array()?
+        .iter()
+        .find(|f| f.get("name").and_then(Value::as_str) == Some(field_name))
+}
+
+/// Render a GraphQL introspection type-ref as SDL, unwrapping `NON_NULL`/
+/// `LIST` nesting: `T`, `T!`, `[T]`, `[T!]!`, etc.
+#[allow(dead_code)]
+fn render_type_ref(t: &Value) -> String {
+    match t.get("kind").and_then(Value::as_str) {
+        Some("NON_NULL") => format!(
+            "{}!",
+            render_type_ref(t.get("ofType").unwrap_or(&Value::Null))
+        ),
+        Some("LIST") => format!(
+            "[{}]",
+            render_type_ref(t.get("ofType").unwrap_or(&Value::Null))
+        ),
+        _ => t
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("Unknown")
+            .to_string(),
+    }
+}
+
+/// Unwrap `NON_NULL`/`LIST` nesting down to the innermost named type (used to
+/// resolve a field's return OBJECT type for lookup in `types[]`).
+#[allow(dead_code)]
+fn unwrap_named_type(t: &Value) -> Option<&str> {
+    match t.get("kind").and_then(Value::as_str) {
+        Some("NON_NULL") | Some("LIST") => unwrap_named_type(t.get("ofType")?),
+        _ => t.get("name").and_then(Value::as_str),
+    }
+}
+
+/// Render a field's `args[]` as a comma-separated SDL argument list.
+#[allow(dead_code)]
+fn render_args(field: &Value) -> String {
+    let Some(args) = field.get("args").and_then(Value::as_array) else {
+        return String::new();
+    };
+    args.iter()
+        .map(|a| {
+            let name = a.get("name").and_then(Value::as_str).unwrap_or("");
+            let ty = render_type_ref(a.get("type").unwrap_or(&Value::Null));
+            format!("{name}: {ty}")
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Render an OBJECT type's `fields[]` (deterministic, introspection order) as
+/// a `type Name { ... }` SDL block.
+#[allow(dead_code)]
+fn render_object_type(type_obj: &Value) -> String {
+    let name = type_obj
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("Unknown");
+    let mut out = format!("type {name} {{\n");
+    if let Some(fields) = type_obj.get("fields").and_then(Value::as_array) {
+        for f in fields {
+            let fname = f.get("name").and_then(Value::as_str).unwrap_or("");
+            let fty = render_type_ref(f.get("type").unwrap_or(&Value::Null));
+            out.push_str(&format!("  {fname}: {fty}\n"));
+        }
+    }
+    out.push_str("}\n");
+    out
+}
+
+/// Strip a vendored contract file's leading provenance header: lines
+/// starting with `#` and blank lines before the first SDL token.
+#[allow(dead_code)]
+pub fn strip_provenance_header(content: &str) -> String {
+    content
+        .lines()
+        .skip_while(|line| line.trim().is_empty() || line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ============================================================================
+// Tests (moved from `src/bin/capture_contract.rs`)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A canned `__schema` introspection fixture (the shape
+    /// `extract_capture_sdl` expects: a `data`-object-like value carrying a
+    /// top-level `__schema` key) modeled on the CLI's real
+    /// `submitPackageCapture`/`getPackageCaptureStatus` operations
+    /// (`cargo-pmcp/src/deployment/targets/pmcp_run/graphql.rs`).
+    fn capture_schema_fixture() -> Value {
+        serde_json::json!({
+            "__schema": {
+                "queryType": { "name": "Query" },
+                "mutationType": { "name": "Mutation" },
+                "types": [
+                    {
+                        "kind": "OBJECT",
+                        "name": "Mutation",
+                        "fields": [
+                            {
+                                "name": "submitPackageCapture",
+                                "args": [
+                                    { "name": "rootComponentType", "type": non_null(scalar("String")) },
+                                    { "name": "rootComponentId", "type": non_null(scalar("String")) },
+                                    { "name": "version", "type": non_null(scalar("String")) },
+                                    { "name": "bump", "type": scalar("String") },
+                                ],
+                                "type": non_null(object_ref("CaptureInfo")),
+                            }
+                        ],
+                    },
+                    {
+                        "kind": "OBJECT",
+                        "name": "Query",
+                        "fields": [
+                            {
+                                "name": "getPackageCaptureStatus",
+                                "args": [
+                                    { "name": "id", "type": non_null(scalar("ID")) },
+                                ],
+                                "type": object_ref("CaptureStatus"),
+                            }
+                        ],
+                    },
+                    {
+                        "kind": "OBJECT",
+                        "name": "CaptureInfo",
+                        "fields": [
+                            { "name": "captureId", "args": [], "type": non_null(scalar("String")) },
+                            { "name": "status", "args": [], "type": non_null(scalar("String")) },
+                            { "name": "createdAt", "args": [], "type": non_null(scalar("String")) },
+                        ],
+                    },
+                    {
+                        "kind": "OBJECT",
+                        "name": "CaptureStatus",
+                        "fields": [
+                            { "name": "id", "args": [], "type": non_null(scalar("ID")) },
+                            { "name": "status", "args": [], "type": scalar("String") },
+                            { "name": "message", "args": [], "type": scalar("String") },
+                            { "name": "errorCode", "args": [], "type": scalar("String") },
+                            { "name": "divergentComponents", "args": [], "type": list(non_null(scalar("String"))) },
+                            { "name": "manifestDigest", "args": [], "type": scalar("String") },
+                            { "name": "updatedAt", "args": [], "type": scalar("String") },
+                        ],
+                    },
+                ],
+            }
+        })
+    }
+
+    fn scalar(name: &str) -> Value {
+        serde_json::json!({ "kind": "SCALAR", "name": name, "ofType": null })
+    }
+
+    fn object_ref(name: &str) -> Value {
+        serde_json::json!({ "kind": "OBJECT", "name": name, "ofType": null })
+    }
+
+    fn non_null(inner: Value) -> Value {
+        serde_json::json!({ "kind": "NON_NULL", "name": null, "ofType": inner })
+    }
+
+    fn list(inner: Value) -> Value {
+        serde_json::json!({ "kind": "LIST", "name": null, "ofType": inner })
+    }
+
+    #[test]
+    fn extract_capture_sdl_renders_expected_shape() {
+        let sdl =
+            extract_capture_sdl(&capture_schema_fixture()).expect("extraction should succeed");
+
+        // The two ops, rendered on the Mutation/Query root types.
+        assert!(
+            sdl.contains("type Mutation {"),
+            "missing Mutation block:\n{sdl}"
+        );
+        assert!(
+            sdl.contains("submitPackageCapture("),
+            "missing submitPackageCapture:\n{sdl}"
+        );
+        assert!(sdl.contains("type Query {"), "missing Query block:\n{sdl}");
+        assert!(
+            sdl.contains("getPackageCaptureStatus(id: ID!)"),
+            "missing getPackageCaptureStatus(id: ID!):\n{sdl}"
+        );
+
+        // status is ALWAYS String, never an invented enum.
+        assert!(
+            sdl.contains("status: String") || sdl.contains("status: String!"),
+            "status must render as String (never an enum):\n{sdl}"
+        );
+        assert!(
+            !sdl.to_lowercase().contains("enum"),
+            "must not invent an enum type:\n{sdl}"
+        );
+
+        // Submit return type (CaptureInfo-equivalent) carries captureId + createdAt.
+        assert!(sdl.contains("captureId"), "missing captureId:\n{sdl}");
+        assert!(sdl.contains("createdAt"), "missing createdAt:\n{sdl}");
+
+        // Status return type (CaptureStatus-equivalent) carries id + updatedAt.
+        assert!(
+            sdl.contains("type CaptureStatus {"),
+            "missing CaptureStatus type:\n{sdl}"
+        );
+        assert!(sdl.contains("updatedAt"), "missing updatedAt:\n{sdl}");
+    }
+
+    #[test]
+    fn extract_capture_sdl_preserves_captureid_vs_id_distinction() {
+        // captureId (submit return) and id (status return) must not collapse
+        // into the same field name — regression guard for the extractor
+        // accidentally merging the two return types.
+        let sdl = extract_capture_sdl(&capture_schema_fixture()).unwrap();
+        assert!(sdl.contains("captureId: String!"), "got:\n{sdl}");
+        assert!(sdl.contains("id: ID!"), "got:\n{sdl}");
+    }
+
+    #[test]
+    fn assert_capture_ops_present_succeeds_when_ops_present() {
+        assert!(assert_capture_ops_present(
+            &capture_schema_fixture(),
+            "https://source.example/graphql"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn assert_capture_ops_present_fails_on_wrong_endpoint() {
+        // A schema that simply lacks the two capture ops (e.g. introspecting
+        // the merged/default API instead of the source data API).
+        let wrong_endpoint_schema = serde_json::json!({
+            "__schema": {
+                "queryType": { "name": "Query" },
+                "mutationType": { "name": "Mutation" },
+                "types": [
+                    { "kind": "OBJECT", "name": "Mutation", "fields": [] },
+                    { "kind": "OBJECT", "name": "Query", "fields": [] },
+                ],
+            }
+        });
+
+        let err =
+            assert_capture_ops_present(&wrong_endpoint_schema, "https://merged.example/graphql")
+                .expect_err("must fail when capture ops are absent");
+        let msg = err.to_string();
+        assert!(msg.contains("wrong endpoint?"), "got: {msg}");
+        assert!(msg.contains("https://merged.example/graphql"), "got: {msg}");
+    }
+
+    #[test]
+    fn strip_provenance_header_skips_comments_and_blank_lines() {
+        let content = "# header line 1\n# header line 2\n\ntype Mutation {\n  foo: String\n}\n";
+        let body = strip_provenance_header(content);
+        assert_eq!(body, "type Mutation {\n  foo: String\n}");
+    }
+}

--- a/cargo-pmcp/src/deployment/targets/pmcp_run/mod.rs
+++ b/cargo-pmcp/src/deployment/targets/pmcp_run/mod.rs
@@ -1,6 +1,11 @@
 pub mod auth;
 mod deploy;
 pub mod graphql;
+// Dependency-light leaf shared with the `cargo-pmcp` lib target (mounted via
+// `#[path]` in `lib.rs`) so the offline contract test can reach the two
+// capture GraphQL query consts without pulling this tree's reqwest/auth/deploy
+// deps into the lib target. See `graphql_contract.rs` for details.
+mod graphql_contract;
 
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;

--- a/cargo-pmcp/src/lib.rs
+++ b/cargo-pmcp/src/lib.rs
@@ -151,3 +151,25 @@ pub mod workbook_explain;
 #[doc(hidden)]
 #[path = "commands/package/kind.rs"]
 pub mod package_kind;
+
+// Package-capture contract test seam (170-08 Task 3; extended in the
+// final-review fix wave with pure SDL-extraction helpers): expose the two
+// dependency-light capture GraphQL query consts, plus the pure,
+// IO-free SDL-extraction helpers (`extract_capture_sdl`,
+// `assert_capture_ops_present`, `strip_provenance_header`), to the lib target
+// (mirrors the `package_kind` / `templates_agent` `#[path]` convention).
+// `graphql_contract.rs` references only `&str` literals plus `anyhow`/
+// `serde_json` (NO `reqwest`/oauth2/the bin-only `pmcp_run` auth+deploy tree
+// that the rest of `deployment/targets/pmcp_run/graphql.rs` depends on), so
+// it compiles in the lib target on its own. This lets the offline blocking
+// contract test (`tests/package_capture_contract.rs`) validate the real
+// runtime `submitPackageCapture`/`getPackageCaptureStatus` queries against
+// the vendored SDL (`contracts/pmcp-run/capture-v1.graphql`) without pulling
+// in the bin-only command layer, AND lets the feature-gated `capture_contract`
+// dev binary (`src/bin/capture_contract.rs`) reuse these pure helpers (and
+// their unit tests run under the default `cargo test -p cargo-pmcp`) without
+// linking the bin-only `deployment` module tree.
+// `#[doc(hidden)]`: an internal test-facing seam, not a stable public API.
+#[doc(hidden)]
+#[path = "deployment/targets/pmcp_run/graphql_contract.rs"]
+pub mod pmcp_run_graphql;

--- a/cargo-pmcp/tests/package_capture_contract.rs
+++ b/cargo-pmcp/tests/package_capture_contract.rs
@@ -1,0 +1,101 @@
+//! Offline blocking contract test (170-08 Task 3).
+//!
+//! Validates that the CLI's two hand-written `package capture` GraphQL
+//! operations (`SUBMIT_PACKAGE_CAPTURE_QUERY` / `GET_PACKAGE_CAPTURE_STATUS_QUERY`
+//! in `src/deployment/targets/pmcp_run/graphql.rs`) — and the response structs
+//! that deserialize their results (`CaptureInfo` / `CaptureStatus`) — have not
+//! drifted from the platform-owned, vendored SDL contract at
+//! `contracts/pmcp-run/capture-v1.graphql`.
+//!
+//! This is a pure offline/static check: no network access, no pmcp.run
+//! credentials. It runs in the normal `cargo test` workspace gate, so any
+//! drift between the CLI's queries and the platform contract fails the SDK
+//! build immediately rather than surfacing at runtime against a live server.
+
+use apollo_compiler::validation::Valid;
+use apollo_compiler::{ExecutableDocument, Schema};
+
+const SDL_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../contracts/pmcp-run/capture-v1.graphql"
+);
+
+// `ExecutableDocument::parse_and_validate` requires `&Valid<Schema>` — keep the
+// `Valid` wrapper rather than unwrapping it, since apollo-compiler 1.x only
+// offers operation-vs-schema validation against an already-`Valid` schema.
+fn schema() -> Valid<Schema> {
+    let sdl = std::fs::read_to_string(SDL_PATH).expect("read capture-v1.graphql");
+    Schema::parse_and_validate(sdl, "capture-v1.graphql").expect("vendored SDL is itself valid")
+}
+
+/// Both runtime queries must validate against the vendored contract.
+#[test]
+fn capture_ops_validate_against_contract() {
+    let schema = schema();
+    for (name, op) in [
+        (
+            "submit",
+            cargo_pmcp::pmcp_run_graphql::SUBMIT_PACKAGE_CAPTURE_QUERY,
+        ),
+        (
+            "status",
+            cargo_pmcp::pmcp_run_graphql::GET_PACKAGE_CAPTURE_STATUS_QUERY,
+        ),
+    ] {
+        ExecutableDocument::parse_and_validate(&schema, op, format!("{name}.graphql"))
+            .unwrap_or_else(|e| panic!("`{name}` op does not match capture-v1.graphql: {e}"));
+    }
+}
+
+/// `status` must be a plain String in the contract — never a GraphQL enum
+/// (an enum would make the online schema-vs-schema diff show permanent drift).
+#[test]
+fn status_field_is_string_not_enum() {
+    let sdl = std::fs::read_to_string(SDL_PATH).unwrap();
+    assert!(
+        sdl.contains("status: String"),
+        "status must be typed String in capture-v1.graphql"
+    );
+    assert!(
+        !sdl.contains("enum CaptureStatusValue"),
+        "status must not be an enum in v1"
+    );
+}
+
+/// The response structs' GraphQL field names must exactly equal each op's
+/// selection set (struct <-> query <-> schema all agree).
+///
+/// NOTE: this greps the hardcoded field-name lists below against the query
+/// STRINGS, not the actual `CaptureInfo`/`CaptureStatus` Rust struct
+/// definitions — it does NOT parse those structs. The query itself is
+/// separately validated against the vendored SDL by
+/// `capture_ops_validate_against_contract` (apollo-compiler, field-existence
+/// + type checking). So this test is a drift sanity check on the selection
+/// set, not a full struct-vs-schema proof: a struct-only serde `rename` with
+/// no accompanying query change would go uncaught here.
+#[test]
+fn response_structs_match_selection_sets() {
+    // CaptureInfo (submit) selects: captureId, status, createdAt
+    for f in ["captureId", "status", "createdAt"] {
+        assert!(
+            cargo_pmcp::pmcp_run_graphql::SUBMIT_PACKAGE_CAPTURE_QUERY.contains(f),
+            "CaptureInfo field `{f}` missing from submit selection set"
+        );
+    }
+    // CaptureStatus (status) selects: id, status, message, errorCode,
+    // divergentComponents, manifestDigest, updatedAt
+    for f in [
+        "id",
+        "status",
+        "message",
+        "errorCode",
+        "divergentComponents",
+        "manifestDigest",
+        "updatedAt",
+    ] {
+        assert!(
+            cargo_pmcp::pmcp_run_graphql::GET_PACKAGE_CAPTURE_STATUS_QUERY.contains(f),
+            "CaptureStatus field `{f}` missing from status selection set"
+        );
+    }
+}

--- a/contracts/pmcp-run/capture-v1.graphql
+++ b/contracts/pmcp-run/capture-v1.graphql
@@ -1,0 +1,50 @@
+# capture-v1.graphql — pmcp.run package-capture contract (SDL subset)
+# Source:   pmcp.run dev amplifyData AppSync API, apiId q3gd4hrbabeytc2o2zazld6igy (us-east-1)
+# Exported: 2026-07-20 via `aws appsync get-introspection-schema --format SDL`, reduced to
+#           the two capture operations + their return types by the pmcp.run platform team.
+# Version:  v1
+#
+# OWNERSHIP: the platform owns this file's CONTENTS. When the capture schema changes,
+# the platform re-exports and PRs an update here; the SDK's blocking contract test then
+# forces cargo-pmcp's queries/structs to follow in the same PR.
+#
+# `status` is String! (NOT a GraphQL enum) in BOTH return types — do NOT tidy it to an enum.
+# Known runtime values (documentation only, not schema-enforced):
+#   queued | walking | extracting | publishing | completed | failed | not_found
+#
+# BOUNDARY NOTE: getPackageCaptureStatus's ARGUMENT is `id: ID!`, but the value passed is the
+# `captureId` returned by submitPackageCapture (the CLI threads captureId -> id). The name
+# differs across the submit/status boundary by design.
+#
+# NOTE: the live schema's @aws_cognito_user_pools / @aws_iam field directives were stripped
+# from this vendored copy — they are auth config, not shape. A platform-side drift diff must
+# normalize them out on both sides.
+
+type Mutation {
+  submitPackageCapture(
+    rootComponentType: String!
+    rootComponentId: String!
+    version: String!
+    bump: String
+  ): SubmitPackageCaptureReturnType
+}
+
+type Query {
+  getPackageCaptureStatus(id: ID!): GetPackageCaptureStatusReturnType
+}
+
+type SubmitPackageCaptureReturnType {
+  captureId: String!
+  createdAt: String!
+  status: String!
+}
+
+type GetPackageCaptureStatusReturnType {
+  id: String!
+  status: String!
+  message: String
+  errorCode: String
+  divergentComponents: [String]
+  manifestDigest: String
+  updatedAt: String
+}

--- a/docs/platform-requests/capture-sdl-export-request.md
+++ b/docs/platform-requests/capture-sdl-export-request.md
@@ -1,0 +1,137 @@
+# Request: export the package-capture SDL subset for the SDK contract seam
+
+**To:** pmcp.run platform dev team
+**From:** SDK / cargo-pmcp side (package-capture contract seam)
+**Date:** 2026-07-20
+
+## What we're building and why
+
+We're adding a **versioned contract** that pins `cargo pmcp package capture`'s two
+GraphQL operations to your capture API, so the CLI and the platform can't silently
+drift again (the Phase-110 class of bug, where the local verb and your remote
+service disagreed). The mechanism: a checked-in SDL file (`capture-v1.graphql`) plus
+a **blocking test** that fails the SDK build if the CLI's queries/response structs
+don't match that SDL.
+
+## What we discovered (why we need you)
+
+Our plan was for the CLI/CI to introspect the **source `amplifyData` AppSync API**
+directly and generate/verify the SDL. That path does not work: the source API
+
+```
+https://pn5dorma2bdhzcdhascvc4xzka.appsync-api.us-east-1.amazonaws.com/graphql   (dev)
+```
+
+rejects **every** client-obtainable token identically:
+
+| token tried | result |
+|---|---|
+| M2M `client_credentials` access token | `401 UnauthorizedException: "Valid authorization header not provided."` |
+| user-pool **access** token (from `cargo pmcp login`) | same |
+| user-pool **id** token | same |
+
+Even a bare `{ __typename }` fails, so it's not introspection-specific — the API
+simply isn't accepting client-facing JWT auth. This is consistent with the source
+API being **IAM-auth'd from your backend resolvers** (SigV4), not client-reachable:
+the capture flow reaches it through the merged/proxy API, and no client token —
+ours or a user's — is meant to hit it directly.
+
+So the schema is yours to export. This actually fits the ownership model we want
+anyway: **the platform owns the capture schema; the SDK vendors it and enforces the
+CLI against it.**
+
+## What we need from you
+
+A **GraphQL SDL subset** covering exactly the two capture operations and the types
+they reference — generated from the real schema, not hand-written (we want the
+authoritative shape, including exact nullability and field names):
+
+- `Mutation.submitPackageCapture(...)` and its return type
+- `Query.getPackageCaptureStatus(...)` and its return type
+- Any object/scalar types those two transitively reference
+
+From our current client code, the shape we *believe* is (please correct against the
+real schema):
+
+```graphql
+type Mutation {
+  submitPackageCapture(
+    rootComponentType: String!
+    rootComponentId:   String!
+    version:           String!
+    bump:              String
+  ): CaptureInfo
+}
+
+type Query {
+  getPackageCaptureStatus(id: ID!): CaptureStatus
+}
+
+type CaptureInfo {           # returned by submit — note: captureId + createdAt
+  captureId:  String!
+  status:     String!
+  createdAt:  String!
+}
+
+type CaptureStatus {         # returned by status — note: id + updatedAt (asymmetry!)
+  id:                  ID!
+  status:              String
+  message:             String
+  errorCode:           String
+  divergentComponents: [String!]
+  manifestDigest:      String
+  updatedAt:           String
+}
+```
+
+Please return the **true** version of the above (real type names, real
+nullability). The details that matter to us:
+
+1. **`status` must be its real type.** Today we believe it's a plain `String`
+   (known values `queued|walking|extracting|publishing|completed|failed|not_found`).
+   If it's actually a GraphQL **enum**, tell us — we type it truthfully and it
+   changes our versioning. Please don't "tidy" it into an enum just for us; give us
+   what the schema really has.
+2. **Preserve the `captureId` vs `id` / `createdAt` vs `updatedAt` asymmetry**
+   between the submit and status return types exactly — that asymmetry is real and
+   our contract must capture it.
+3. **SDL format**, not JSON/YAML — a plain `.graphql` file (or the two-op subset
+   pasted inline is fine; we'll add a provenance header).
+
+Easiest ways to produce it on your side (any one):
+
+```bash
+# From the AppSync API (you have the api-id + IAM access):
+aws appsync get-introspection-schema \
+  --api-id <capture-api-id> --format SDL capture-full.graphql
+# then hand us just the submitPackageCapture / getPackageCaptureStatus subset,
+# or the whole file and we'll extract the subset.
+```
+
+or your Amplify Gen 2 `defineData` schema source for those two operations, or a
+codegen introspection — whatever's least effort.
+
+## Two questions so we point the CLI correctly
+
+1. **Which endpoint does the deployed `capture` verb actually call in dev?** The
+   merged/proxy GraphQL URL the CLI authenticates to (not `pn5dorma2…`, which we've
+   confirmed we can't reach). We need it to configure the client + docs.
+2. **The ongoing drift check.** Because the source API isn't client-reachable, our
+   planned headless CI job can't introspect it. Preferred fix on your side, either:
+   - **(a)** you run a periodic "does the live capture schema still match the
+     vendored `capture-v1.graphql`?" check (you have introspection/IAM access), and
+     open a PR to update the SDL when it changes; **or**
+   - **(b)** you publish the capture SDL as a small read-only artifact/endpoint we
+     can diff against in CI.
+   Which do you prefer?
+
+## The deal going forward
+
+When you change the capture schema, **you PR the updated `capture-v1.graphql` to the
+SDK repo** (`contracts/pmcp-run/`). The SDK's blocking test then forces the CLI's
+queries + response structs to be updated in the same change — so the CLI can never
+ship out of sync with your API again. You own the contract's contents; we own the
+gate that enforces it.
+
+Thanks — this unblocks shipping `cargo pmcp package capture` (+ `show`/`import`/
+`approve`) with a drift-proof contract.

--- a/docs/runbooks/package-capture-release.md
+++ b/docs/runbooks/package-capture-release.md
@@ -1,0 +1,265 @@
+# Release Runbook: `cargo pmcp package capture` (+ `show` / `import` / `approve`)
+
+**Scope.** `cargo pmcp package capture` is a thin GraphQL client of pmcp.run's
+remote capture API — the SDK does not implement capture logic, it only calls it.
+This runbook covers the execution logistics to ship the verb: rebasing the
+long-lived feature branch, running the not-yet-executed end-to-end test against
+the dev endpoint, and the coordinated `cargo-pmcp` release. These steps are
+intentionally kept out of the design spec
+(`docs/superpowers/specs/2026-07-20-package-capture-contract-seam-design.md`,
+§8) because they go stale — treat every count and version number below as a
+snapshot that must be re-verified at execution time, not copied blind.
+
+All four verbs — `capture`, `show`, `import`, `approve` — live on one branch
+(`feat/package-remote-capture-show`) and **ship together in a single
+`cargo-pmcp` release**. There is no way to release `capture` alone.
+
+## Pre-flight checklist
+
+- [ ] `/opt/homebrew/bin/git status` on `feat/package-remote-capture-show` is clean (no uncommitted work).
+- [ ] Confirm PR [#303](https://github.com/paiml/rust-mcp-sdk/pull/303) (`ci(release): publish pmcp-package/agent/team-servers before cargo-pmcp`) is **merged**. It fixes a `release.yml` crate-ordering bug where `cargo-pmcp` published before its `pmcp-agent` / `pmcp-package` dependencies. As of this writing it is **still open** — do not tag a release relying on the automated publish order until it merges; if it's still open when you get here, either land it first or manually verify/adjust the publish order in `release.yml`.
+- [ ] You have either interactive pmcp.run credentials (for `cargo pmcp login`) or M2M env credentials for the dev environment, for the E2E phase.
+- [ ] You know which AgentTeam **slug id** (not UUID) you'll capture against for the E2E run (e.g. `day-trip-planner-team`).
+- [ ] **`import` E2E is green before you tag.** The release ships `capture`/`show`/`import`/`approve` together, but `import`'s happy path (`completed_dry_run` → the rendered pre-flight disposition table) had **never** run live as of 2026-07-21 — it was blocked server-side by the per-component pull-by-payload-digest bug (pmcp.run Phase-171 handoff `171-HANDOFF-import-component-pull-digest.md`; FIX #1 is platform-only, in their import Lambda `pull.rs`, no SDK change). The CLI verb is a correct thin client, but do not tag a release shipping a verb whose success path is unproven. Once the platform deploys their fix, run `cargo pmcp package import day-trip-planner-team@1.0.0` and confirm it returns `completed_dry_run` with all-`reuse` dispositions and a clean report. (`capture`/`approve` are already verified; this gate is `import`-specific.)
+- [ ] Use the **absolute git binary** (`/opt/homebrew/bin/git`) for every rebase/diff/status command in this runbook. The `rtk` shell proxy in this environment corrupts `git diff` / `git status` / `gh` output — a prior session lost time to this before identifying it. Prefer `/opt/homebrew/bin/gh` for the same reason if `gh` output looks garbled.
+
+---
+
+## Phase 1 — Build the clean release branch off `upstream/main`
+
+**Do NOT rebase the long-lived feature branch.** The real PR target is
+`upstream/main` (paiml), **not** `origin/main` — the fork's `origin/main` carries
+auto-committed "quality badges" bot commits and is itself diverged from paiml (in
+one 2026-07 snapshot: `origin/main` was 73 behind / 111 ahead of `upstream/main`).
+Rebasing onto `origin/main` chases that badge-bot noise and points at the wrong
+base.
+
+Against `upstream/main` the release is small and self-contained. Verify:
+
+```bash
+/opt/homebrew/bin/git fetch upstream main
+# net code delta vs paiml, excluding planning/tooling noise:
+/opt/homebrew/bin/git diff --name-only upstream/main..feat/package-remote-capture-show \
+  | grep -vE "^\.planning/|^\.pmat/|^\.claude/|^cargo-pmcp/\.claude/"
+```
+
+In the 2026-07-21 snapshot this was exactly **20 files** — the cargo-pmcp
+capture/import/approve verbs + contract seam + docs — with **zero** changes to
+pmcp core (`src/`), `pmcp-package`, cargo-pmcp's workspace deps, or the root
+`Cargo.toml`. Confirm that's still true before proceeding; if `src/` or
+`crates/` show up, the release is no longer self-contained and this recipe needs
+revisiting.
+
+Build the clean branch = paiml main + exactly those release files:
+
+```bash
+/opt/homebrew/bin/git checkout -b release/cargo-pmcp-vX.Y.Z upstream/main
+/opt/homebrew/bin/git checkout feat/package-remote-capture-show -- <the release files>
+/opt/homebrew/bin/git commit -m "feat(cargo-pmcp): vX.Y.Z — remote package verbs + capture contract seam"
+```
+
+Then verify it builds off paiml's current main (use plain `cargo`, which respects
+this repo's `rust-toolchain.toml` pin — do NOT invoke an absolute
+`…/toolchains/stable/bin/cargo`, which fights the pin and produces phantom
+`dashmap`/rustc-version errors):
+
+```bash
+cargo build -p cargo-pmcp --bin cargo-pmcp
+cargo fmt -p cargo-pmcp -- --check
+cargo test -p cargo-pmcp --test package_capture_contract   # 3 tests
+```
+
+The result should be **1 ahead / 0 behind `upstream/main`** — a single clean,
+mergeable commit. `feat/package-remote-capture-show` keeps the full development
+history (and is the branch pmcp.run installs from via `cargo install --git`);
+`release/cargo-pmcp-vX.Y.Z` is the PR artifact.
+
+---
+
+## Phase 2 — End-to-end test against dev
+
+**Status: run and passing (2026-07-20).** A locally-built CLI ran
+`cargo pmcp package capture day-trip-planner-team --version 1.0.0` against the
+dev platform to a terminal `✅ Capture complete`, manifest digest
+`sha256:af0ae208cceb706a492c03ff0d79e970c76eaf54b9596d54b2229c7e2de1f249`. A
+re-run produced the **identical** digest, confirming the platform capture is
+deterministic (same team + version → byte-identical manifest). Re-run this
+before each release to confirm the deployed platform still answers.
+
+**Endpoints (from the discovered `~/.pmcp/pmcp-run-config.json`).** Two
+different URLs — do not conflate them:
+
+- **Environment / discovery base** (`source_api_url` / `mcp_url`) —
+  `https://6vlog1csj4.execute-api.us-east-1.amazonaws.com`. This is what
+  `PMCP_API_URL` wants (see Auth below); it is the API-Gateway base, **not** the
+  GraphQL URL.
+- **GraphQL endpoint** the capture ops POST to (`graphql_url`) — **the CLI
+  resolves this dynamically from your discovery cache; do not hardcode it.** In
+  one 2026-07 dev config it was an `…appsync-api.us-east-1.amazonaws.com/graphql`
+  merged-API URL, but the platform team has flagged specific merged-API ids as
+  rotating/dead (e.g. `nieihn7yhjbzldmrm6b74ndcha`, `pn5dorma2bdhzcdhascvc4xzka`
+  — the latter also being a wrong SDL-introspection source; the authoritative
+  source data API is `amplifyData` apiId `q3gd4hrbabeytc2o2zazld6igy`). So rely
+  on discovery: **no `PMCP_RUN_GRAPHQL_URL` override is needed**, and don't paste
+  a specific merged-API id anywhere as if it were stable.
+
+**Auth — the `PMCP_API_URL` token-refresh gotcha (real snag).** A fresh
+`cargo pmcp login` works, but when the cached **access token expires**, the
+refresh path runs discovery against the prod default
+`https://api.pmcp.run/.well-known/pmcp-config` (which does not resolve for dev)
+**unless** you point it at the environment base. It does not reuse the cached
+config's endpoint for refresh. So for any dev run, set:
+
+```bash
+export PMCP_API_URL="https://6vlog1csj4.execute-api.us-east-1.amazonaws.com"
+```
+
+or persist it once so plain `cargo pmcp package capture …` just works:
+
+```bash
+cargo pmcp configure add dev --type pmcp-run \
+  --api-url https://6vlog1csj4.execute-api.us-east-1.amazonaws.com
+cargo pmcp configure use dev
+```
+
+Then authenticate (only needed if you have no valid refresh token):
+
+```bash
+cargo pmcp login          # interactive PKCE flow
+# — or —
+# set M2M env credentials per the CLI's documented env vars, no interactive step
+```
+
+**Run the capture.** The positional argument is the AgentTeam's **slug id**
+(e.g. `day-trip-planner-team`), **not a UUID**:
+
+```bash
+cargo pmcp package capture <team-slug-id> --version <x.y.z>
+```
+
+> **Known doc bug (tracked separately, Task 6):** `capture.rs`'s current
+> `long_help` for this argument says `AgentTeam ID (UUID) — the team's id, not
+> its display name.`, which is wrong — the CLI takes the slug id, not a UUID.
+> Fix this in the CLI help text as part of (or before) this release; don't let
+> the E2E run mask it — verify with a real slug id, not something that merely
+> looks like one.
+
+**Success criteria.** The command must reach `completed` status and print a
+real manifest digest — not a timeout, not an error status, not a stub value.
+Watch the poll loop: `MAX_POLL_WAIT` is 20 minutes, which exceeds the
+platform's capture Lambda's 15-minute timeout, so a genuine backend hang will
+surface as a normal poller timeout rather than hanging indefinitely. If you
+hit the 20-minute bound, that's a real signal (backend stuck or erroring),
+not a runbook problem — investigate on the platform side before retrying.
+
+Record the slug id used, the version tag, and the resulting manifest digest
+for the release notes / follow-up ticket trail.
+
+---
+
+## Phase 3 — Contract/drift invariant (must be green before release)
+
+The CLI's two hand-written GraphQL operations are checked offline against a
+vendored SDL contract:
+
+```bash
+cargo test -p cargo-pmcp --test package_capture_contract
+```
+
+This must show all **3 tests passing** before you proceed. It validates the
+CLI's `SUBMIT_PACKAGE_CAPTURE_QUERY` / `GET_PACKAGE_CAPTURE_STATUS_QUERY`
+operations and their response structs against
+`contracts/pmcp-run/capture-v1.graphql`.
+
+**Ownership model — read before "fixing" a failure here.** The vendored SDL
+is **platform-exported**: the platform owns its contents and PRs updates to
+this repo whenever their capture schema changes (see design spec §5b, §6).
+The SDK does **not** introspect the source GraphQL API to regenerate this
+file — that API is IAM-only, reachable only from the platform's own backend,
+and is not client-reachable (no SDK-held credential, user or M2M, can reach
+it directly). There is no SDK-side scheduled drift job; the "online" half of
+the drift check is entirely platform-owned — they detect schema drift on
+their side and open a PR against `capture-v1.graphql` here, which then trips
+this same blocking test to force the CLI into lockstep.
+
+**What this means for release:** you do **not** regenerate or re-export the
+SDL as part of this release. You only need the offline test green against
+whatever `capture-v1.graphql` is currently vendored in the branch. If it's
+red, that means the CLI's queries/structs have drifted from the vendored
+contract — fix the CLI code (or pull the platform's latest contract-update PR
+if one is pending) before continuing; do not weaken or skip the test.
+
+---
+
+## Phase 4 — Coordinated `cargo-pmcp` release
+
+`capture` / `show` / `import` / `approve` ship together in **one**
+`cargo-pmcp` release, since they're all on this one branch.
+
+1. **Bump the version.** Update `cargo-pmcp/Cargo.toml`'s `version` field to
+   `<x.y.z>` (choose per semver: new verbs → at least a minor bump). If this
+   branch also touched `pmcp` itself, bump it too and update the `pmcp = {
+   version = "..." }` line(s) that pin it — per the repo's standard
+   cross-crate version-bump rule (any downstream crate pinning a bumped dep
+   must bump its own pin and version). `cargo-pmcp` currently depends on
+   `pmcp`, `mcp-tester`, and `mcp-preview` — confirm none of those also need a
+   coordinated bump before tagging.
+
+2. **Run the mandatory quality gate** — this is the same gate CI runs, and is
+   stricter than individual `cargo` commands (fmt --all, clippy
+   pedantic+nursery, build, test, audit):
+
+   ```bash
+   rustup update stable   # local/CI toolchain mismatch is the #1 cause of CI-only failures
+   make quality-gate
+   ```
+
+   Do not substitute bare `cargo clippy`/`cargo test` calls for this — they
+   are weaker than what CI enforces and will miss lints.
+
+3. **Commit the version bump(s), push, PR to upstream `main`** per the
+   standard release flow:
+
+   ```bash
+   git add cargo-pmcp/Cargo.toml   # + any other bumped Cargo.toml files
+   git commit -m "chore: bump cargo-pmcp v<x.y.z>"
+   git push -u origin feat/package-remote-capture-show
+   gh pr create --repo paiml/rust-mcp-sdk --base main
+   ```
+
+4. **After the PR merges and CI is green, tag and push** the tag to
+   `upstream` (not your fork):
+
+   ```bash
+   git checkout main && git pull upstream main
+   git tag -a v<x.y.z> -m "cargo-pmcp v<x.y.z> - package capture/show/import/approve"
+   git push upstream v<x.y.z>
+   ```
+
+   Pushing a `v*` tag to upstream triggers `.github/workflows/release.yml`,
+   which publishes to crates.io in dependency order (with the PR #303
+   crate-ordering fix applied — re-confirm it's merged if you skipped the
+   pre-flight check above), publishes to the MCP Registry via OIDC-authenticated
+   `mcp-publisher`, and attaches cross-platform `mcp-tester`/`cargo-pmcp`
+   binaries to the GitHub Release.
+
+5. **Verify the publish.** Check crates.io for the new `cargo-pmcp` version,
+   and spot-check the release workflow run in GitHub Actions for the
+   crates.io + MCP Registry publish steps succeeding (not just the build/test
+   jobs).
+
+---
+
+## Summary — order of operations
+
+1. Rebase (`/opt/homebrew/bin/git rebase origin/main`) — expect low-conflict,
+   badge-line-only; escalate anything else.
+2. E2E against dev — set `PMCP_API_URL=https://6vlog1csj4.execute-api.us-east-1.amazonaws.com`
+   (token-refresh base; the GraphQL URL resolves from discovery), run capture to
+   `completed` + a real manifest digest; use a slug id, not a UUID.
+3. Offline contract test green (`cargo test -p cargo-pmcp --test
+   package_capture_contract`, 3 tests) — no SDL regeneration needed, that's
+   platform-owned.
+4. Coordinated `cargo-pmcp` release: bump → `make quality-gate` → PR → merge
+   → tag `v<x.y.z>` → automated publish via `release.yml` (confirm PR #303 is
+   merged first).

--- a/docs/superpowers/plans/2026-07-20-package-capture-contract-seam.md
+++ b/docs/superpowers/plans/2026-07-20-package-capture-contract-seam.md
@@ -1,0 +1,361 @@
+# Package-Capture Contract Seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind `cargo pmcp package capture`'s two GraphQL operations to a versioned, platform-owned SDL contract enforced by a blocking test, so the CLI and pmcp.run cannot silently drift.
+
+**Architecture:** Approach B — vendored SDL + contract test, no runtime codegen. A `capture-v1.graphql` SDL subset is **platform-exported from the live source data API** and checked in. An offline blocking test validates the CLI's actual runtime query strings and response structs against that SDL. The online drift check is **PLATFORM-OWNED**: the platform introspects the source API it alone can reach and PRs the vendored SDL on drift; the SDK ships no scheduled job. One shared introspect+extract tool (`capture_contract`) remains in the SDK repo as a manual dev aid, reused for local generation and available to whoever runs the platform-side diff.
+
+**Tech Stack:** Rust, `reqwest` (existing hand-rolled GraphQL), `apollo-compiler` (new dev-dependency, operation-vs-schema validation), the existing `auth.rs` client_credentials (M2M) flow — used only by the manual `capture_contract` dev tool, not by any SDK CI workflow.
+
+## Global Constraints
+
+- **Binding approach B only** — no `graphql-client`/`cynic` runtime codegen; the two ops stay hand-written in `graphql.rs`.
+- **`status` is typed `String`** in the SDL (NOT a GraphQL `enum`); known values live as an SDL doc-comment. A `status` enum is explicitly deferred to a future `capture-v2` (out of scope).
+- **The SDL is platform-exported from the live schema, never hand-authored.**
+- **The contract's return types must preserve the asymmetry exactly:** `submitPackageCapture` → `captureId` + `createdAt`; `getPackageCaptureStatus` → `id` + `updatedAt`.
+- **The online drift check is platform-owned**, not an SDK-side job: they introspect the **source `amplifyData` API** (capture ops live there, never the merged API) and PR the vendored SDL on drift. The SDK's `capture_contract` dev tool still authenticates via M2M (`PMCP_CLIENT_ID`/`PMCP_CLIENT_SECRET`, never the PKCE user token) for its manual local-generation use.
+- **Offline contract test is blocking (normal CI); online drift job is non-blocking/scheduled.**
+- All work is on branch `feat/package-remote-capture-show` in worktree `~/Development/mcp/sdk/rust-mcp-sdk-package-capture`. Paths below are relative to that worktree root.
+- Commit after every task. Match existing repo style (`cargo fmt`, clippy clean).
+
+---
+
+### Task 1: Extract the two capture query strings into shared constants
+
+Makes the runtime queries reachable by the contract test, so the test validates the *actual* queries (not a copy). Pure refactor — behavior-preserving.
+
+**Files:**
+- Modify: `cargo-pmcp/src/deployment/targets/pmcp_run/graphql.rs` (the `submit_package_capture` and `get_package_capture_status` fns, ~lines 1310–1400)
+
+**Interfaces:**
+- Produces: `pub(crate) const SUBMIT_PACKAGE_CAPTURE_QUERY: &str` and `pub(crate) const GET_PACKAGE_CAPTURE_STATUS_QUERY: &str` (the exact GraphQL operation documents the CLI sends).
+
+- [ ] **Step 1: Add the two constants** immediately above `submit_package_capture`, moving the existing raw strings verbatim:
+
+```rust
+/// The exact `submitPackageCapture` operation the CLI sends. Shared with the
+/// offline contract test (`tests/package_capture_contract.rs`) so the test
+/// validates the real runtime query against the vendored SDL.
+pub(crate) const SUBMIT_PACKAGE_CAPTURE_QUERY: &str = r#"
+        mutation SubmitPackageCapture(
+            $rootComponentType: String!,
+            $rootComponentId: String!,
+            $version: String!,
+            $bump: String
+        ) {
+            submitPackageCapture(
+                rootComponentType: $rootComponentType,
+                rootComponentId: $rootComponentId,
+                version: $version,
+                bump: $bump
+            ) {
+                captureId
+                status
+                createdAt
+            }
+        }
+    "#;
+
+/// The exact `getPackageCaptureStatus` operation the CLI sends. Shared with the
+/// offline contract test.
+pub(crate) const GET_PACKAGE_CAPTURE_STATUS_QUERY: &str = r#"
+        query GetPackageCaptureStatus($id: ID!) {
+            getPackageCaptureStatus(id: $id) {
+                id
+                status
+                message
+                errorCode
+                divergentComponents
+                manifestDigest
+                updatedAt
+            }
+        }
+    "#;
+```
+
+- [ ] **Step 2: Replace the inline `let query = r#"..."#;` in both fns** with `let query = SUBMIT_PACKAGE_CAPTURE_QUERY;` and `let query = GET_PACKAGE_CAPTURE_STATUS_QUERY;` respectively. Delete the now-duplicated inline strings.
+
+- [ ] **Step 3: Build and run the existing capture unit/integration coverage to prove no behavior change**
+
+Run: `cargo build -p cargo-pmcp && cargo test -p cargo-pmcp capture`
+Expected: PASS (same as before — pure extraction).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cargo-pmcp/src/deployment/targets/pmcp_run/graphql.rs
+git commit -m "refactor(capture): hoist the two capture GraphQL ops to shared consts"
+```
+
+---
+
+### Task 2: Build the shared introspect + extract-subset tool
+
+One reusable command that authenticates (M2M), introspects the **source data API**, and emits the capture-subset SDL. Used by Task 2b (generate/vendor) and Task 4 (online diff). Kept as a `cargo-pmcp` subcommand-free internal binary so CI can invoke it without network deps leaking into the library.
+
+**Files:**
+- Create: `cargo-pmcp/src/bin/capture_contract.rs`
+- Reuse: `cargo-pmcp/src/deployment/targets/pmcp_run/auth.rs` (`get_credentials`), the `execute_graphql`/endpoint plumbing in `graphql.rs`
+
+**Interfaces:**
+- Produces a CLI: `capture_contract emit` (prints the extracted capture-subset SDL to stdout) and `capture_contract check <path>` (introspects live, extracts subset, diffs against the SDL at `<path>`, exits non-zero on drift).
+- Consumes: `PMCP_CLIENT_ID`/`PMCP_CLIENT_SECRET` (M2M) via `auth::get_credentials`; `PMCP_SOURCE_GRAPHQL_URL` for the source data API endpoint (the amplifyData API behind `api_url`, distinct from the merged `DEFAULT_GRAPHQL_URL`).
+
+- [ ] **Step 1: Write the introspection request** — a standard GraphQL `__schema` introspection query POSTed with the M2M bearer token to `PMCP_SOURCE_GRAPHQL_URL`. Add the well-known introspection query as a `const INTROSPECTION_QUERY: &str` (the standard full `IntrospectionQuery` document).
+
+- [ ] **Step 2: Write the subset extractor.** From the introspected schema JSON, select ONLY: the `Mutation.submitPackageCapture` and `Query.getPackageCaptureStatus` fields, their argument types, and the transitive types they return (`CaptureInfo`-equivalent and `CaptureStatus`-equivalent, whatever the schema names them). Render them as SDL. Type `status` fields as `String` (they already are in the schema) and DO NOT invent an enum.
+
+- [ ] **Step 3: The right-endpoint assertion (source vs merged).** After introspection, assert the extracted schema actually contains `submitPackageCapture` AND `getPackageCaptureStatus`. If either is absent, exit with: `error: introspected schema has no capture ops — wrong endpoint? expected the source data API (amplifyData) behind api_url, got {url}`. (This is the one-line guard against introspecting the merged API, whose shape can lag.)
+
+- [ ] **Step 4: `emit` prints SDL; `check <path>` diffs.** `check` normalizes both the freshly-extracted SDL and the file at `<path>` (parse → canonical print via `apollo-compiler`, so field ordering/whitespace don't cause false diffs) and exits `1` with a unified diff if they differ, `0` if identical.
+
+- [ ] **Step 5: Manual smoke (requires dev M2M creds; skip in offline CI)**
+
+Run: `PMCP_CLIENT_ID=… PMCP_CLIENT_SECRET=… PMCP_SOURCE_GRAPHQL_URL=<source-api> cargo run -p cargo-pmcp --features capture-contract-tool --bin capture_contract -- emit`
+Expected: prints an SDL block containing `submitPackageCapture`, `getPackageCaptureStatus`, `status: String`, `captureId`, `createdAt`, `id`, `updatedAt`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cargo-pmcp/src/bin/capture_contract.rs cargo-pmcp/Cargo.toml
+git commit -m "feat(capture): shared introspect+extract tool for the capture contract"
+```
+
+---
+
+### Task 2b: Generate and vendor `capture-v1.graphql`
+
+**Files:**
+- Create: `contracts/pmcp-run/capture-v1.graphql`
+
+- [ ] **Step 1: Generate from live** using the Task 2 tool against dev, and write the output to the contract file with a provenance header prepended:
+
+```bash
+mkdir -p contracts/pmcp-run
+{
+  echo "# pmcp.run package-capture contract — v1"
+  echo "# GENERATED from the live source data API by cargo-pmcp/src/bin/capture_contract.rs."
+  echo "# Do NOT hand-edit. Regenerate: capture_contract emit > contracts/pmcp-run/capture-v1.graphql"
+  echo "# Source endpoint: <source data API url>   Introspected: 2026-07-20"
+  echo "# NOTE: 'status' is String (not an enum). Known values: queued, walking,"
+  echo "#       extracting, publishing, completed, failed, not_found."
+  echo ""
+  PMCP_CLIENT_ID=… PMCP_CLIENT_SECRET=… PMCP_SOURCE_GRAPHQL_URL=<source-api> \
+    cargo run -q -p cargo-pmcp --features capture-contract-tool --bin capture_contract -- emit
+} > contracts/pmcp-run/capture-v1.graphql
+```
+
+- [ ] **Step 2: Eyeball the invariants** — confirm the file types `status: String`, includes `createdAt` on the submit return type and `id`+`updatedAt` on the status return type, and preserves `captureId` vs `id`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add contracts/pmcp-run/capture-v1.graphql
+git commit -m "feat(capture): vendor capture-v1 SDL contract (generated from live dev schema)"
+```
+
+---
+
+### Task 3: Offline blocking contract test (operation- AND struct-vs-schema validation)
+
+**Files:**
+- Create: `cargo-pmcp/tests/package_capture_contract.rs`
+- Modify: `cargo-pmcp/Cargo.toml` (`[dev-dependencies]`: add `apollo-compiler`)
+
+**Interfaces:**
+- Consumes: `SUBMIT_PACKAGE_CAPTURE_QUERY`, `GET_PACKAGE_CAPTURE_STATUS_QUERY` (Task 1); `contracts/pmcp-run/capture-v1.graphql` (Task 2b).
+
+> **Crate choice (explicit, per review):** use **`apollo-compiler`** — it parses SDL into a validated `Schema` and validates an executable operation against it (field existence, argument types, selection-set shape). Plain `graphql-parser` only *parses* and will NOT validate op-vs-schema; do not use it here. Fallback only if `apollo-compiler` proves unworkable: `async-graphql-parser` + a hand-walked AST check.
+
+- [ ] **Step 1: Add the dev-dependency**
+
+```toml
+# cargo-pmcp/Cargo.toml, under [dev-dependencies]
+apollo-compiler = "1"
+```
+
+- [ ] **Step 2: Write the failing test** — validates BOTH runtime ops against the vendored SDL, plus a struct-field cross-check:
+
+```rust
+// cargo-pmcp/tests/package_capture_contract.rs
+use apollo_compiler::{ExecutableDocument, Schema};
+
+const SDL_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../contracts/pmcp-run/capture-v1.graphql"
+);
+
+fn schema() -> Schema {
+    let sdl = std::fs::read_to_string(SDL_PATH).expect("read capture-v1.graphql");
+    Schema::parse_and_validate(sdl, "capture-v1.graphql")
+        .expect("vendored SDL is itself valid")
+        .into_inner()
+}
+
+/// Both runtime queries must validate against the vendored contract.
+#[test]
+fn capture_ops_validate_against_contract() {
+    let schema = schema();
+    for (name, op) in [
+        ("submit", cargo_pmcp::pmcp_run_graphql::SUBMIT_PACKAGE_CAPTURE_QUERY),
+        ("status", cargo_pmcp::pmcp_run_graphql::GET_PACKAGE_CAPTURE_STATUS_QUERY),
+    ] {
+        ExecutableDocument::parse_and_validate(&schema, op, format!("{name}.graphql"))
+            .unwrap_or_else(|e| panic!("`{name}` op does not match capture-v1.graphql: {e}"));
+    }
+}
+
+/// `status` must be a plain String in the contract — never a GraphQL enum
+/// (an enum would make the online schema-vs-schema diff show permanent drift).
+#[test]
+fn status_field_is_string_not_enum() {
+    let sdl = std::fs::read_to_string(SDL_PATH).unwrap();
+    assert!(sdl.contains("status: String"), "status must be typed String in capture-v1.graphql");
+    assert!(!sdl.contains("enum CaptureStatusValue"), "status must not be an enum in v1");
+}
+
+/// The response structs' GraphQL field names must exactly equal each op's
+/// selection set (struct <-> query <-> schema all agree).
+#[test]
+fn response_structs_match_selection_sets() {
+    // CaptureInfo (submit) selects: captureId, status, createdAt
+    for f in ["captureId", "status", "createdAt"] {
+        assert!(cargo_pmcp::pmcp_run_graphql::SUBMIT_PACKAGE_CAPTURE_QUERY.contains(f),
+            "CaptureInfo field `{f}` missing from submit selection set");
+    }
+    // CaptureStatus (status) selects: id, status, message, errorCode,
+    // divergentComponents, manifestDigest, updatedAt
+    for f in ["id", "status", "message", "errorCode", "divergentComponents",
+              "manifestDigest", "updatedAt"] {
+        assert!(cargo_pmcp::pmcp_run_graphql::GET_PACKAGE_CAPTURE_STATUS_QUERY.contains(f),
+            "CaptureStatus field `{f}` missing from status selection set");
+    }
+}
+```
+
+- [ ] **Step 3: Expose the consts to the test.** The test references `cargo_pmcp::pmcp_run_graphql::…`. In `cargo-pmcp/src/lib.rs`, add a narrow test-facing re-export so integration tests can reach the two consts without making the whole GraphQL module public:
+
+```rust
+// cargo-pmcp/src/lib.rs
+/// Test-facing re-exports for the offline capture contract test. Not a public API.
+#[doc(hidden)]
+pub mod pmcp_run_graphql {
+    pub use crate::deployment::targets::pmcp_run::graphql::{
+        GET_PACKAGE_CAPTURE_STATUS_QUERY, SUBMIT_PACKAGE_CAPTURE_QUERY,
+    };
+}
+```
+
+(Adjust the two consts' visibility to `pub` if the re-export requires it, keeping the `#[doc(hidden)]` module as the only exposure.)
+
+- [ ] **Step 4: Run the test to verify it fails first (before the SDL is correct)** — temporarily point `SDL_PATH` at a truncated copy, confirm `capture_ops_validate_against_contract` FAILS, then restore. This proves the test actually validates rather than vacuously passing.
+
+Run: `cargo test -p cargo-pmcp --test package_capture_contract`
+Expected (with truncated SDL): FAIL naming the missing field. (with real SDL): PASS.
+
+- [ ] **Step 5: Run the full test green**
+
+Run: `cargo test -p cargo-pmcp --test package_capture_contract`
+Expected: 3 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cargo-pmcp/tests/package_capture_contract.rs cargo-pmcp/Cargo.toml cargo-pmcp/src/lib.rs
+git commit -m "test(capture): offline blocking contract test (ops + structs vs capture-v1 SDL)"
+```
+
+> The offline test runs in the normal `cargo test` gate (`ci.yml` already runs the workspace tests) — no CI change needed for the blocking layer.
+
+---
+
+### Task 4: Online drift check — PLATFORM-OWNED (no SDK-side workflow)
+
+**Status: no code in this repo.** Revised from the original "scheduled M2M CI job"
+after the source `amplifyData` API (apiId `q3gd4hrbabeytc2o2zazld6igy`) was confirmed
+IAM-auth'd from the platform backend and **not client-reachable**: no SDK-obtainable
+token (M2M client-credentials or PKCE user token) can introspect it, so a headless
+SDK CI job structurally cannot perform the diff. The online drift check therefore
+lives on the platform side (see revised spec §5b), and the SDK repo ships **no**
+`.github/workflows/capture-contract-drift.yml`.
+
+**What the platform owns (their counterpart ticket, filed by pmcp.run):**
+- Periodic (e.g. weekly) `aws appsync get-introspection-schema` against
+  apiId `q3gd4hrbabeytc2o2zazld6igy` → reduce to the capture subset → diff against
+  the vendored `contracts/pmcp-run/capture-v1.graphql`.
+- On drift: open a PR to `paiml/rust-mcp-sdk` updating `capture-v1.graphql`. That PR
+  trips the offline blocking test (Task 3), forcing the CLI's ops/structs to follow
+  in lockstep (spec §6).
+
+**What stays in this repo:** the `capture_contract` dev tool (Task 2) remains a
+useful *manual* introspect/diff aid for anyone with source-API access, but nothing
+in SDK CI depends on it. The offline blocking test (Task 3) is the SDK's hard gate.
+
+No implementation step, no commit. This task is satisfied by the spec §5b revision
+(recording platform ownership) and the request already sent to the platform in
+`docs/platform-requests/capture-sdl-export-request.md` (its "ongoing drift check"
+section asks them to own exactly this). The runbook (Task 5) references the
+platform-owned model rather than an SDK workflow.
+
+---
+
+### Task 5: Release runbook
+
+**Files:**
+- Create: `docs/runbooks/package-capture-release.md`
+
+- [ ] **Step 1: Write the runbook** covering, in order: (a) rebase `feat/package-remote-capture-show` onto current `origin/main` (110 commits behind — expect conflict resolution; use the absolute git binary to avoid the `rtk` proxy corrupting diffs, per prior session note); (b) run the not-yet-run **E2E test against dev** — `cargo pmcp login` (or M2M env), then `cargo pmcp package capture <team-slug-id> --version <x.y.z>` end-to-end to a `completed` status + a real manifest digest; (c) the coordinated `cargo-pmcp` release shipping **capture/show/import/approve together** (bump, `make quality-gate`, tag/publish per the repo's Release workflow, including the release.yml crate-ordering already fixed in PR #303). State the invariant that the offline contract test must be green against a live-generated `capture-v1.graphql` before release.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/package-capture-release.md
+git commit -m "docs(capture): package-capture release runbook (rebase + E2E + coordinated publish)"
+```
+
+---
+
+### Task 6: File the two spun-off tickets
+
+Not code — GitHub issues so the DX and future-enum work aren't lost. (If `gh` isn't authenticated for this repo, write them as `docs/tickets/*.md` stubs instead and note to file them.)
+
+- [ ] **Step 1: Slug-vs-name `--team-id` UX + `long_help` fix**
+
+```bash
+gh issue create --repo paiml/rust-mcp-sdk \
+  --title "package capture: slug-friendly --team-id guard + fix wrong 'UUID' long_help" \
+  --body "capture.rs takes an AgentTeam id that is a SLUG (e.g. day-trip-planner-team), not a UUID; its long_help wrongly says UUID. A 'reject non-UUID' guard would reject valid slug ids. Do: (1) fix long_help to say 'AgentTeam id (slug), not the display name'; (2) reject only OBVIOUS display names (input contains a space or is mixed-case) with a clear message; (3) otherwise pass through and surface a clean server-side 'AgentTeam not found'. Client-side code cannot reliably tell a valid slug-id from a display name, so do NOT gate on UUID format. Orthogonal to the contract seam."
+```
+
+- [ ] **Step 2: Optional `status` → server-side enum (future capture-v2)**
+
+```bash
+gh issue create --repo paiml/rust-mcp-sdk \
+  --title "capture-v2 (optional): promote GraphQL 'status' from String to a real enum" \
+  --body "capture-v1.graphql types status as String to match the live schema (an enum would false-positive the online drift diff). If the platform promotes status to a server-side GraphQL enum, a future capture-v2 contract can assert the enum truthfully. Optional cleanup, zero dependency on the v1 critical path."
+```
+
+- [ ] **Step 3: Commit any doc stubs** (only if `gh` was unavailable and stubs were written)
+
+```bash
+git add docs/tickets/ 2>/dev/null && git commit -m "docs(capture): stub the two spun-off tickets" || true
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §3 (generated SDL, String-not-enum, provenance) → Tasks 2, 2b + `status_field_is_string_not_enum` test. ✅
+- Spec §4 (Approach B, no codegen, offline test of ops + structs) → Tasks 1, 3. ✅
+- Spec §5a (offline blocking) → Task 3 (runs in normal `cargo test`). ✅
+- Spec §5b (online drift check) → **platform-owned** (Task 4 revised: no SDK-side workflow; the source API isn't client-reachable). The `capture_contract` dev tool (Task 2) remains a manual aid. ✅
+- Spec §6 (platform PRs the contract; offline gate forces lockstep) → the blocking Task 3 test enforces it; documented in Task 5 invariant. ✅
+- Spec §7 (compat/versioning) → contract filename `capture-v1`; no code needed. ✅
+- Spec §8 (delivery invariant, steps in runbook) → Task 5. ✅
+- Spec §9 (out-of-scope tickets: slug UX, enum promotion) → Task 6. ✅
+
+**Placeholder scan:** the only intentionally-parameterized values are live secrets/URLs (`<source-api>`, `PMCP_CLIENT_ID=…`) which are environment inputs, not plan gaps. No TODO/TBD logic.
+
+**Type consistency:** `SUBMIT_PACKAGE_CAPTURE_QUERY` / `GET_PACKAGE_CAPTURE_STATUS_QUERY` named identically in Tasks 1, 3. `capture_contract emit`/`check` used consistently in Tasks 2, 2b, 4. Struct field lists in Task 3 match the verified `CaptureInfo`/`CaptureStatus` definitions.

--- a/docs/superpowers/specs/2026-07-20-package-capture-contract-seam-design.md
+++ b/docs/superpowers/specs/2026-07-20-package-capture-contract-seam-design.md
@@ -1,0 +1,190 @@
+# Package-Capture Contract Seam — Design
+
+**Date:** 2026-07-20
+**Status:** Approved (green-lit with three gating corrections, incorporated)
+**Scope:** How `cargo pmcp package capture` binds to pmcp.run's remote capture API,
+so the CLI and the platform cannot silently drift.
+
+---
+
+## 1. Problem
+
+`cargo pmcp package capture` is a **pure thin client** of pmcp.run's remote,
+already-deployed capture job API. The platform does all substantive work
+server-side (reads the component graph from its own DynamoDB models, extracts
+config slots, packs the canonical `pmcp-package` OCI layout, pushes it to ECR).
+The CLI only **submits a team reference and polls** for a terminal status.
+
+The verb already exists and is hardened (branch `feat/package-remote-capture-show`,
+`cargo-pmcp/src/commands/package/capture.rs` + `.../pmcp_run/graphql.rs`). But its
+GraphQL binding is **hand-written raw query strings + serde structs over reqwest**,
+with **no shared schema and no drift gate**. That is precisely the setup that let
+the CLI and platform diverge in Phase 110 (a `capture` verb POSTing to an endpoint
+that 404'd everywhere). Nothing structurally prevents it from happening again.
+
+**Goal:** give the two capture operations a **versioned, platform-owned GraphQL
+contract**, checked into the SDK repo and **enforced by a test**, so a platform
+schema change the CLI hasn't tracked fails the SDK build.
+
+## 2. The two operations (ground truth, verified against the live schema)
+
+Asymmetry between the two ops is real and the contract must capture it **exactly**:
+
+```graphql
+# submit — returns captureId
+submitPackageCapture(
+  rootComponentType: String!   # v1: "team" only
+  rootComponentId:   String!   # AgentTeam id (a slug like day-trip-planner-team, NOT a UUID)
+  version:           String!   # semver, e.g. 1.0.0
+  bump:              String    # major|minor|patch; consulted only on errorCode=BUMP_REQUIRED
+): CaptureInfo                 # { captureId, status }
+
+# status — keyed on id, returns id
+getPackageCaptureStatus(id: ID!): CaptureStatus
+# CaptureStatus { id, status, message, errorCode, divergentComponents[], manifestDigest, updatedAt }
+```
+
+- `submitPackageCapture` returns **`captureId`**; `getPackageCaptureStatus` is
+  argued and keyed on **`id`** and its return identity field is **`id`**. The CLI
+  already threads `CaptureInfo.captureId` → the `id` variable correctly.
+- **`status` is a plain `String`**, not a GraphQL enum. Known values observed:
+  `queued`, `walking`, `extracting`, `publishing`, `completed`, `failed`,
+  `not_found`. The poller treats any *unrecognized* value as in-progress (warns
+  once), so additive platform statuses never break an older CLI.
+
+## 3. The contract artifact
+
+A single file: **`contracts/pmcp-run/capture-v1.graphql`** — the **SDL subset** for
+exactly the two operations above and their input/output types.
+
+- **Generated, never hand-written — exported by the platform.** It is produced by
+  the pmcp.run platform running `aws appsync get-introspection-schema` against the
+  live source `amplifyData` AppSync API (apiId `q3gd4hrbabeytc2o2zazld6igy`, us-east-1)
+  and reducing the result to the two capture operations + their return types. The
+  SDK does **not** introspect the source API itself: that API is IAM-auth'd from the
+  platform's backend resolvers and is not client-reachable (no user or M2M token
+  reaches it directly — see §5b), so the platform is the only party that can export
+  it. This also matches the ownership model: the platform owns the schema, therefore
+  it owns the contract's contents. Rationale for "generated, never transcribed":
+  careful human transcription already drifted once in this very design (a
+  hand-authored field list dropped `id`/`updatedAt` and mis-typed `status` as an
+  enum), and the platform export subsequently corrected three more field-shape
+  errors in the SDK-side sketch — proof the artifact must reflect reality, not memory.
+- **`status` is typed `String`** in the SDL to match the schema, with the known
+  values recorded as an SDL doc-comment — NOT as a GraphQL `enum`. Typing it as an
+  enum would make the online schema-vs-schema diff report permanent false drift
+  (`enum` in the contract vs `String` in the live schema).
+- **Provenance header** (as SDL comments): source endpoint, introspection date,
+  contract version. So a reader knows what it was cut from and when.
+- **GraphQL SDL, not `contracts/*.yaml`.** The transport is GraphQL, so SDL lets the
+  online gate be a direct, mechanical schema-vs-schema diff of introspected output
+  against the vendored file. A YAML re-description would be a lossy translation that
+  becomes its own drift source (the CLI would be tested against a remembered copy).
+  The `*.yaml` convention remains correct for non-GraphQL transports.
+- **Ownership:** the platform owns the schema and therefore the contract's
+  *contents*; the SDK owns the artifact's *presence and the test that enforces it*.
+
+## 4. CLI binding (Approach B — vendored SDL + contract test)
+
+Keep `submit_package_capture` / `get_package_capture_status` as hand-written ops in
+`graphql.rs`. **No codegen, no new runtime dependency.** Add a `#[cfg(test)]`
+contract module that, using a GraphQL-parser **dev-dependency**:
+
+1. Parses each operation's query string and validates every selected field,
+   argument, and type against `capture-v1.graphql`.
+2. Asserts the response structs (`CaptureInfo`, `CaptureStatus`) field-for-field
+   against the SDL return types (the field the CLI deserializes must exist in the
+   contract).
+
+If a query or struct references something not in the contract, the test fails.
+(A full `graphql-client`/`cynic` codegen migration — compile-time binding — is a
+reasonable *future* step for all of `graphql.rs`, but is out of scope here: it
+would force a codegen migration through a 52 KB hand-rolled client for two ops.)
+
+## 5. Drift gate (CI) — two layers
+
+**a. Offline (blocking, default).** The §4 contract test runs in normal CI with no
+network. It catches CLI-vs-contract mismatch on every PR. This is the layer that
+forces a platform contract-update PR (§6) to also update the CLI in lockstep.
+
+**b. Online (platform-owned, out-of-band).** A scheduled job introspects the **live
+source data API**, extracts the capture subset, and diffs it against the vendored
+`capture-v1.graphql`, flagging *platform-ahead-of-contract* drift — the schema
+changed but the vendored contract wasn't updated yet. **This job runs on the
+platform side, not in the SDK repo's CI**, because the source `amplifyData` API is
+IAM-auth'd from the platform's backend and is not client-reachable: no SDK-obtainable
+token (M2M client-credentials or PKCE user token) can introspect it, so a headless
+SDK CI job structurally cannot perform the diff. The platform already has the IAM
+introspection access, so it owns this layer:
+
+- The platform runs the periodic introspect → extract-subset → diff against the
+  vendored SDL, and on drift **opens a PR to the SDK repo** updating
+  `capture-v1.graphql` (§6). That PR then trips the offline blocking test (§5a),
+  forcing the CLI's ops/structs to move in lockstep.
+- **Endpoint: the source `amplifyData` data API** (apiId `q3gd4hrbabeytc2o2zazld6igy`),
+  NOT the merged/front-door API. The two can diverge; the capture ops live in
+  `amplifyData`, so the diff must be against that schema.
+
+The SDK repo therefore ships **no** scheduled drift workflow of its own. The
+`capture_contract` dev tool (§4 tooling) remains a useful *manual* introspect/diff
+aid for anyone with source-API access, but nothing in SDK CI depends on it. The
+offline layer (§5a) is the SDK's hard gate; the platform's out-of-band check is the
+early-warning half of the same loop.
+
+## 6. Ownership & change process
+
+When the platform changes the capture schema, **it opens a PR to the SDK repo**
+updating `capture-v1.graphql` (or bumps to `capture-v2` on a breaking change).
+Because the offline contract test (§5a) is blocking, that PR **must** also update
+the CLI's ops/structs to match — the two move together in one reviewable change.
+
+This is the concrete resolution of the two-team boundary: pmcp.run does not need to
+add CLI verbs (they can't), and the SDK does not implement capture logic (it can't).
+The platform PRs the **contract**; the SDK's gate forces the thin client to follow.
+
+## 7. Compatibility policy
+
+- The contract is **versioned** (`capture-v1.graphql`).
+- **Additive** platform changes (e.g., a new intermediate status) need **no CLI
+  release** — the poller already tolerates unknown statuses.
+- **Breaking** changes go to `capture-v2` + a coordinated CLI update.
+- So the drift gate fires only on changes that actually affect the client.
+
+## 8. Delivery invariant (steps live in a separate runbook)
+
+The capture verb ships as a **coordinated SDK release** together with
+`show` / `import` / `approve` (they are one branch), gated by a green contract test
+against a `capture-v1.graphql` generated from the live schema. The verb currently
+lives on `feat/package-remote-capture-show`, unmerged and behind `origin/main`, so
+landing it requires a rebase-and-release.
+
+The concrete rebase / end-to-end-test / publish steps are **execution logistics that
+go stale on completion** and are intentionally kept out of this doc. See:
+`docs/runbooks/package-capture-release.md` (to be written).
+
+## 9. Explicitly out of scope (tracked separately)
+
+- **`--team-id` slug-vs-name UX** (was §7 of the draft): the argument accepts a slug
+  id (e.g. `day-trip-planner-team`), which is **not** a UUID, so a "reject non-UUID"
+  guard would reject valid ids. The separate ticket reworks this: reject only
+  *obvious display names* (input containing spaces or mixed-case) with a clear
+  message, and surface a clean server-side "AgentTeam not found" otherwise —
+  client-side code cannot reliably tell a valid slug-id from a display name. That
+  ticket also fixes `capture.rs`'s `long_help`, which currently (wrongly) says the
+  argument is a UUID. Orthogonal to the contract seam.
+- **`status` → server-side GraphQL enum**: an optional, clean platform schema change
+  that a future `capture-v2` contract could then assert truthfully. Not required for
+  v1; v1 must match today's `String`.
+- **Full `graphql.rs` codegen migration**: a possible future direction, not this work.
+
+## 10. Success criteria
+
+- `contracts/pmcp-run/capture-v1.graphql` exists, is generated from the live source
+  data API, types `status` as `String`, and includes `id` + `updatedAt` and the
+  `captureId`/`id` asymmetry.
+- The offline contract test fails the build if the CLI's capture ops/structs diverge
+  from the contract.
+- The online drift check is **platform-owned** (the platform introspects the source
+  data API it alone can reach and PRs the vendored SDL on drift); the SDK repo ships
+  no scheduled drift workflow and ordinary SDK PRs never depend on network/secrets.
+- A platform schema change and its CLI update land as one contract-update PR.

--- a/docs/tickets/capture-v2-status-enum.md
+++ b/docs/tickets/capture-v2-status-enum.md
@@ -1,0 +1,42 @@
+# Ticket: `capture-v2` (optional) — promote GraphQL `status` from `String` to a real enum
+
+**Status:** open / not yet filed as a GitHub issue (stub — file against `paiml/rust-mcp-sdk`)
+**Spun off from:** package-capture contract seam (design spec §9, 2026-07-20)
+**Priority:** optional cleanup — zero dependency on the v1 critical path
+
+## Context
+
+`contracts/pmcp-run/capture-v1.graphql` types the capture `status` field as a plain
+`String!` in **both** return types (`SubmitPackageCaptureReturnType`,
+`GetPackageCaptureStatusReturnType`), matching the live platform schema. Known
+runtime values are documented as an SDL comment, not schema-enforced:
+
+```
+queued | walking | extracting | publishing | completed | failed | not_found
+```
+
+The CLI poller already tolerates unknown statuses (treats any unrecognized value as
+in-progress, warns once), so additive platform statuses never break an older CLI.
+
+## Why v1 keeps `String`
+
+Typing `status` as a GraphQL `enum` in the vendored contract while the live schema
+still returns `String` would make the platform-owned online schema-vs-schema diff
+report **permanent false drift** (`enum` in the contract vs `String` live). v1 must
+match today's schema exactly.
+
+## The optional change
+
+If the **platform** promotes `status` to a server-side GraphQL `enum` (a clean schema
+improvement on their side), then a future **`capture-v2.graphql`** contract can assert
+the enum truthfully, and the CLI can type the status as an enum end-to-end.
+
+Sequencing (must be in this order to avoid false drift):
+1. Platform changes the live schema `status` → enum.
+2. Platform exports and PRs `capture-v2.graphql` with the enum (per the §6 ownership
+   model — platform owns the contract contents).
+3. SDK bumps the CLI ops/structs + the offline contract test to `capture-v2`.
+
+## Out of scope
+
+Not required for v1. No SDK work until/unless the platform does step 1.

--- a/docs/tickets/package-capture-team-id-slug-ux.md
+++ b/docs/tickets/package-capture-team-id-slug-ux.md
@@ -1,0 +1,44 @@
+# Ticket: `package capture` — slug-friendly `--team-id` guard + fix wrong "UUID" `long_help`
+
+**Status:** open / not yet filed as a GitHub issue (stub — file against `paiml/rust-mcp-sdk`)
+**Spun off from:** package-capture contract seam (design spec §9, 2026-07-20)
+**Priority:** DX polish — orthogonal to the contract seam, not release-blocking
+
+## Problem
+
+`cargo pmcp package capture`'s positional argument is an **AgentTeam id that is a
+slug** (e.g. `day-trip-planner-team`), **not a UUID**. Two defects follow from the
+current code assuming a UUID:
+
+1. **Wrong help text.** `cargo-pmcp/src/commands/package/capture.rs` describes the
+   argument (both the `///` doc and the `long_help`) as
+   `AgentTeam ID (UUID) — the team's id, not its display name.` and claims
+   `submitPackageCapture` does a `GetItem` by primary key so "a display name will
+   not resolve." The "(UUID)" characterization is wrong — the id is a slug.
+2. **No guard, so display names fail opaquely.** If a user passes a display name
+   (e.g. `"Day Trip Planner"`) it is sent as-is and the server returns a bare
+   not-found, with nothing steering the user toward the slug id.
+
+## Why a naive UUID guard is WRONG
+
+A "reject anything that isn't a UUID" validation would reject every valid slug id.
+Client-side code **cannot reliably distinguish a valid slug-id from a display
+name** — both are arbitrary strings. So the guard must be conservative.
+
+## Fix
+
+1. ✅ **DONE (cargo-pmcp 0.19.0)** — **Fixed the help text** (`capture.rs`): the `///`
+   doc comment and `long_help` now say the argument is an **AgentTeam id (slug)** —
+   e.g. `day-trip-planner-team` — **not the display name (and not a UUID)**. The
+   remaining items below (the conservative display-name guard) are still open.
+2. **Reject only OBVIOUS display names** with a clear, actionable message: input that
+   **contains a space** or is **mixed-case** is almost certainly a display name, not a
+   slug — reject those up front pointing the user at the slug form. Everything else
+   passes through.
+3. **Lean on a clean server-side "AgentTeam not found"** for anything that passes the
+   client guard but doesn't resolve. Do NOT gate on UUID format.
+
+## Out of scope
+
+Server-side name→id lookup (a documented deferral). This ticket only fixes the
+client help text + the conservative display-name guard.


### PR DESCRIPTION
## cargo-pmcp v0.19.0 — remote package verbs + capture contract seam

Adds the `cargo pmcp package` remote lifecycle verbs — **`capture` / `import` / `approve`** (plus `show`) — as thin GraphQL clients of pmcp.run's already-deployed platform API, together with a versioned, platform-owned contract seam that pins the capture operations to the live schema so the CLI and platform can't silently drift.

### What's in it

- **`capture` / `import` / `approve` verbs** + their GraphQL client fns. All substantive work (dependency-graph walk, config-slot extraction, OCI pack, ECR push, import pre-flight) runs **server-side**; the CLI only submits a reference and polls to a terminal status.
- **Capture contract seam** — `contracts/pmcp-run/capture-v1.graphql` (exported from the live platform schema) + an **offline blocking test** (`tests/package_capture_contract.rs`, `apollo-compiler` dev-dependency) that fails the build if the CLI's two capture ops or their response structs drift from the vendored SDL. The online drift check is platform-owned (they re-export and PR the SDL on change).
- **`capture_contract` internal tool is feature-gated** behind a non-default `capture-contract-tool` feature, so `cargo install cargo-pmcp` doesn't ship it. Its pure SDL-extraction logic + unit tests live in the library so they still run under the default test gate.
- **Fixed `capture <TEAM_ID>` help text** — it's an AgentTeam **slug** id (e.g. `day-trip-planner-team`), not a UUID.
- **Bump `cargo-pmcp` 0.18.0 → 0.19.0** + CHANGELOG entry.

### Scope & safety

- **Self-contained:** net delta vs `main` is confined to cargo-pmcp + `contracts/` + docs. **Zero** changes to pmcp core, `pmcp-package`, cargo-pmcp's workspace dependencies, or the root `Cargo.toml` — so it builds against the currently published dependency versions.
- **Verified end-to-end against the dev platform:** `cargo pmcp package capture day-trip-planner-team --version 1.0.0` → `completed` with a deterministic manifest digest (`approve` verified too). Builds clean off current `main`, `cargo fmt` clean, 3/3 contract tests pass.
- Full development history lives on `feat/package-remote-capture-show`; this branch is the squashed, reviewable release artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HD14oPYRXfcg6tTfoKYqTb
