### PR TITLE
fix(release): close the ledger gap that left pmcp-tasks unpublished

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,13 @@ jobs:
       with:
         components: rustfmt, clippy
     
+    # Release-ledger coverage. Runs FIRST and costs ~2s: a crate with no publish
+    # step ships nothing, and that has now happened twice (pmcp-openapi-server,
+    # pmcp-tasks). Lives in the quality-gate job because `gate.needs` already
+    # includes it, so a failure blocks merge via the org-required `gate` check.
+    - name: Release-ledger coverage
+      run: ./scripts/check-release-coverage.sh
+
     - name: Cache cargo
       uses: actions/cache@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,6 +550,27 @@ jobs:
           fi
         }
 
+    # pmcp-tasks: experimental 0.x leaf. Depends on `pmcp` only, and NOTHING in
+    # this workspace depends on it — so it publishes late, for the same reason
+    # pmcp-package does: a failure here must not abort the job before the core
+    # SDK and its dependents publish. It is consumed out-of-repo (pmcp-run's
+    # built-in servers pin it with `features = ["dynamodb"]`), which is why it
+    # must publish at all rather than staying a path-dep.
+    - name: Publish pmcp-tasks
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        echo "Publishing pmcp-tasks..."
+        OUTPUT=$(cargo publish -p pmcp-tasks 2>&1) && echo "$OUTPUT" || {
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "already exists"; then
+            echo "pmcp-tasks already published, continuing..."
+          else
+            echo "::error::Failed to publish pmcp-tasks"
+            exit 1
+          fi
+        }
+
     # pmcp-package: standalone workspace-EXCLUDED leaf (has its own [workspace]
     # table, so `-p pmcp-package` does NOT resolve — it must be reached via
     # --manifest-path). It has NO in-repo consumers yet, so it is published LAST:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,21 @@ make test-integration   # Integration tests
    gate the core SDK release. Its `webhook` (reqwest) and `http`
    (`pmcp/streamable-http`) features are non-default, so the default publish
    build is reqwest-free and wasm-clean.
+16. `pmcp-server` (the docs/resources MCP server at `crates/pmcp-server/`). A root
+   workspace member pinning `pmcp` (item 2) and `mcp-tester` (item 10), so it must
+   publish AFTER both. **This entry was missing from this list until 2026-08-21** —
+   it was present in `release.yml` the whole time, so CI published it correctly and
+   only the prose order was wrong. Its sibling `pmcp-server-lambda` is
+   `publish = []` and never publishes.
+17. `pmcp-tasks` (the experimental 0.x MCP-Tasks crate at `crates/pmcp-tasks/`). Pins
+   `pmcp` (item 2) only, and NOTHING in this workspace depends on it — so it
+   publishes late, like `pmcp-package`, and a failure here must not gate the core
+   SDK release. **This entry was missing from BOTH this list and `release.yml`
+   until 2026-08-21**, so it had never published at all; pmcp-run's built-in
+   servers consume it out-of-repo with `features = ["dynamodb"]` and could not pin
+   until 0.1.0 was published by hand. Both ledgers are now covered by the
+   `release-coverage` CI check (see below), which is what makes a third recurrence
+   a build failure rather than a discovery.
 
 The three per-backend connector crates (`pmcp-toolkit-postgres`, `-mysql`, `-athena`)
 have no inter-dependencies — they may publish in any order relative to each other,

--- a/crates/pmcp-agent/Cargo.toml
+++ b/crates/pmcp-agent/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 edition = "2021"
 description = "Deploy-anywhere agent decision loop for the PMCP SDK (experimental)"
 license = "MIT"
+repository = "https://github.com/paiml/rust-mcp-sdk"
 readme = "README.md"
 rust-version = "1.91.0"
 

--- a/crates/pmcp-tasks/Cargo.toml
+++ b/crates/pmcp-tasks/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "MCP Tasks support for the PMCP SDK (experimental)"
 license = "MIT"
+repository = "https://github.com/paiml/rust-mcp-sdk"
 rust-version = "1.91.0"
 
 [dependencies]

--- a/crates/pmcp-team-servers/Cargo.toml
+++ b/crates/pmcp-team-servers/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 edition = "2021"
 description = "Dev-grade reference team servers (team-fs, mem-mcp, approval-mcp, team-mcp) for the PMCP SDK (experimental)"
 license = "MIT"
+repository = "https://github.com/paiml/rust-mcp-sdk"
 readme = "README.md"
 rust-version = "1.91.0"
 # .planning/ (GSD scaffolding), fuzz/ (workspace-excluded cargo-fuzz sub-package),

--- a/examples/25-oauth-basic/Cargo.toml
+++ b/examples/25-oauth-basic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oauth-basic"
 version = "0.1.0"
 edition = "2021"
+publish = false  # example crate, never published
 description = "OAuth authentication example for MCP servers using the Rust SDK"
 license = "MIT"
 repository = "https://github.com/anthropics/claude-code"

--- a/examples/test-basic/Cargo.toml
+++ b/examples/test-basic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-basic"
 version = "0.1.0"
 edition = "2021"
+publish = false  # example crate, never published
 description = "Basic test example for PMCP SDK"
 license = "MIT"
 repository = "https://github.com/paiml/rust-mcp-sdk"

--- a/scripts/check-release-coverage.sh
+++ b/scripts/check-release-coverage.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Every publishable workspace member MUST have a publish step in release.yml.
+#
+# Why this exists: a crate can be a workspace member, build in CI, and pass every
+# quality gate while having no publish step at all — so it silently never ships.
+# That went unnoticed twice: `pmcp-openapi-server` (fixed 2026-07-27) and
+# `pmcp-tasks` (fixed 2026-08-21, discovered only because a downstream consumer
+# could not pin it). Both ledgers are hand-maintained prose; this makes the
+# workflow half machine-checked.
+#
+# A crate that should NOT publish declares `publish = false` in its Cargo.toml.
+# That is the single opt-out — there is no allowlist here on purpose.
+set -euo pipefail
+
+WORKFLOW="${1:-.github/workflows/release.yml}"
+[ -f "$WORKFLOW" ] || { echo "::error::$WORKFLOW not found"; exit 1; }
+
+# `publish` is null for publishable crates and [] for `publish = false`.
+mapfile -t PUBLISHABLE < <(
+  cargo metadata --no-deps --format-version 1 \
+    | python3 -c 'import json,sys; print("\n".join(sorted(p["name"] for p in json.load(sys.stdin)["packages"] if p.get("publish") is None)))'
+)
+
+missing=()
+for crate in "${PUBLISHABLE[@]}"; do
+  # Match the publish step, not a comment or a longer crate name that shares the prefix.
+  if ! grep -qE "cargo publish (-p ${crate}( |\$)|--manifest-path [^ ]*/${crate}/Cargo\.toml)" "$WORKFLOW"; then
+    missing+=("$crate")
+  fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "::error::${#missing[@]} publishable workspace member(s) have no publish step in $WORKFLOW:"
+  for m in "${missing[@]}"; do echo "  - $m"; done
+  echo ""
+  echo "Fix by EITHER adding a publish step to $WORKFLOW (and an entry to CLAUDE.md's"
+  echo "publish order), OR setting 'publish = false' if the crate is not meant to ship."
+  exit 1
+fi
+
+echo "release-coverage: all ${#PUBLISHABLE[@]} publishable workspace members have a publish step."


### PR DESCRIPTION
## What this fixes

`pmcp-tasks` has been a publishable workspace member since Phase 83 with **no publish step in `release.yml`** and **no entry in CLAUDE.md's publish order** — so it had never reached crates.io at all. pmcp-run's built-in servers consume it out-of-repo (`features = ["dynamodb"]`, in `approval-mcp` and `agent-lake`) and could not pin their dependency until `0.1.0` was published by hand on 2026-08-21.

This is the **second** occurrence of the same defect. `pmcp-openapi-server` was missing from the same list until 2026-07-27, and CLAUDE.md documents that miss in its own text:

> **This entry was missing until 2026-07-27** — the crate has existed at `crates/pmcp-openapi-server/` … while being absent from this list, so a release would have silently skipped it.

Both ledgers are hand-maintained prose. A third recurrence was a matter of time.

## Changes

- **`release.yml`** — add the `pmcp-tasks` publish step, placed late alongside `pmcp-package`. It depends on `pmcp` only and nothing in this workspace depends on it, so a failure must not abort the job before the core SDK publishes.
- **`CLAUDE.md`** — add items **16** (`pmcp-server`) and **17** (`pmcp-tasks`). `pmcp-server` was in `release.yml` the whole time, so CI published it correctly and only the prose order was wrong.
- **`scripts/check-release-coverage.sh`** *(new)* — assert every publishable workspace member has a publish step. `publish = false` is the single opt-out; there is deliberately **no allowlist**.
- **`ci.yml`** — run the check in the `quality-gate` job, which `gate.needs` already lists, so a failure blocks merge via the org-required `gate` status check. Costs ~2s and runs before the expensive legs.
- **`examples/{25-oauth-basic,test-basic}`** — `publish = false`. Both were publishable-by-default workspace members, which is wrong on its own merits and also made them false positives for the new check.
- **`repository`** added to `pmcp-tasks`, `pmcp-agent`, `pmcp-team-servers`. `mcp-e2e-tests` is `publish = []` and needs none.

## The check is proven RED, not just green

A coverage check that has only ever passed proves nothing. Removing the `pmcp-tasks` publish step:

```
::error::1 publishable workspace member(s) have no publish step in .github/workflows/release.yml:
  - pmcp-tasks
EXIT=1
```

Restoring it:

```
release-coverage: all 24 publishable workspace members have a publish step.
EXIT=0
```

## Filed, not fixed here: fail-fast stranding

`release.yml` contains **zero** `continue-on-error`, so one recoverable failure strands every crate below it. This is what actually left `cargo-pmcp` and `pmcp-server` unpublished on 2026-08-21:

```
489  pmcp-agent
504  pmcp-team-servers   <- 403: crate exists but CI is not an owner
525  cargo-pmcp          <- never ran
543  pmcp-server         <- never ran
```

Both were then published by hand. Note this is a **different** bug from the ledger gap above, and the more consequential one.

`release.yml` already articulates the right principle in its `pmcp-package` comment — *"a failure in this experimental 0.x crate must not abort the job before the core `pmcp` SDK and its dependents publish"* — and solves it there by ordering. **That fix is unavailable for `pmcp-team-servers`**, because `cargo-pmcp` genuinely depends on it and must publish after it. It needs error tolerance (collect failures, report at the end) rather than reordering, which is a larger change to release machinery and deserves its own review.

Related open item: `pmcp-team-servers` still needs its CI co-owner added via the crates.io web UI — `cargo owner --add` 403s on token scope. Until then that step fails every release.

## Verification

`make quality-gate` passes — 2020 tests, 433 test-result lines, all reporting `0 failed`, banner present and log untruncated. Both workflow files validated as parseable YAML, and the new step confirmed to sit inside the `quality-gate` job that `gate.needs` includes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)