### PR TITLE
docs: record the #316 stdio fix in the 2.18.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.18.0] - Unreleased
+## [2.18.0] - 2026-08-16
 
 SEP-2352 credential storage and OAuth discovery hardening (Phase 116). `pmcp`
 gains a credential-storage seam addressed by `(issuer, account, server)`, and
@@ -26,6 +26,30 @@ behaviour changes are called out below because both are visible to operators.
 - `OAuthHelper::with_credential_store` / `with_account_scope` /
   `with_interactivity`, and `Interactivity::RefreshOnly` for callers (scripts,
   CI) that must never be handed a browser.
+
+### Fixed
+
+- **stdin EOF disabled stdout, dropping responses to requests the server had
+  already accepted** (#316). `StdioTransport` tracked both directions with a
+  single `closed` flag, so the moment stdin reached EOF the transport refused
+  to *write* as well — `stdio.rs:172` set the flag on read EOF and `send()` at
+  `:79` returned `ConnectionClosed` on that same flag. A client that writes
+  its requests and closes stdin — the ordinary shape for a batch or one-shot
+  invocation — is a client that has already handed the server work; those
+  responses were silently discarded, and from the client's side the server
+  looked like it had hung or answered nothing.
+
+  The flag is now split into `read_closed` and `write_closed`. EOF on stdin
+  closes the read side only; the write side latches shut on a real write error
+  or an explicit `close()`, so the server can still deliver what it owes.
+  Downstream impact, stated precisely: pmat worked around this with a
+  three-layer mitigation, the last layer of which exists *only* because of this
+  defect — it catches the response pmcp refuses to write and re-emits it
+  through `serialize_message` so the bytes match what the transport would have
+  produced. That layer can now be deleted. The other two layers address
+  separate races (a session ending while a consumed request is in flight, and
+  the actor's `select!` breaking without draining its outbound queue) and are
+  still needed.
 
 ### Changed
 


### PR DESCRIPTION
The 2.18.0 entry was headed `Unreleased` and had no `### Fixed` section, so #316 — the one change in this release that alters runtime behaviour for every stdio consumer — was missing from the changelog entirely. Dates the entry 2026-08-16 and adds it.

Two corrections I made while writing it, both caught before commit:

- I first attributed "10/40 → 40/40" to this fix. Those numbers are real but belong to pmat's own mitigation work (40/40 on pmcp 2.11, 10/40 on 2.17 with one layer, 40/40 on 2.17 with all three of pmat's layers). This fix's real downstream effect is narrower: it retires pmat's *third* layer, the one that exists solely to salvage a response pmcp refuses to write.
- I cited `stdio.rs:79` as the read-EOF setter and `:172` as the write gate. Verified against `1c1f4ab^` — it is the reverse.

Docs only, no code change.