### PR TITLE
chore: gitignore cargo-pmcp's per-workspace local state and credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,20 @@ examples/spin
 
 # PMAT/pv lint cache (machine-generated tooling scratch — never commit)
 .pv/
+
+# cargo-pmcp per-workspace local state and credentials (`.pmcp/`).
+# NOT a blanket `.pmcp/` ignore: that directory legitimately carries COMMITTED
+# config — `crates/pmcp-server/.pmcp/{deploy,deployment}.toml` are tracked — so
+# ignoring the whole directory would silently swallow future config additions.
+# These entries name only the machine-generated and secret-bearing files that
+# `cargo pmcp` writes at runtime.
+# The `**/` prefix is REQUIRED: a pattern containing a slash is anchored to this
+# file's directory, so a bare `.pmcp/active-target` would match only the repo
+# root and miss `cargo-pmcp/.pmcp/active-target` entirely (measured).
+**/.pmcp/active-target
+**/.pmcp/credentials.toml
+**/.pmcp/oauth-cache.json
+**/.pmcp/oauth-tokens.json
+**/.pmcp/secrets/
+**/.pmcp/binaries/
+**/.pmcp/reports/


### PR DESCRIPTION
## What

`cargo pmcp` writes per-workspace runtime state into a `.pmcp/` directory. None of it was gitignored. This adds targeted entries for the machine-generated and secret-bearing files only.

## Why it was found

While publishing v2.19.1 by hand, `cargo package -p cargo-pmcp` refused:

```
error: 1 files in the working directory contain changes that were not yet committed into git:
  cargo-pmcp/.pmcp/active-target
to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
```

Taking cargo's suggested `--allow-dirty` would have shipped that untracked local state into the published `.crate`.

## Why not a blanket `.pmcp/` ignore

That directory legitimately carries **committed** config — `crates/pmcp-server/.pmcp/deploy.toml` and `deployment.toml` are tracked. Ignoring the whole directory would silently swallow future config additions there. These entries name only what the CLI writes at runtime.

## The part that matters more than the ergonomics

`cargo pmcp` can write `.pmcp/credentials.toml`, `.pmcp/oauth-tokens.json`, `.pmcp/oauth-cache.json` and `.pmcp/secrets/`.

**Verified none is currently tracked, and none appears anywhere in git history** — so this is preventive, not remedial. But a `git add -A` after an auth flow would have committed live tokens.

## The `**/` prefix is required

Measured, not assumed. A gitignore pattern containing a slash is anchored to its own file's directory, so a bare `.pmcp/active-target` matches only the repo root and misses `cargo-pmcp/.pmcp/active-target`. The first draft of this patch had exactly that bug; `git check-ignore` caught it.

## Verification

Both directions checked with `git check-ignore`:

| Path | Expected | Result |
|---|---|---|
| `cargo-pmcp/.pmcp/active-target` | ignored | ignored |
| `cargo-pmcp/.pmcp/credentials.toml` | ignored | ignored |
| `some/deep/dir/.pmcp/secrets/tok` | ignored | ignored |
| `crates/pmcp-server/.pmcp/deploy.toml` | **not** ignored, still tracked | not ignored, tracked |
| `crates/pmcp-server/.pmcp/deployment.toml` | **not** ignored, still tracked | not ignored, tracked |

`cargo package -p cargo-pmcp --list` now exits 0 with 386 files and no workaround.

Branched from `upstream/main` rather than the v2.6 branch, which diverged when #348 squash-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
