### PR TITLE
fix: stdin EOF disabled stdout, dropping already-accepted responses (#316)

### DIFF
--- a/src/shared/stdio.rs
+++ b/src/shared/stdio.rs
@@ -459,7 +459,7 @@ mod tests {
             .split("// EOF on stdin closes the READ side only")
             .nth(1)
             .expect("the EOF branch must carry its marker comment");
-        let branch = &body[..body.find("\n    }").unwrap_or(body.len().min(400))];
+        let branch = &body[..body.find("\n    }").unwrap_or_else(|| body.len().min(400))];
         assert!(
             branch.contains("read_closed"),
             "the EOF branch must close the read side: {branch}"

--- a/src/shared/stdio.rs
+++ b/src/shared/stdio.rs
@@ -42,7 +42,19 @@ pub struct StdioTransport {
     /// full newline-delimited line is available.
     partial: Mutex<Vec<u8>>,
     stdout: Mutex<tokio::io::Stdout>,
-    closed: std::sync::atomic::AtomicBool,
+    /// Set on stdin EOF, or by `close()`. Gates `receive()`.
+    read_closed: std::sync::atomic::AtomicBool,
+    /// Set ONLY by `close()` or a real stdout write error. Gates `send()`.
+    ///
+    /// These were one flag, and stdin EOF set it — so `send()` then refused
+    /// every stdout write. A client that pipes a batch of requests and closes
+    /// stdin, which is the normal shape of a one-shot MCP session and the only
+    /// way this transport can signal end-of-input, never received the responses
+    /// to requests the server had already accepted and answered (#316).
+    ///
+    /// stdin and stdout are separate pipes. "I have no further requests" is not
+    /// "I have stopped reading your replies".
+    write_closed: std::sync::atomic::AtomicBool,
 }
 
 impl StdioTransport {
@@ -61,7 +73,8 @@ impl StdioTransport {
             stdin: Mutex::new(BufReader::new(tokio::io::stdin())),
             partial: Mutex::new(Vec::new()),
             stdout: Mutex::new(tokio::io::stdout()),
-            closed: std::sync::atomic::AtomicBool::new(false),
+            read_closed: std::sync::atomic::AtomicBool::new(false),
+            write_closed: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -76,7 +89,9 @@ impl Default for StdioTransport {
 impl Transport for StdioTransport {
     async fn send(&mut self, message: TransportMessage) -> Result<()> {
         contract_pre_transport_abstraction!();
-        if self.closed.load(std::sync::atomic::Ordering::Acquire) {
+        // `write_closed`, not the read side: stdin EOF must not stop us
+        // answering what we already accepted (#316).
+        if self.write_closed.load(std::sync::atomic::Ordering::Acquire) {
             return Err(TransportError::ConnectionClosed.into());
         }
 
@@ -86,7 +101,7 @@ impl Transport for StdioTransport {
 
     async fn receive(&mut self) -> Result<TransportMessage> {
         contract_pre_transport_abstraction!();
-        if self.closed.load(std::sync::atomic::Ordering::Acquire) {
+        if self.read_closed.load(std::sync::atomic::Ordering::Acquire) {
             return Err(TransportError::ConnectionClosed.into());
         }
 
@@ -96,7 +111,10 @@ impl Transport for StdioTransport {
 
     async fn close(&mut self) -> Result<()> {
         contract_pre_transport_abstraction!();
-        self.closed
+        // close() still stops BOTH directions — that guarantee is unchanged.
+        self.read_closed
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.write_closed
             .store(true, std::sync::atomic::Ordering::Release);
 
         // Flush any pending output
@@ -113,7 +131,9 @@ impl Transport for StdioTransport {
     }
 
     fn is_connected(&self) -> bool {
-        !self.closed.load(std::sync::atomic::Ordering::Acquire)
+        // Still connected while we can answer. A server that has read EOF but
+        // has responses to write is not disconnected.
+        !self.write_closed.load(std::sync::atomic::Ordering::Acquire)
     }
 
     fn transport_type(&self) -> &'static str {
@@ -134,20 +154,24 @@ impl StdioTransport {
     async fn write_message(&self, json_bytes: &[u8]) -> Result<()> {
         let mut stdout = self.stdout.lock().await;
 
+        // A real stdout failure — a closed or broken pipe — DOES close the
+        // write side. That is the other half of #316: `send()` no longer gives
+        // up on stdin EOF, so the write side must still latch shut when stdout
+        // itself is gone, or a dead pipe would be retried forever.
+        let mut fail = |e: std::io::Error| {
+            self.write_closed
+                .store(true, std::sync::atomic::Ordering::Release);
+            TransportError::from(e)
+        };
+
         // Write message payload
-        stdout
-            .write_all(json_bytes)
-            .await
-            .map_err(TransportError::from)?;
+        stdout.write_all(json_bytes).await.map_err(&mut fail)?;
 
         // Write newline delimiter (MCP spec requirement)
-        stdout
-            .write_all(b"\n")
-            .await
-            .map_err(TransportError::from)?;
+        stdout.write_all(b"\n").await.map_err(&mut fail)?;
 
         // Always flush stdio
-        stdout.flush().await.map_err(TransportError::from)?;
+        stdout.flush().await.map_err(&mut fail)?;
         drop(stdout);
 
         Ok(())
@@ -168,8 +192,9 @@ impl StdioTransport {
         if let Some(bytes) = Self::read_cancel_safe_line(&mut stdin, &mut partial).await? {
             Ok(bytes)
         } else {
-            // EOF reached.
-            self.closed
+            // EOF on stdin closes the READ side only. stdout stays writable so
+            // in-flight responses can still be delivered (#316).
+            self.read_closed
                 .store(true, std::sync::atomic::Ordering::Release);
             Err(TransportError::ConnectionClosed.into())
         }
@@ -397,5 +422,104 @@ mod tests {
             .await
             .unwrap();
         assert!(eof.is_none(), "the tail must not be re-delivered");
+    }
+    // ================= #316: stdin EOF must not disable stdout =================
+
+    use crate::shared::Transport;
+    use std::sync::atomic::Ordering;
+
+    /// REGRESSION (#316): one `closed` flag served two independent pipes.
+    ///
+    /// Reaching EOF on **stdin** set it, and `send()` then refused every
+    /// **stdout** write — so a client that piped a batch of requests and closed
+    /// stdin never received the responses to requests the server had already
+    /// accepted and answered. That is the normal shape of a one-shot MCP
+    /// session, and closing stdin is the only way this transport can signal
+    /// end-of-input. Measured downstream: 40/40 sessions answered on pmcp 2.11,
+    /// 10/40 on 2.17.
+    ///
+    /// This assertion is over the SOURCE of `read_line`, deliberately.
+    /// `StdioTransport` reads the process's real stdin, so the EOF branch
+    /// cannot be driven from a unit test — and the first version of this test
+    /// set `read_closed` by hand instead, which meant it passed just as happily
+    /// with the bug reinstated. A test that cannot fail on the defect it names
+    /// is worse than none, so this reads the branch itself.
+    #[test]
+    fn stdin_eof_closes_the_read_side_only() {
+        // Only the PRODUCTION half of the file. `include_str!` pulls in this
+        // test module too, and the first version of this assertion matched its
+        // own string literals — the same self-reference that makes a drift
+        // guard silently compare the wrong thing.
+        let src = include_str!("stdio.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("the file has a test module");
+        let body = production
+            .split("// EOF on stdin closes the READ side only")
+            .nth(1)
+            .expect("the EOF branch must carry its marker comment");
+        let branch = &body[..body.find("\n    }").unwrap_or(body.len().min(400))];
+        assert!(
+            branch.contains("read_closed"),
+            "the EOF branch must close the read side: {branch}"
+        );
+        assert!(
+            !branch.contains("write_closed"),
+            "stdin EOF must NOT close the write side — the server still owes \
+             responses to requests it already accepted (#316). Found:\n{branch}"
+        );
+    }
+
+    /// The state really is two independent flags, and a fresh transport has
+    /// both open.
+    #[test]
+    fn read_and_write_state_are_independent() {
+        let t = StdioTransport::new();
+        assert!(!t.read_closed.load(Ordering::Acquire));
+        assert!(!t.write_closed.load(Ordering::Acquire));
+
+        t.read_closed.store(true, Ordering::Release);
+        assert!(
+            !t.write_closed.load(Ordering::Acquire),
+            "closing reads must leave writes open"
+        );
+        assert!(t.is_connected(), "still connected while it can answer");
+    }
+
+    /// `close()` must still stop BOTH directions — the guarantee that existed
+    /// before the split, and the reason the split is not simply "drop the flag".
+    #[tokio::test]
+    async fn close_still_stops_both_directions() {
+        let mut t = StdioTransport::new();
+        t.close().await.expect("close");
+        assert!(
+            t.read_closed.load(Ordering::Acquire),
+            "close() closes reads"
+        );
+        assert!(
+            t.write_closed.load(Ordering::Acquire),
+            "close() closes writes"
+        );
+        assert!(!t.is_connected());
+    }
+
+    /// And a `send()` after `close()` is still refused, so the split did not
+    /// widen what the transport accepts.
+    #[tokio::test]
+    async fn send_after_close_is_still_refused() {
+        let mut t = StdioTransport::new();
+        t.close().await.expect("close");
+        let sent = t
+            .send(TransportMessage::Notification(
+                crate::types::Notification::Progress(crate::types::ProgressNotification {
+                    progress_token: crate::types::ProgressToken::String("t".into()),
+                    progress: 1.0,
+                    message: None,
+                    total: None,
+                }),
+            ))
+            .await;
+        assert!(sent.is_err(), "send() after close() must fail");
     }
 }


### PR DESCRIPTION
Closes #316.

`StdioTransport` used **one `closed` flag for two independent pipes**. Reaching EOF on stdin
set it, and `send()` then refused every stdout write — so a client that pipes a batch of
requests and closes stdin never received the responses to requests the server had already
accepted and answered.

That is the normal shape of a one-shot MCP session, and closing stdin is the *only* way this
transport can signal end-of-input. stdin and stdout are separate pipes: **"I have no further
requests" is not "I have stopped reading your replies".**

Measured downstream on pmat: **40/40** sessions answered against pmcp 2.11, **10/40** against 2.17.

## The change

| flag | set by | gates |
|---|---|---|
| `read_closed` | stdin EOF, or `close()` | `receive()` |
| `write_closed` | `close()`, or a **real** stdout write error | `send()` |

Every existing guarantee holds, and both are pinned by tests because the fix must not widen
what the transport accepts:

- `close()` still stops **both** directions
- `send()` after `close()` is still refused
- a broken stdout still fails fast — `write_message` now latches `write_closed` on any write or
  flush error. That is the other half of this change: `send()` no longer gives up on stdin EOF,
  so the write side must latch when stdout itself is gone, or a dead pipe would be retried forever.

`is_connected()` now reports the write side — a server that has read EOF but still owes
responses is not disconnected.

## Two notes on the test, both of which cost a round to find

**The first version passed with the bug reinstated.** It set `read_closed` by hand to simulate
EOF, so it never reached the branch in `read_line` where the defect lives. `StdioTransport`
reads the process's real stdin, so that branch cannot be driven from a unit test — the assertion
is therefore over the *source* of the branch, and says so plainly.

**The second version matched its own string literals.** `include_str!("stdio.rs")` pulls in the
test module, so the marker it searched for was found inside the test itself. It now splits on
`mod tests {` and inspects only the production half.

Verified by reinstating the defect and watching the test go red, then restoring.

**1,632 lib tests pass**; clippy clean with `--all-features`.