### PR TITLE
feat(cargo-pmcp 0.24.0): package save --binary; close the env-surface exchange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,9 +291,21 @@ test-tester:
 # describes in general terms.
 #
 # Two details, both measured rather than assumed:
-#   * `--test-threads=1` is REQUIRED. The doctor and aws-artifact tests race on
-#     shared fixture paths: `--bins` in parallel fails 5 tests
-#     nondeterministically, serialized passes 927/927.
+#   * TWO invocations, not one: `-- --test-threads=1` reaches every binary in an
+#     invocation, and only the BIN target has racers. Measured: lib 524 tests,
+#     5.06s parallel vs 7.58s serial; bin 927 tests, 4-9 failures every parallel
+#     run vs 4.66s clean serialized. Splitting keeps the lib leg parallel.
+#     The racers are wider than doctor alone -- configure/{list,show,workspace,
+#     resolver,use_cmd}.rs, deploy/mod.rs and doctor.rs make 20 process-global
+#     `set_current_dir` calls. Isolating them is a real refactor; serializing the
+#     bin leg is the right trade.
+#   * The PER-TARGET guard is the load-bearing half. A summed count answers "was
+#     the selection non-empty", NEVER "was it complete" -- which is why the
+#     `ran -eq 0` check stayed green at 524 while 927 tests were dark. It reuses
+#     `scripts/named-test-binary-count.awk` from `test-cargo-pmcp-integration`,
+#     whose own comment states the principle: a nonzero SUM proves the SELECTION
+#     ran, not that any particular binary ran. Drop `--bins` above and this now
+#     FAILS instead of passing.
 #   * `RUSTFLAGS=` is deliberate and matches `test-cargo-pmcp-integration`, which
 #     already empties it for the same crate. The bin has never been compiled
 #     under the `-D warnings` this Makefile sets, and it carries 13 pre-existing
@@ -301,10 +313,16 @@ test-tester:
 #     commands/package/. Emptying RUSTFLAGS keeps this leg's posture identical to
 #     its sibling instead of making 927 tests hostage to a cleanup that needs a
 #     per-item judgement (scaffolding for pending work vs. genuinely dead).
+#     NOT this target's debt to pay: `make lint` carries no `-p`, so it resolves
+#     to the root `pmcp` and never lints cargo-pmcp's bin at all. The root cause
+#     is the dual-target layout (`main.rs` re-declares every module instead of
+#     consuming the lib), already recorded as a follow-up elsewhere in this file.
+#     Fix it there, not by turning a test target into a linter.
 .PHONY: test-cargo-pmcp
 test-cargo-pmcp:
 	@echo "$(BLUE)Running cargo-pmcp's own tests...$(NC)"
-	@out=$$(RUSTFLAGS= RUST_LOG=$(RUST_LOG) RUST_BACKTRACE=$(RUST_BACKTRACE) $(CARGO) test -p cargo-pmcp --lib --bins -- --test-threads=1 2>&1); \
+	@out=$$(RUSTFLAGS= RUST_LOG=$(RUST_LOG) RUST_BACKTRACE=$(RUST_BACKTRACE) $(CARGO) test -p cargo-pmcp --lib 2>&1; \
+	        RUSTFLAGS= RUST_LOG=$(RUST_LOG) RUST_BACKTRACE=$(RUST_BACKTRACE) $(CARGO) test -p cargo-pmcp --bins -- --test-threads=1 2>&1); \
 	status=$$?; \
 	echo "$$out"; \
 	if [ $$status -ne 0 ]; then exit $$status; fi; \
@@ -313,6 +331,24 @@ test-cargo-pmcp:
 		echo "$(RED)✗ cargo-pmcp reported 0 tests — the gate is not reaching this crate$(NC)"; \
 		exit 1; \
 	fi; \
+	for t in src/lib.rs src/main.rs; do \
+		n=$$(printf '%s\n' "$$out" | awk -v want="$$t" -f scripts/named-test-binary-count.awk); \
+		case "$$n" in \
+		-1) \
+			echo "$(RED)✗ unittest target '$$t' never RAN. If a --lib/--bins selector was dropped from this recipe that is the cause — it is exactly how 927 bin-target tests went dark while this leg reported green.$(NC)"; \
+			exit 1;; \
+		-2) \
+			echo "$(RED)✗ unittest target '$$t' printed a target line but NO 'test result:' followed — truncated output. This gate refuses to pass on output it cannot read.$(NC)"; \
+			exit 1;; \
+		0) \
+			echo "$(RED)✗ unittest target '$$t' RAN but passed ZERO tests. The summed total ($$ran) stays nonzero from the other target, so the count guard above CANNOT catch this.$(NC)"; \
+			exit 1;; \
+		''|*[!0-9]*) \
+			echo "$(RED)✗ unittest target '$$t' — extractor gave no usable reading ('$$n'). EMPTY means awk did not run: check scripts/named-test-binary-count.awk.$(NC)"; \
+			exit 1;; \
+		esac; \
+		echo "$(GREEN)  ✓ $$t ran ($$n passed)$(NC)"; \
+	done; \
 	echo "$(GREEN)✓ cargo-pmcp tests passed ($$ran tests)$(NC)"
 
 # The GATE's reach into `cargo-pmcp/tests/`, mirroring test-openapi-server.

--- a/Makefile
+++ b/Makefile
@@ -280,10 +280,31 @@ test-tester:
 # templates/agent.rs PMCP_AGENT_VERSION), the tests whose whole job is to fire on
 # a version bump. A `chore: bump` commit passed this gate green and then failed
 # CI on exactly that tripwire; this target closes that hole.
+#
+# `--lib` AND `--bins`, because this leg once closed the hole one level short.
+# `cargo-pmcp/src/lib.rs` declares NO `mod commands`, so ALL of
+# `src/commands/**` (save, load, deploy, doctor, secret, package/*) compiles into
+# the BIN target. Measured 2026-08-29: `--lib` alone runs 524 tests and the bin
+# adds a further 927 that were reached by NOTHING. The vacuity guard below could
+# not catch it -- it fires only at ZERO, so this leg was green at 524 while
+# missing 927, the partial-blind-spot shape `test-server-toolkit`'s comment
+# describes in general terms.
+#
+# Two details, both measured rather than assumed:
+#   * `--test-threads=1` is REQUIRED. The doctor and aws-artifact tests race on
+#     shared fixture paths: `--bins` in parallel fails 5 tests
+#     nondeterministically, serialized passes 927/927.
+#   * `RUSTFLAGS=` is deliberate and matches `test-cargo-pmcp-integration`, which
+#     already empties it for the same crate. The bin has never been compiled
+#     under the `-D warnings` this Makefile sets, and it carries 13 pre-existing
+#     dead-code violations across pentest/, deployment/, secrets/, configure/ and
+#     commands/package/. Emptying RUSTFLAGS keeps this leg's posture identical to
+#     its sibling instead of making 927 tests hostage to a cleanup that needs a
+#     per-item judgement (scaffolding for pending work vs. genuinely dead).
 .PHONY: test-cargo-pmcp
 test-cargo-pmcp:
 	@echo "$(BLUE)Running cargo-pmcp's own tests...$(NC)"
-	@out=$$(RUST_LOG=$(RUST_LOG) RUST_BACKTRACE=$(RUST_BACKTRACE) $(CARGO) test -p cargo-pmcp --lib 2>&1); \
+	@out=$$(RUSTFLAGS= RUST_LOG=$(RUST_LOG) RUST_BACKTRACE=$(RUST_BACKTRACE) $(CARGO) test -p cargo-pmcp --lib --bins -- --test-threads=1 2>&1); \
 	status=$$?; \
 	echo "$$out"; \
 	if [ $$status -ne 0 ]; then exit $$status; fi; \

--- a/cargo-pmcp/CHANGELOG.md
+++ b/cargo-pmcp/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the `cargo-pmcp` crate will be documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2026-08-29
+
+### Added
+
+- **`package save` learns where the binary is.** Three mutually-exclusive inputs
+  — `--binary <path>` (embeds the bytes), `--binary-from <path>` (references,
+  digest derived from the file) and the existing `--binary-digest sha256:<hex>`
+  (references, digest supplied) — defaulting to `deploy/.build/bootstrap`, which
+  is where `cargo pmcp deploy` leaves the artifact it uploads. The common case is
+  now a bare `cargo pmcp package save`.
+
+  Deriving the digest from bytes removes the class of error where the digest and
+  the binary disagree because a human typed one of them. Before this, packing
+  meant hand-computing a `shasum` even though `deploy` had just produced the
+  exact bytes.
+
+  **Referencing remains the default.** A configuration server should name its
+  runtime rather than carry it, and a team package sharing one MCP server across
+  N agents would otherwise carry that binary N times. Embedding is opt-in.
+
+  The trade is documented in `--binary`'s long help: an embedded package's digest
+  moves on every rebuild, including a byte-identical-source rebuild on a
+  different toolchain, while a referenced one's does not.
+
+### Changed
+
+- **`--binary-digest` is no longer required.** Existing invocations are
+  unaffected; it is now one of three ways to answer the same question.
+
 ## [0.23.1] - 2026-08-28
 
 Ships with `pmcp` 2.19.2 / `pmcp-package` 0.3.1 (tag `v2.19.2`). Scaffold-output

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pmcp"
-version = "0.23.1"
+version = "0.24.0"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 description = "Production-grade MCP server development toolkit"

--- a/cargo-pmcp/README.md
+++ b/cargo-pmcp/README.md
@@ -292,7 +292,39 @@ cargo pmcp team dev --serve --port 8080     # or serve team-mcp over HTTP
 
 # 4. Inspect a portable AI-Package bundle locally, fully offline:
 cargo pmcp package inspect ./some-agent.pmcp
+
+# 5. Pack a server into a portable AI-Package. After `cargo pmcp deploy` has
+#    built the bootstrap, this needs no binary flag at all:
+cargo pmcp package save --config ./config.toml -o my-server.tar
 ```
+
+### Packing a server: the binary
+
+`package save` needs to know which runtime binary the package is about. It
+defaults to `deploy/.build/bootstrap` — where `cargo pmcp deploy` leaves the
+artifact it uploads — so the common case is the bare command above.
+
+| Flag | What it does |
+|---|---|
+| *(none)* | references `deploy/.build/bootstrap`, deriving the digest from it |
+| `--binary-from <path>` | references that file, deriving the digest from it |
+| `--binary <path>` | **embeds** the bytes; the package is self-contained |
+| `--binary-digest sha256:<hex>` | references a digest you supply (CI, artifact built elsewhere) |
+
+Deriving the digest from the bytes is the point of the first three: a digest you
+type by hand can disagree with the binary it names, and nothing downstream can
+tell.
+
+**Referencing is the default on purpose.** A configuration server should NAME its
+runtime rather than carry it, and a team package holding several agents that
+share one MCP server would otherwise carry that binary once per agent.
+
+**If you do embed**, know the trade: an embedded package's digest moves whenever
+the binary is rebuilt — including a byte-identical-source rebuild on a different
+toolchain — while a referenced package's digest does not. That stability is what
+lets one tested package move between environments unchanged. For a hand-rolled
+server whose identity *is* its code, a digest that tracks the code is arguably
+what you want; for a configuration server it is not.
 
 > `package inspect` reads an OCI image-layout `.pmcp` bundle. The remote
 > `capture`/`show` verbs (upload / fetch against the pmcp.run platform) are a

--- a/cargo-pmcp/src/commands/package/save.rs
+++ b/cargo-pmcp/src/commands/package/save.rs
@@ -177,13 +177,111 @@ pub struct SaveArgs {
     #[arg(long)]
     pub force: bool,
 
+    /// Embed this binary's bytes, making the package self-contained.
+    ///
+    /// The digest is derived from the bytes, so it cannot disagree with them.
+    /// Note an embedded package's digest moves whenever the binary is rebuilt —
+    /// see [`BINARY_LONG_HELP`].
+    #[arg(long, conflicts_with_all = ["binary_from", "binary_digest"], long_help = BINARY_LONG_HELP)]
+    pub binary: Option<PathBuf>,
+
+    /// Reference the binary at this path; its digest is derived from the file.
+    #[arg(long, conflicts_with_all = ["binary", "binary_digest"])]
+    pub binary_from: Option<PathBuf>,
+
     /// `sha256:<hex>` digest of the runtime binary the target must resolve.
-    #[arg(long)]
-    pub binary_digest: String,
+    ///
+    /// For CI, where the artifact was built elsewhere and only its digest is in
+    /// hand. Prefer `--binary-from` locally: deriving the digest from the bytes
+    /// removes the class of error where the two disagree because a human typed
+    /// one of them.
+    #[arg(long, conflicts_with_all = ["binary", "binary_from"])]
+    pub binary_digest: Option<String>,
 
     /// Descriptive media-type hint for that runtime binary.
     #[arg(long, default_value = DEFAULT_BINARY_MEDIA_TYPE)]
     pub binary_media_type: String,
+}
+
+/// Where `cargo pmcp deploy` leaves the artifact it uploads.
+///
+/// `deploy` runs `cargo lambda build --release --arm64` with Zig wrappers and
+/// copies the result here (`deployment/builder.rs`), so this is a genuine
+/// `aarch64-unknown-linux` bootstrap and the exact bytes that reach Lambda —
+/// arm64 being the target on both Lambda and pmcp.run. Defaulting to it makes
+/// the common case a bare `cargo pmcp package save`.
+pub(crate) const DEFAULT_BINARY_PATH: &str = "deploy/.build/bootstrap";
+
+/// Long help for `--binary`, which states the one trade embedding makes.
+const BINARY_LONG_HELP: &str = "\
+Embed the binary's bytes in the package, making it self-contained.
+
+REFERENCING IS THE DEFAULT, and stays the right choice for two shapes: a
+configuration server should NAME its runtime rather than carry it, and a team
+package holding several agents that share one MCP server would otherwise carry
+that binary once per agent.
+
+THE TRADE, stated here because it is otherwise debugged later: an embedded
+package's digest moves whenever the binary is rebuilt — including a
+byte-identical-source rebuild on a different toolchain. A referenced package's
+digest does not, which is what lets one tested package move between environments
+unchanged. For a hand-rolled server whose identity IS its code, a digest that
+tracks the code is arguably correct; for a configuration server it is not.";
+
+/// Which binary input `save` will use, after resolving the flags against the
+/// default path. Split from the I/O so the precedence rules are testable
+/// without a filesystem.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BinarySource {
+    /// Embed the bytes at this path — the package becomes self-contained.
+    Embed(PathBuf),
+    /// Reference the binary at this path; derive the digest from its bytes.
+    ReferencePath(PathBuf),
+    /// Reference a binary by a digest supplied on the command line.
+    ReferenceDigest(String),
+}
+
+/// Resolve the three mutually-exclusive binary flags against the default path.
+///
+/// `default_path` is `Some` only when the file actually EXISTS — the caller does
+/// that check, so this function stays pure and the "nothing to pack" error can
+/// name the path that was looked for.
+///
+/// # Errors
+///
+/// Returns an error naming all three flags and the default path when no input
+/// is available.
+pub(crate) fn resolve_binary_source(
+    binary: Option<&Path>,
+    binary_from: Option<&Path>,
+    binary_digest: Option<&str>,
+    default_path: Option<&Path>,
+) -> Result<BinarySource> {
+    // Clap marks the three flags mutually exclusive, so at most one is Some
+    // through the CLI. The order below is still explicit rather than implied:
+    // this is a total function and a non-CLI caller can reach it.
+    if let Some(path) = binary {
+        return Ok(BinarySource::Embed(path.to_path_buf()));
+    }
+    if let Some(path) = binary_from {
+        return Ok(BinarySource::ReferencePath(path.to_path_buf()));
+    }
+    if let Some(digest) = binary_digest {
+        return Ok(BinarySource::ReferenceDigest(digest.to_string()));
+    }
+    // R4.3: the default REFERENCES. A default that embedded would silently grow
+    // every package, and multiply a shared binary across a team's agents.
+    if let Some(path) = default_path {
+        return Ok(BinarySource::ReferencePath(path.to_path_buf()));
+    }
+    bail!(
+        "no runtime binary given, and none found at {DEFAULT_BINARY_PATH}.\n  \
+         Build it first with `cargo pmcp deploy` (which writes {DEFAULT_BINARY_PATH}), or name \
+         one:\n    \
+         --binary <path>         embed the bytes (self-contained package)\n    \
+         --binary-from <path>    reference it; the digest is derived from the file\n    \
+         --binary-digest sha256:<hex>  reference it by digest (CI)"
+    );
 }
 
 /// The narrow view of a server `config.toml` that D-10 actually needs.
@@ -368,12 +466,43 @@ pub fn execute(args: SaveArgs, global_flags: &GlobalFlags) -> Result<()> {
         );
     }
 
-    let binary_digest = ManifestDigest::parse(&args.binary_digest).with_context(|| {
-        format!(
-            "--binary-digest '{}' is not a sha256:<hex> digest",
-            args.binary_digest
-        )
-    })?;
+    // The default path is offered only when it exists, so the "nothing to pack"
+    // error can name what it looked for rather than failing on a read.
+    let default_binary = project_root.join(DEFAULT_BINARY_PATH);
+    let source = resolve_binary_source(
+        args.binary.as_deref(),
+        args.binary_from.as_deref(),
+        args.binary_digest.as_deref(),
+        default_binary.exists().then_some(default_binary.as_path()),
+    )?;
+
+    // Bytes are bound here, outside the `pack_server` call, because
+    // `BinaryMode::Embedded` BORROWS them.
+    let binary_bytes = match &source {
+        BinarySource::Embed(path) | BinarySource::ReferencePath(path) => Some(
+            std::fs::read(path)
+                .with_context(|| format!("read the runtime binary {}", path.display()))?,
+        ),
+        BinarySource::ReferenceDigest(_) => None,
+    };
+    let binary_mode = match (&source, &binary_bytes) {
+        (BinarySource::Embed(_), Some(bytes)) => BinaryMode::Embedded(bytes),
+        (BinarySource::ReferencePath(_), Some(bytes)) => BinaryMode::Referenced {
+            // R4.4: derived from the bytes, so digest and binary cannot disagree.
+            digest: ManifestDigest::from_bytes(bytes),
+            media_type: args.binary_media_type.clone(),
+        },
+        (BinarySource::ReferenceDigest(digest), _) => BinaryMode::Referenced {
+            digest: ManifestDigest::parse(digest).with_context(|| {
+                format!("--binary-digest '{digest}' is not a sha256:<hex> digest")
+            })?,
+            media_type: args.binary_media_type.clone(),
+        },
+        // Unreachable: the two path arms always bind bytes above.
+        (BinarySource::Embed(path) | BinarySource::ReferencePath(path), None) => {
+            bail!("failed to read the runtime binary {}", path.display())
+        },
+    };
 
     let spec_bytes = match &args.spec {
         Some(path) => Some((
@@ -391,10 +520,7 @@ pub fn execute(args: SaveArgs, global_flags: &GlobalFlags) -> Result<()> {
     let layout = OciLayout::create(staging.path()).context("create the temporary pack layout")?;
     pack_server(
         &package,
-        BinaryMode::Referenced {
-            digest: binary_digest,
-            media_type: args.binary_media_type.clone(),
-        },
+        binary_mode,
         Some(ConfigFile {
             file_name: &config_file_name,
             bytes: &config_bytes,
@@ -441,4 +567,89 @@ pub fn execute(args: SaveArgs, global_flags: &GlobalFlags) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    /// R4.1: `--binary` is the ONE form that embeds. Everything else references.
+    #[test]
+    fn binary_flag_embeds() {
+        let got = resolve_binary_source(Some(&p("b/bootstrap")), None, None, None).unwrap();
+        assert_eq!(got, BinarySource::Embed(p("b/bootstrap")));
+    }
+
+    /// R4.1/R4.4: `--binary-from` references, with the digest derived from the
+    /// file rather than retyped by a human.
+    #[test]
+    fn binary_from_references_the_path() {
+        let got = resolve_binary_source(None, Some(&p("b/bootstrap")), None, None).unwrap();
+        assert_eq!(got, BinarySource::ReferencePath(p("b/bootstrap")));
+    }
+
+    /// R4.1: the CI form, where the artifact was built elsewhere and only its
+    /// digest is in hand.
+    #[test]
+    fn binary_digest_references_the_supplied_digest() {
+        let got = resolve_binary_source(None, None, Some("sha256:abc"), None).unwrap();
+        assert_eq!(got, BinarySource::ReferenceDigest("sha256:abc".to_string()));
+    }
+
+    /// R4.2 + R4.3 TOGETHER, and the pairing is the point: the default path
+    /// makes the common case a bare `save`, and it resolves to a REFERENCE, not
+    /// an embed. A team package sharing one MCP server across N agents must not
+    /// silently carry that binary N times because a default changed shape.
+    #[test]
+    fn the_default_path_is_used_and_it_references_rather_than_embeds() {
+        let got =
+            resolve_binary_source(None, None, None, Some(&p("deploy/.build/bootstrap"))).unwrap();
+        assert_eq!(
+            got,
+            BinarySource::ReferencePath(p("deploy/.build/bootstrap")),
+            "embedding must stay opt-in — the default may never grow the package"
+        );
+    }
+
+    /// With nothing given and no artifact on disk, the error has to teach all
+    /// three forms AND name the path that would have worked, because "build it
+    /// first" is the actual fix most of the time.
+    #[test]
+    fn no_input_and_no_default_names_every_way_out() {
+        let err = resolve_binary_source(None, None, None, None).unwrap_err();
+        let rendered = err.to_string();
+        for expected in [
+            "--binary",
+            "--binary-from",
+            "--binary-digest",
+            DEFAULT_BINARY_PATH,
+            "cargo pmcp deploy",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "the error must mention {expected}; was: {rendered}"
+            );
+        }
+    }
+
+    /// Precedence is asserted rather than assumed. Clap marks the three flags
+    /// mutually exclusive, so this combination is unreachable through the CLI —
+    /// but `resolve_binary_source` is a total function and a later caller (a
+    /// library user, a test) can reach it. Silently picking one would be the
+    /// wrong kind of total.
+    #[test]
+    fn explicit_input_always_beats_the_default_path() {
+        let got = resolve_binary_source(
+            None,
+            None,
+            Some("sha256:abc"),
+            Some(&p("deploy/.build/bootstrap")),
+        )
+        .unwrap();
+        assert_eq!(got, BinarySource::ReferenceDigest("sha256:abc".to_string()));
+    }
 }

--- a/cargo-pmcp/src/commands/package/save.rs
+++ b/cargo-pmcp/src/commands/package/save.rs
@@ -242,6 +242,56 @@ digest does not, which is what lets one tested package move between environments
 unchanged. For a hand-rolled server whose identity IS its code, a digest that
 tracks the code is arguably correct; for a configuration server it is not.";
 
+/// A binary input after the flags are resolved AND the I/O is done.
+///
+/// Distinct from [`BinarySource`], which is the pure pre-I/O intent: this owns
+/// the bytes for the embed case, because [`BinaryMode::Embedded`] borrows and
+/// the borrow must outlive `pack_server`.
+enum ResolvedBinary {
+    /// Bytes to embed, read from disk.
+    Embed(Vec<u8>),
+    /// A digest to reference — derived from a file or supplied on the command line.
+    Reference(ManifestDigest),
+}
+
+/// Resolve `--binary` / `--binary-from` / `--binary-digest` (or the default
+/// path) into the binary this pack is about, doing the reads.
+///
+/// Extracted from `execute` rather than inlined so that function stays under
+/// the repo's cognitive-complexity ceiling — CLAUDE.md caps it at 25 per
+/// function and CI enforces it with `pmat quality-gate --checks complexity`.
+/// Inlined, this block put `execute` at 27.
+///
+/// # Errors
+///
+/// Per [`resolve_binary_source`] when no input is available; otherwise when a
+/// named binary cannot be read, or a supplied digest is not `sha256:<hex>`.
+fn resolve_binary(args: &SaveArgs, project_root: &Path) -> Result<ResolvedBinary> {
+    // The default path is offered only when it EXISTS, so the "nothing to pack"
+    // error can name what it looked for rather than failing on a read.
+    let default_binary = bootstrap_path(project_root);
+    let source = resolve_binary_source(
+        args.binary.as_deref(),
+        args.binary_from.as_deref(),
+        args.binary_digest.as_deref(),
+        default_binary.exists().then_some(default_binary.as_path()),
+    )?;
+    Ok(match &source {
+        BinarySource::Embed(path) => ResolvedBinary::Embed(read_runtime_binary(path)?),
+        // R4.4: derived from the bytes, so digest and binary cannot disagree.
+        // The Vec is a statement temporary and drops here, so a 15 MB bootstrap
+        // is not held for the rest of the pack.
+        BinarySource::ReferencePath(path) => {
+            ResolvedBinary::Reference(ManifestDigest::from_bytes(&read_runtime_binary(path)?))
+        },
+        BinarySource::ReferenceDigest(digest) => {
+            ResolvedBinary::Reference(ManifestDigest::parse(digest).with_context(|| {
+                format!("--binary-digest '{digest}' is not a sha256:<hex> digest")
+            })?)
+        },
+    })
+}
+
 /// Read the runtime binary, naming the path in the error rather than surfacing
 /// a bare ENOENT.
 fn read_runtime_binary(path: &Path) -> Result<Vec<u8>> {
@@ -486,36 +536,13 @@ pub fn execute(args: SaveArgs, global_flags: &GlobalFlags) -> Result<()> {
         );
     }
 
-    // The default path is offered only when it exists, so the "nothing to pack"
-    // error can name what it looked for rather than failing on a read.
-    let default_binary = bootstrap_path(&project_root);
-    let source = resolve_binary_source(
-        args.binary.as_deref(),
-        args.binary_from.as_deref(),
-        args.binary_digest.as_deref(),
-        default_binary.exists().then_some(default_binary.as_path()),
-    )?;
-
-    // Declared here rather than inside the arm because `BinaryMode::Embedded`
-    // BORROWS, so the bytes must outlive `pack_server`. Only the embed arm needs
-    // that: the reference arm's read is a statement temporary that drops as soon
-    // as the digest is taken, so a 15 MB bootstrap is not held for the rest of
-    // the pack.
-    let embedded_bytes: Vec<u8>;
-    let binary_mode = match &source {
-        BinarySource::Embed(path) => {
-            embedded_bytes = read_runtime_binary(path)?;
-            BinaryMode::Embedded(&embedded_bytes)
-        },
-        BinarySource::ReferencePath(path) => BinaryMode::Referenced {
-            // R4.4: derived from the bytes, so digest and binary cannot disagree.
-            digest: ManifestDigest::from_bytes(&read_runtime_binary(path)?),
-            media_type: args.binary_media_type.clone(),
-        },
-        BinarySource::ReferenceDigest(digest) => BinaryMode::Referenced {
-            digest: ManifestDigest::parse(digest).with_context(|| {
-                format!("--binary-digest '{digest}' is not a sha256:<hex> digest")
-            })?,
+    // `resolved` OWNS the embedded bytes, so it must outlive `binary_mode`,
+    // which borrows them — hence two bindings here rather than one expression.
+    let resolved = resolve_binary(&args, &project_root)?;
+    let binary_mode = match &resolved {
+        ResolvedBinary::Embed(bytes) => BinaryMode::Embedded(bytes),
+        ResolvedBinary::Reference(digest) => BinaryMode::Referenced {
+            digest: digest.clone(),
             media_type: args.binary_media_type.clone(),
         },
     };

--- a/cargo-pmcp/src/commands/package/save.rs
+++ b/cargo-pmcp/src/commands/package/save.rs
@@ -66,8 +66,8 @@ use crate::deployment::stack_routing::load_deploy_descriptor;
 /// A configuration server NAMES its runtime rather than carrying it, exactly as
 /// `crates/pmcp-openapi-server/tests/roundtrip_e2e.rs` does. The value is a
 /// hint recorded in the binary-ref layer for the target environment; the digest
-/// is the load-bearing half and has no default, which is why `--binary-digest`
-/// is required and this is not.
+/// is the load-bearing half, which is why the three `--binary*` inputs derive or
+/// demand one while this stays a hint with a default.
 const DEFAULT_BINARY_MEDIA_TYPE: &str = "application/x-lambda-bootstrap; arch=arm64";
 
 /// Long help for `--spec`, written out because omitting the flag silently
@@ -151,7 +151,16 @@ fn refuse_a_kind_save_cannot_pack(kind: SaveKind) -> Result<()> {
 }
 
 /// Arguments for `cargo pmcp package save`.
+///
+/// The three `--binary*` inputs form one at-most-one group. Stated once here
+/// rather than as three cross-referencing `conflicts_with_all` attributes,
+/// which cost six name mentions for a three-way rule and grow quadratically.
 #[derive(Debug, Args)]
+#[command(group(clap::ArgGroup::new("binary_input").args([
+    "binary",
+    "binary_from",
+    "binary_digest",
+])))]
 pub struct SaveArgs {
     /// Path to the server's `config.toml`.
     #[arg(long)]
@@ -182,11 +191,11 @@ pub struct SaveArgs {
     /// The digest is derived from the bytes, so it cannot disagree with them.
     /// Note an embedded package's digest moves whenever the binary is rebuilt —
     /// see [`BINARY_LONG_HELP`].
-    #[arg(long, conflicts_with_all = ["binary_from", "binary_digest"], long_help = BINARY_LONG_HELP)]
+    #[arg(long, long_help = BINARY_LONG_HELP)]
     pub binary: Option<PathBuf>,
 
     /// Reference the binary at this path; its digest is derived from the file.
-    #[arg(long, conflicts_with_all = ["binary", "binary_digest"])]
+    #[arg(long)]
     pub binary_from: Option<PathBuf>,
 
     /// `sha256:<hex>` digest of the runtime binary the target must resolve.
@@ -195,7 +204,7 @@ pub struct SaveArgs {
     /// hand. Prefer `--binary-from` locally: deriving the digest from the bytes
     /// removes the class of error where the two disagree because a human typed
     /// one of them.
-    #[arg(long, conflicts_with_all = ["binary", "binary_from"])]
+    #[arg(long)]
     pub binary_digest: Option<String>,
 
     /// Descriptive media-type hint for that runtime binary.
@@ -203,14 +212,19 @@ pub struct SaveArgs {
     pub binary_media_type: String,
 }
 
-/// Where `cargo pmcp deploy` leaves the artifact it uploads.
+/// Where `cargo pmcp deploy` leaves the artifact it uploads, project-relative.
 ///
-/// `deploy` runs `cargo lambda build --release --arm64` with Zig wrappers and
-/// copies the result here (`deployment/builder.rs`), so this is a genuine
-/// `aarch64-unknown-linux` bootstrap and the exact bytes that reach Lambda —
-/// arm64 being the target on both Lambda and pmcp.run. Defaulting to it makes
-/// the common case a bare `cargo pmcp package save`.
-pub(crate) const DEFAULT_BINARY_PATH: &str = "deploy/.build/bootstrap";
+/// Re-exported from `deployment::builder`, which OWNS it: `deploy` runs
+/// `cargo lambda build --release --arm64` with Zig wrappers and writes the
+/// result there, so this is a genuine `aarch64-unknown-linux` bootstrap and the
+/// exact bytes that reach Lambda — arm64 being the target on both Lambda and
+/// pmcp.run. Defaulting to it makes the common case a bare
+/// `cargo pmcp package save`.
+///
+/// Taken from the producer rather than restated here because a disagreement is
+/// SILENT: a stale bootstrap left by a path change is still found, hashed and
+/// packed, pinning bytes the deployed server does not run.
+use crate::deployment::builder::{bootstrap_path, BOOTSTRAP_RELATIVE};
 
 /// Long help for `--binary`, which states the one trade embedding makes.
 const BINARY_LONG_HELP: &str = "\
@@ -228,11 +242,17 @@ digest does not, which is what lets one tested package move between environments
 unchanged. For a hand-rolled server whose identity IS its code, a digest that
 tracks the code is arguably correct; for a configuration server it is not.";
 
+/// Read the runtime binary, naming the path in the error rather than surfacing
+/// a bare ENOENT.
+fn read_runtime_binary(path: &Path) -> Result<Vec<u8>> {
+    std::fs::read(path).with_context(|| format!("read the runtime binary {}", path.display()))
+}
+
 /// Which binary input `save` will use, after resolving the flags against the
 /// default path. Split from the I/O so the precedence rules are testable
 /// without a filesystem.
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum BinarySource {
+enum BinarySource {
     /// Embed the bytes at this path — the package becomes self-contained.
     Embed(PathBuf),
     /// Reference the binary at this path; derive the digest from its bytes.
@@ -251,7 +271,7 @@ pub(crate) enum BinarySource {
 ///
 /// Returns an error naming all three flags and the default path when no input
 /// is available.
-pub(crate) fn resolve_binary_source(
+fn resolve_binary_source(
     binary: Option<&Path>,
     binary_from: Option<&Path>,
     binary_digest: Option<&str>,
@@ -275,8 +295,8 @@ pub(crate) fn resolve_binary_source(
         return Ok(BinarySource::ReferencePath(path.to_path_buf()));
     }
     bail!(
-        "no runtime binary given, and none found at {DEFAULT_BINARY_PATH}.\n  \
-         Build it first with `cargo pmcp deploy` (which writes {DEFAULT_BINARY_PATH}), or name \
+        "no runtime binary given, and none found at {BOOTSTRAP_RELATIVE}.\n  \
+         Build it first with `cargo pmcp deploy` (which writes {BOOTSTRAP_RELATIVE}), or name \
          one:\n    \
          --binary <path>         embed the bytes (self-contained package)\n    \
          --binary-from <path>    reference it; the digest is derived from the file\n    \
@@ -468,7 +488,7 @@ pub fn execute(args: SaveArgs, global_flags: &GlobalFlags) -> Result<()> {
 
     // The default path is offered only when it exists, so the "nothing to pack"
     // error can name what it looked for rather than failing on a read.
-    let default_binary = project_root.join(DEFAULT_BINARY_PATH);
+    let default_binary = bootstrap_path(&project_root);
     let source = resolve_binary_source(
         args.binary.as_deref(),
         args.binary_from.as_deref(),
@@ -476,31 +496,27 @@ pub fn execute(args: SaveArgs, global_flags: &GlobalFlags) -> Result<()> {
         default_binary.exists().then_some(default_binary.as_path()),
     )?;
 
-    // Bytes are bound here, outside the `pack_server` call, because
-    // `BinaryMode::Embedded` BORROWS them.
-    let binary_bytes = match &source {
-        BinarySource::Embed(path) | BinarySource::ReferencePath(path) => Some(
-            std::fs::read(path)
-                .with_context(|| format!("read the runtime binary {}", path.display()))?,
-        ),
-        BinarySource::ReferenceDigest(_) => None,
-    };
-    let binary_mode = match (&source, &binary_bytes) {
-        (BinarySource::Embed(_), Some(bytes)) => BinaryMode::Embedded(bytes),
-        (BinarySource::ReferencePath(_), Some(bytes)) => BinaryMode::Referenced {
+    // Declared here rather than inside the arm because `BinaryMode::Embedded`
+    // BORROWS, so the bytes must outlive `pack_server`. Only the embed arm needs
+    // that: the reference arm's read is a statement temporary that drops as soon
+    // as the digest is taken, so a 15 MB bootstrap is not held for the rest of
+    // the pack.
+    let embedded_bytes: Vec<u8>;
+    let binary_mode = match &source {
+        BinarySource::Embed(path) => {
+            embedded_bytes = read_runtime_binary(path)?;
+            BinaryMode::Embedded(&embedded_bytes)
+        },
+        BinarySource::ReferencePath(path) => BinaryMode::Referenced {
             // R4.4: derived from the bytes, so digest and binary cannot disagree.
-            digest: ManifestDigest::from_bytes(bytes),
+            digest: ManifestDigest::from_bytes(&read_runtime_binary(path)?),
             media_type: args.binary_media_type.clone(),
         },
-        (BinarySource::ReferenceDigest(digest), _) => BinaryMode::Referenced {
+        BinarySource::ReferenceDigest(digest) => BinaryMode::Referenced {
             digest: ManifestDigest::parse(digest).with_context(|| {
                 format!("--binary-digest '{digest}' is not a sha256:<hex> digest")
             })?,
             media_type: args.binary_media_type.clone(),
-        },
-        // Unreachable: the two path arms always bind bytes above.
-        (BinarySource::Embed(path) | BinarySource::ReferencePath(path), None) => {
-            bail!("failed to read the runtime binary {}", path.display())
         },
     };
 
@@ -606,11 +622,10 @@ mod tests {
     /// silently carry that binary N times because a default changed shape.
     #[test]
     fn the_default_path_is_used_and_it_references_rather_than_embeds() {
-        let got =
-            resolve_binary_source(None, None, None, Some(&p("deploy/.build/bootstrap"))).unwrap();
+        let got = resolve_binary_source(None, None, None, Some(&p(BOOTSTRAP_RELATIVE))).unwrap();
         assert_eq!(
             got,
-            BinarySource::ReferencePath(p("deploy/.build/bootstrap")),
+            BinarySource::ReferencePath(p(BOOTSTRAP_RELATIVE)),
             "embedding must stay opt-in — the default may never grow the package"
         );
     }
@@ -626,7 +641,7 @@ mod tests {
             "--binary",
             "--binary-from",
             "--binary-digest",
-            DEFAULT_BINARY_PATH,
+            BOOTSTRAP_RELATIVE,
             "cargo pmcp deploy",
         ] {
             assert!(
@@ -643,13 +658,9 @@ mod tests {
     /// wrong kind of total.
     #[test]
     fn explicit_input_always_beats_the_default_path() {
-        let got = resolve_binary_source(
-            None,
-            None,
-            Some("sha256:abc"),
-            Some(&p("deploy/.build/bootstrap")),
-        )
-        .unwrap();
+        let got =
+            resolve_binary_source(None, None, Some("sha256:abc"), Some(&p(BOOTSTRAP_RELATIVE)))
+                .unwrap();
         assert_eq!(got, BinarySource::ReferenceDigest("sha256:abc".to_string()));
     }
 }

--- a/cargo-pmcp/src/deployment/builder.rs
+++ b/cargo-pmcp/src/deployment/builder.rs
@@ -23,6 +23,28 @@ pub struct BuildResult {
     pub deployment_package: Option<PathBuf>,
 }
 
+/// Where `deploy` writes the Lambda bootstrap it uploads, under `project_root`.
+///
+/// THE one definition of that path. `cargo pmcp package save` defaults to it
+/// (its `--binary-from`/`--binary` inputs), so producer and consumer must agree
+/// — and the failure when they do not is silent, not loud: a STALE bootstrap
+/// left behind by a path change is still found, still hashed, and still packed,
+/// yielding a package that pins bytes the deployed server does not run. That is
+/// an integrity failure in a format whose whole purpose is byte-accurate
+/// identity, and no error is raised anywhere along the way.
+///
+/// A shared function rather than a drift test on purpose: the authority here is
+/// Rust in the same binary, so the compiler can enforce it. This repo's
+/// drift-guard idiom (`templates/workbook_server.rs`'s `PMCP_VERSION`) is for
+/// authorities Rust cannot import — an external `Cargo.toml` — and is a
+/// fallback for uncrossable boundaries, not the default.
+pub fn bootstrap_path(project_root: &Path) -> PathBuf {
+    project_root.join(BOOTSTRAP_RELATIVE)
+}
+
+/// [`bootstrap_path`]'s project-relative form, for messages that name it.
+pub const BOOTSTRAP_RELATIVE: &str = "deploy/.build/bootstrap";
+
 impl BinaryBuilder {
     pub fn new(project_root: PathBuf) -> Self {
         // Check if OAuth is enabled in config and if we should build local OAuth lambdas
@@ -182,11 +204,10 @@ impl BinaryBuilder {
         }
 
         // Destination path for CDK
-        let deploy_build_dir = self.project_root.join("deploy/.build");
-        std::fs::create_dir_all(&deploy_build_dir)
+        let dst = bootstrap_path(&self.project_root);
+        let deploy_build_dir = dst.parent().expect("bootstrap_path always has a parent");
+        std::fs::create_dir_all(deploy_build_dir)
             .context("Failed to create deploy/.build directory")?;
-
-        let dst = deploy_build_dir.join("bootstrap");
 
         // Copy binary
         std::fs::copy(&src, &dst).context("Failed to copy binary to deploy/.build/bootstrap")?;

--- a/cargo-pmcp/tests/package_save_load.rs
+++ b/cargo-pmcp/tests/package_save_load.rs
@@ -123,8 +123,17 @@ fn referenced_binary_digest() -> String {
         .to_string()
 }
 
-/// Run `package save` on the london-tube project at `root`, writing `output`.
-fn save_london_tube(root: &Path, config: &Path, output: &Path) -> assert_cmd::assert::Assert {
+/// Run `package save` on the london-tube project at `root`, writing `output`,
+/// with `extra` appended verbatim.
+///
+/// One argv for every save in this file, so a test reads as exactly the rule it
+/// names — the trailing slice — instead of restating the leading arguments.
+fn save_with(
+    root: &Path,
+    config: &Path,
+    output: &Path,
+    extra: &[&str],
+) -> assert_cmd::assert::Assert {
     Command::cargo_bin("cargo-pmcp")
         .expect("cargo-pmcp binary must be available")
         .args([
@@ -132,16 +141,29 @@ fn save_london_tube(root: &Path, config: &Path, output: &Path) -> assert_cmd::as
             "save",
             "--config",
             config.to_str().unwrap(),
-            "--spec",
-            root.join("london-tube-api.yaml").to_str().unwrap(),
             "--project-root",
             root.to_str().unwrap(),
             "--output",
             output.to_str().unwrap(),
+        ])
+        .args(extra)
+        .assert()
+}
+
+/// Run `package save` on the london-tube project at `root`, writing `output`.
+fn save_london_tube(root: &Path, config: &Path, output: &Path) -> assert_cmd::assert::Assert {
+    let spec = root.join("london-tube-api.yaml");
+    save_with(
+        root,
+        config,
+        output,
+        &[
+            "--spec",
+            spec.to_str().unwrap(),
             "--binary-digest",
             &referenced_binary_digest(),
-        ])
-        .assert()
+        ],
+    )
 }
 
 /// Run `package load`, returning the assertion for the caller to judge.
@@ -1737,31 +1759,13 @@ fn unpacked_binary(layout_dir: &Path) -> UnpackedBinary {
         .binary
 }
 
-/// Run `package save` with an explicit binary flag pair.
-fn save_with_binary_flag(
-    root: &Path,
-    config: &Path,
-    output: &Path,
-    flag: &str,
-    value: &str,
-) -> assert_cmd::assert::Assert {
-    Command::cargo_bin("cargo-pmcp")
-        .expect("cargo-pmcp binary must be available")
-        .args([
-            "package",
-            "save",
-            "--config",
-            config.to_str().unwrap(),
-            "--spec",
-            root.join("london-tube-api.yaml").to_str().unwrap(),
-            "--project-root",
-            root.to_str().unwrap(),
-            "--output",
-            output.to_str().unwrap(),
-            flag,
-            value,
-        ])
-        .assert()
+/// Write the stand-in bootstrap at `path`, creating its directory, and return it.
+fn write_fake_bootstrap(path: PathBuf) -> PathBuf {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create the bootstrap's directory");
+    }
+    std::fs::write(&path, FAKE_BOOTSTRAP).expect("write the fake bootstrap");
+    path
 }
 
 /// R4.1/R4.4: `--binary` embeds, and the package becomes self-contained — the
@@ -1771,11 +1775,16 @@ fn binary_flag_embeds_bytes_that_survive_the_round_trip() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
     let config = london_tube_project(root);
-    let bootstrap = root.join("bootstrap");
-    std::fs::write(&bootstrap, FAKE_BOOTSTRAP).expect("write the fake bootstrap");
+    let bootstrap = write_fake_bootstrap(root.join("bootstrap"));
     let tar = root.join("out.tar");
 
-    save_with_binary_flag(root, &config, &tar, "--binary", bootstrap.to_str().unwrap()).success();
+    save_with(
+        root,
+        &config,
+        &tar,
+        &["--binary", bootstrap.to_str().unwrap()],
+    )
+    .success();
 
     let unpacked = root.join("unpacked");
     load_artifact(&tar, &unpacked, false).success();
@@ -1799,16 +1808,14 @@ fn binary_from_derives_a_digest_matching_an_independent_computation() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
     let config = london_tube_project(root);
-    let bootstrap = root.join("bootstrap");
-    std::fs::write(&bootstrap, FAKE_BOOTSTRAP).expect("write the fake bootstrap");
+    let bootstrap = write_fake_bootstrap(root.join("bootstrap"));
     let tar = root.join("out.tar");
 
-    save_with_binary_flag(
+    save_with(
         root,
         &config,
         &tar,
-        "--binary-from",
-        bootstrap.to_str().unwrap(),
+        &["--binary-from", bootstrap.to_str().unwrap()],
     )
     .success();
 
@@ -1834,27 +1841,10 @@ fn the_default_path_is_found_and_referenced_not_embedded() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
     let config = london_tube_project(root);
-    let build_dir = root.join("deploy/.build");
-    std::fs::create_dir_all(&build_dir).expect("create deploy/.build");
-    std::fs::write(build_dir.join("bootstrap"), FAKE_BOOTSTRAP).expect("write the bootstrap");
+    write_fake_bootstrap(root.join("deploy/.build/bootstrap"));
     let tar = root.join("out.tar");
 
-    Command::cargo_bin("cargo-pmcp")
-        .expect("cargo-pmcp binary must be available")
-        .args([
-            "package",
-            "save",
-            "--config",
-            config.to_str().unwrap(),
-            "--spec",
-            root.join("london-tube-api.yaml").to_str().unwrap(),
-            "--project-root",
-            root.to_str().unwrap(),
-            "--output",
-            tar.to_str().unwrap(),
-        ])
-        .assert()
-        .success();
+    save_with(root, &config, &tar, &[]).success();
 
     let unpacked = root.join("unpacked");
     load_artifact(&tar, &unpacked, false).success();
@@ -1882,19 +1872,7 @@ fn a_bare_save_with_no_binary_anywhere_names_every_option() {
     let root = dir.path();
     let config = london_tube_project(root);
 
-    Command::cargo_bin("cargo-pmcp")
-        .expect("cargo-pmcp binary must be available")
-        .args([
-            "package",
-            "save",
-            "--config",
-            config.to_str().unwrap(),
-            "--project-root",
-            root.to_str().unwrap(),
-            "--output",
-            root.join("out.tar").to_str().unwrap(),
-        ])
-        .assert()
+    save_with(root, &config, &root.join("out.tar"), &[])
         .failure()
         .stderr(
             contains("--binary ")
@@ -1912,25 +1890,18 @@ fn the_three_binary_forms_are_mutually_exclusive() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
     let config = london_tube_project(root);
-    let bootstrap = root.join("bootstrap");
-    std::fs::write(&bootstrap, FAKE_BOOTSTRAP).expect("write the fake bootstrap");
+    let bootstrap = write_fake_bootstrap(root.join("bootstrap"));
 
-    Command::cargo_bin("cargo-pmcp")
-        .expect("cargo-pmcp binary must be available")
-        .args([
-            "package",
-            "save",
-            "--config",
-            config.to_str().unwrap(),
-            "--project-root",
-            root.to_str().unwrap(),
-            "--output",
-            root.join("out.tar").to_str().unwrap(),
+    save_with(
+        root,
+        &config,
+        &root.join("out.tar"),
+        &[
             "--binary",
             bootstrap.to_str().unwrap(),
             "--binary-digest",
             &referenced_binary_digest(),
-        ])
-        .assert()
-        .failure();
+        ],
+    )
+    .failure();
 }

--- a/cargo-pmcp/tests/package_save_load.rs
+++ b/cargo-pmcp/tests/package_save_load.rs
@@ -39,7 +39,7 @@ use oci_spec::image::{
     Descriptor, ImageIndexBuilder, ImageManifestBuilder, MediaType, SCHEMA_VERSION,
 };
 use pmcp_package::oci::media_types::{ARTIFACT_TYPE_SERVER, EMPTY_CONFIG_BLOB, MT_EMPTY_CONFIG};
-use pmcp_package::oci::OciLayout;
+use pmcp_package::oci::{unpack_server, OciLayout, UnpackedBinary};
 use pmcp_package::ManifestDigest;
 use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
@@ -1719,4 +1719,218 @@ fn save_help_documents_the_kind_asymmetry() {
         .success()
         .stdout(contains("Only `server` is supported today"))
         .stdout(contains("per-kind"));
+}
+
+// ---------------------------------------------------------------------
+// R4: --binary / --binary-from / the default path
+// ---------------------------------------------------------------------
+
+/// Stand-in runtime binary bytes. Not a real ELF: `save` treats the file as
+/// opaque content to hash and carry, and pinning that opacity is the point.
+const FAKE_BOOTSTRAP: &[u8] = b"\x7fELF fake aarch64 bootstrap \x00\x01\x02";
+
+/// Read the binary carriage out of a layout `package load` wrote.
+fn unpacked_binary(layout_dir: &Path) -> UnpackedBinary {
+    let layout = OciLayout::open(layout_dir);
+    unpack_server(&layout)
+        .expect("unpack the loaded layout")
+        .binary
+}
+
+/// Run `package save` with an explicit binary flag pair.
+fn save_with_binary_flag(
+    root: &Path,
+    config: &Path,
+    output: &Path,
+    flag: &str,
+    value: &str,
+) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("cargo-pmcp")
+        .expect("cargo-pmcp binary must be available")
+        .args([
+            "package",
+            "save",
+            "--config",
+            config.to_str().unwrap(),
+            "--spec",
+            root.join("london-tube-api.yaml").to_str().unwrap(),
+            "--project-root",
+            root.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            flag,
+            value,
+        ])
+        .assert()
+}
+
+/// R4.1/R4.4: `--binary` embeds, and the package becomes self-contained — the
+/// restored bytes must be byte-identical to what the author handed in.
+#[test]
+fn binary_flag_embeds_bytes_that_survive_the_round_trip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let config = london_tube_project(root);
+    let bootstrap = root.join("bootstrap");
+    std::fs::write(&bootstrap, FAKE_BOOTSTRAP).expect("write the fake bootstrap");
+    let tar = root.join("out.tar");
+
+    save_with_binary_flag(root, &config, &tar, "--binary", bootstrap.to_str().unwrap()).success();
+
+    let unpacked = root.join("unpacked");
+    load_artifact(&tar, &unpacked, false).success();
+
+    // Byte-identical, not merely "a layer exists" — the weaker assertion would
+    // pass on a truncated or re-encoded binary.
+    match unpacked_binary(&unpacked) {
+        UnpackedBinary::Embedded(bytes) => assert_eq!(
+            bytes, FAKE_BOOTSTRAP,
+            "an embedded binary must round-trip byte-for-byte"
+        ),
+        other => panic!("--binary must embed, got {other:?}"),
+    }
+}
+
+/// R4.4: `--binary-from` references, and the digest is DERIVED — so it equals an
+/// independently computed one. This is the property that removes the class of
+/// error where a hand-typed digest and the binary disagree.
+#[test]
+fn binary_from_derives_a_digest_matching_an_independent_computation() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let config = london_tube_project(root);
+    let bootstrap = root.join("bootstrap");
+    std::fs::write(&bootstrap, FAKE_BOOTSTRAP).expect("write the fake bootstrap");
+    let tar = root.join("out.tar");
+
+    save_with_binary_flag(
+        root,
+        &config,
+        &tar,
+        "--binary-from",
+        bootstrap.to_str().unwrap(),
+    )
+    .success();
+
+    let unpacked = root.join("unpacked");
+    load_artifact(&tar, &unpacked, false).success();
+
+    match unpacked_binary(&unpacked) {
+        UnpackedBinary::Referenced { digest, .. } => assert_eq!(
+            digest,
+            ManifestDigest::from_bytes(FAKE_BOOTSTRAP),
+            "the referenced digest must be derived from the file's bytes"
+        ),
+        other => panic!("--binary-from must reference, got {other:?}"),
+    }
+}
+
+/// R4.2 + R4.3: a bare `save` finds `deploy/.build/bootstrap` — and REFERENCES
+/// it. The negative half is the load-bearing one: a default that embedded would
+/// silently grow every package and multiply a shared binary across a team's
+/// agents, so this asserts no bootstrap layer was written.
+#[test]
+fn the_default_path_is_found_and_referenced_not_embedded() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let config = london_tube_project(root);
+    let build_dir = root.join("deploy/.build");
+    std::fs::create_dir_all(&build_dir).expect("create deploy/.build");
+    std::fs::write(build_dir.join("bootstrap"), FAKE_BOOTSTRAP).expect("write the bootstrap");
+    let tar = root.join("out.tar");
+
+    Command::cargo_bin("cargo-pmcp")
+        .expect("cargo-pmcp binary must be available")
+        .args([
+            "package",
+            "save",
+            "--config",
+            config.to_str().unwrap(),
+            "--spec",
+            root.join("london-tube-api.yaml").to_str().unwrap(),
+            "--project-root",
+            root.to_str().unwrap(),
+            "--output",
+            tar.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let unpacked = root.join("unpacked");
+    load_artifact(&tar, &unpacked, false).success();
+
+    match unpacked_binary(&unpacked) {
+        UnpackedBinary::Referenced { digest, .. } => assert_eq!(
+            digest,
+            ManifestDigest::from_bytes(FAKE_BOOTSTRAP),
+            "the default path must be read and its digest derived from it"
+        ),
+        // The negative half, and the load-bearing one: a default that embedded
+        // would silently grow every package and multiply a shared binary across
+        // a team's agents.
+        UnpackedBinary::Embedded(_) => {
+            panic!("the DEFAULT must reference, never embed — embedding is opt-in via --binary")
+        },
+    }
+}
+
+/// With no flag and no artifact on disk, the error teaches every way out rather
+/// than failing on a missing file.
+#[test]
+fn a_bare_save_with_no_binary_anywhere_names_every_option() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let config = london_tube_project(root);
+
+    Command::cargo_bin("cargo-pmcp")
+        .expect("cargo-pmcp binary must be available")
+        .args([
+            "package",
+            "save",
+            "--config",
+            config.to_str().unwrap(),
+            "--project-root",
+            root.to_str().unwrap(),
+            "--output",
+            root.join("out.tar").to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            contains("--binary ")
+                .and(contains("--binary-from"))
+                .and(contains("--binary-digest"))
+                .and(contains("deploy/.build/bootstrap"))
+                .and(contains("cargo pmcp deploy")),
+        );
+}
+
+/// The three forms are mutually exclusive, and clap must say so rather than
+/// letting a precedence rule decide silently.
+#[test]
+fn the_three_binary_forms_are_mutually_exclusive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let config = london_tube_project(root);
+    let bootstrap = root.join("bootstrap");
+    std::fs::write(&bootstrap, FAKE_BOOTSTRAP).expect("write the fake bootstrap");
+
+    Command::cargo_bin("cargo-pmcp")
+        .expect("cargo-pmcp binary must be available")
+        .args([
+            "package",
+            "save",
+            "--config",
+            config.to_str().unwrap(),
+            "--project-root",
+            root.to_str().unwrap(),
+            "--output",
+            root.join("out.tar").to_str().unwrap(),
+            "--binary",
+            bootstrap.to_str().unwrap(),
+            "--binary-digest",
+            &referenced_binary_digest(),
+        ])
+        .assert()
+        .failure();
 }

--- a/docs/design/env-surface-and-binary-server-packaging-requirements.md
+++ b/docs/design/env-surface-and-binary-server-packaging-requirements.md
@@ -1,0 +1,218 @@
+# Requirements: typed env surface, binary-server packaging, and `--binary`
+
+**Status:** requirements for the local development phase — pre-plan, not a plan.
+**Owner:** SDK / cargo-pmcp.
+**Origin:** the pmcp.run exchange in `docs/platform-requests/` —
+`env-surface-manifest-request.md` (`fe9a0b1c`), `env-surface-sdk-reply.md`,
+`env-surface-platform-reply.md` (`4b2adbc4`), `env-surface-sdk-signoff.md`.
+
+## The governing constraint — read this before anything else
+
+There are **two independent requirements** here that both talk about environment variables.
+They must not be joined:
+
+- **A — batteries-included DX.** Subject is the *source code*. Consumers: `deploy`,
+  `secret set`, `doctor`, the compile loop. Value: one server compiles and deploys unchanged
+  to Lambda, Docker/Cloud Run and Cloudflare Workers.
+- **B — AI Package portability.** Subject is the *artifact*. Consumers: `package
+  save`/`load`/`pull` and the receiving host. Value: a tested bundle stands up safely in a new
+  environment with some values swapped.
+
+**B's guarantee is verifiability at rest**: a holder gets `package.config_slots` *and* the
+`config` bytes from `unpack_server`, and all four validators are `pub` and bytes-taking, so the
+claim can be re-derived from the artifact with zero trust in the packer. Any design that makes
+the package's slot list an *assertion by the packer* destroys that while looking identical.
+
+**Therefore: A generates, B verifies.** The derive is a code generator whose output lands in
+the config document that travels inside the artifact — never a runtime or link-time channel
+into the packer. See `env-surface-sdk-reply.md` §2 for the full argument.
+
+A load-bearing fact behind this: **`cargo pmcp package save` never holds the binary today**
+(`save.rs:394` builds `BinaryMode::Referenced` only). R4 changes that by choice, but it does not
+change the conclusion — even with the bytes present, no one can derive the env surface from a
+binary. Scanning cannot distinguish a var read via `env::var` from one logged in an error;
+executing an untrusted binary at pack time is a security regression in the tool whose purpose is
+safe handoff.
+
+## Versioning posture
+
+`cargo pmcp package` and `pmcp-package` are new with very few users. **Break freely.** Prefer a
+correct vocabulary over a compatible one; do not carry workarounds to avoid a bump. R1 is
+already known to force `pmcp-package` 0.4.0 and, per CLAUDE.md's authoritative ordering
+constraint, moves `pmcp-cfn-renderer`, `pmcp-agent`, `pmcp-team-servers` and `cargo-pmcp` as one
+set. Price that in; do not design around it.
+
+---
+
+## R1 — `supplied_by` on `ConfigSlot` *(B; blocks R2)*
+
+Optional attribute `supplied_by = "environment" | "platform" | "runtime"`, defaulting to
+`"environment"` when absent so existing packages keep their meaning.
+
+- **R1.1** `required_slots` excludes non-`environment` slots.
+- **R1.2** `package inspect` and `package load` MUST render non-`environment` slots in their
+  own labelled section — *"Supplied by the host at deploy time"*. **Never a silent filter.** A
+  slot no operator must fill is near-invisible, and near-invisibility is the disease this whole
+  exchange is about.
+- **R1.3** Orthogonal to `kind`. `detect_deviation` keeps keying on `kind` alone, so a
+  platform-supplied *endpoint* stays deviation-visible. Who fills a value and whether its value
+  is behaviour-relevant are independent axes.
+- **R1.4** `reconcile_collision` (`aggregate.rs:83-106`) MUST compare `supplied_by` and refuse a
+  disagreement, in the same shape as the existing `config_key` refusal, naming both values.
+  Without this, two team components declaring the same secret with different `supplied_by`
+  dedupe to whichever was inserted first — and since R1.1 makes `required_slots` depend on the
+  field, the aggregated team either asks for a value the host injects or fails to ask for one
+  nobody supplies. Silent, and wrong either way.
+- **R1.5** Source-breaking by construction: a new public field breaks every `ConfigSlot { … }`
+  literal (21 in-tree). Add a `with_supplied_by()` builder for future callers, and accept the
+  break for existing ones.
+
+**Verification:** a property test that `required_slots` never emits a non-`environment` slot; a
+test that `inspect` output contains the labelled section whenever one exists (assert on rendered
+output, not on the filter); a `reconcile_collision` disagreement test per axis.
+
+## R2 — the binary-server gate *(B; sequenced WITH R1, not after)*
+
+Close the hole `env-surface-manifest-request.md` §1.1 measured: binary servers pack green with
+empty slot lists while reading real secrets, because the 0.3.1 gate's subject is the config
+document and their documents contain no `${...}`.
+
+- **R2.1** A binary server declares its slots **by hand, in the config document that travels in
+  the artifact**. That document already carries the `[[config_slots]]` schema and
+  `parse_declared_config_slots` reads it out of arbitrary TOML with no toolkit schema required —
+  so this works against existing built-ins unchanged. Those documents are already pure packaging
+  metadata (*"the team-fs stub Lambda does NOT read this file"*), which makes them the right
+  carrier.
+- **R2.2** An explicit **declared-surface marker**, so *"needs nothing"* and *"never said"* stop
+  being the same bit. Absence must be distinguishable from an empty-but-declared surface — this
+  is the fail-open signature every drift mode in the exchange shares.
+- **R2.3** Gate lives in `pmcp-package` beside its 0.3.1 sibling (platform-endorsed: one
+  implementation, one semantics). Rollout mirrors 0.3.1: **warn, then refuse.**
+- **R2.4** Sequence with R1, not after it. Platform measurement: for hand-rolled servers
+  `supplied_by` is the *majority* case, not the edge case — `team-fs`'s 12 vars are mostly
+  platform-wired. Shipping R2 first would force twenty-odd declarations that R1 then rewrites.
+
+**Verification:** the §1.1 servers' shapes as fixtures — refused before R2.1 declarations, and
+accepted after. Assert the refusal writes nothing to the layout (both blobs *and* index — the
+index alone is the weaker assertion that let a leak through once already).
+
+## R3 — the typed env surface *(A; independent of R1/R2)*
+
+A derive on a config struct, with three outputs. **Only the first is target-specific.**
+
+- **R3.1 — `Config` + `load()`.** Typed struct; `load()` resolves values at runtime. This is A's
+  actual payload: without it the feature is a TOML generator and the Cloudflare vendor-fork
+  survives (a server written for Lambda today must be rewritten against `env.secret("API_KEY")`
+  for Workers).
+  - **R3.1a** Core defines `trait EnvSource` and ships exactly one impl, `ProcessEnv` over
+    `std::env::var`. Every host adapter lives **outside** core. `pmcp` core has zero vendor
+    dependencies today and keeps them.
+  - **R3.1b** The trait MUST carry the variable's kind:
+    `fn get(&self, name: &str, kind: EnvKind) -> Option<String>`. Workers distinguishes secret
+    bindings from plain vars (`env.secret(…)`); a single `get` forces the adapter to probe or
+    guess. The derive already knows which is which.
+  - **R3.1c** Required values fail at `load()` with **one aggregate error** listing every unset
+    name with its `obtain` hint and the `secret set` command — the existing
+    `SecretError::Missing` guidance promoted from per-call to per-surface. `required = false`
+    keeps the lazy pattern: the server boots and the dependent tool returns a structured error
+    naming the secret and the fix.
+- **R3.2 — declaration text → `config.toml`,** via `cargo pmcp env sync`. Emits
+  `[[config_slots]]` / `[[secrets.definitions]]`, replacing today's hand-syncing.
+  **Target-INDEPENDENT: one declaration, many renderings.** Per-target fan-out belongs to
+  `deploy` (deploy.toml `[environment]`/`[secrets]`, `wrangler.toml` bindings, Docker
+  `--env-file`). A per-target `env sync` would produce N config documents and the package would
+  have to pick one — which re-breaks B in a fresh way.
+- **R3.3 — a drift check** (`doctor` / `validate` / CI) asserting the committed declarations
+  still match what the derive would emit. **Not optional.** One-shot codegen rots: someone adds
+  `#[secret] new_thing`, does not re-run sync, and the package faithfully verifies a stale
+  declaration. In-tree precedent: `PMCP_VERSION` in `cargo-pmcp`'s workbook template went stale
+  through a `pmcp` bump and *only* its drift test caught it while `cargo build --workspace`
+  stayed green at exit 0.
+- **R3.4** Attribute vocabulary maps onto existing slot vocabulary: `#[secret]` →
+  `SlotType::Secret` (identity-bearing, redacted `Debug`/`Display`, no `tested_value`);
+  `#[endpoint(tested = …)]` → `SlotType::Endpoint`; `#[var(default = …)]` →
+  `DeployDescriptor.environment`; `required = false`, `obtain = "…"`, and `supplied_by` ride
+  along. Doc comments become descriptions.
+- **R3.5** Derive-on-struct, **not** free registration macros. A type can expose
+  `Config::env_surface() -> &'static [EnvVarSpec]` as a plain associated item, so **no
+  link-time collection is needed at all.** (Measured, for the archaeology: `inventory` 0.3.24
+  works on `wasm32-unknown-unknown` — 3/3, surviving `opt-level="z"` + LTO + strip +
+  `panic="abort"`, needing no ctor call; `linkme` 0.3 fails to compile there outright. Both
+  loud, neither silent. Moot under R3.5.)
+- **R3.6** Lint raw `std::env::var` in server crates. It cannot be banned, but it can be loud.
+  Ships with the warn phase so adoption pressure precedes any refusal.
+
+**Scope boundary — hold it.** Env names in, typed struct out, declarations on the side. The
+moment this grows file config, layering, profiles or hot reload it competes with `config.toml`
+and re-blurs the configuration-server / binary-server line the whole design rests on.
+
+**Verification:** R3.3's drift check is itself the primary test. Add a round-trip: derive →
+`env sync` → `parse_declared_config_slots` → assert the slot set equals `Config::env_surface()`.
+
+## R4 — `--binary` on `package save` *(CLI only; no format change)*
+
+The format already supports embedding (`BinaryMode::Embedded` → `MT_SERVER_BOOTSTRAP`, *"The
+package is self-contained"*); the CLI simply never constructs it.
+
+- **R4.1** Three input forms:
+
+  | Flag | Behaviour |
+  |---|---|
+  | `--binary <path>` | **embeds** the bytes and derives the digest from them |
+  | `--binary-from <path>` | **references**; digest derived from the file |
+  | `--binary-digest <sha256>` | references; digest supplied (CI, artifact built elsewhere) |
+
+- **R4.2** Default the path to **`deploy/.build/bootstrap`** when present, so the common case is
+  a bare `cargo pmcp package save`. That is where `cargo pmcp deploy` puts the artifact it
+  uploads (`builder.rs:189`), built by `cargo lambda build --release --arm64` with Zig wrappers
+  (`:135`) — a genuine `aarch64-unknown-linux` bootstrap, and arm64 is the target on both Lambda
+  and pmcp.run for cost reasons.
+- **R4.3** **Referenced stays the default.** A team package holding N agents that share an MCP
+  server would otherwise embed the same binary N times; a Shape A config server should name its
+  runtime rather than carry it. Embedding is opt-in, per package, chosen by the author.
+- **R4.4** Deriving the digest from bytes removes the class of error where digest and binary
+  disagree because a human typed one. Today `--binary-digest` is required with no default, which
+  has already forced hand-computed digests.
+- **R4.5** Document the trade where a reader will hit it: an embedded package's digest moves on
+  every rebuild, including a byte-identical-source rebuild on a different toolchain. A
+  referenced package's digest does not — the environment-independence property
+  `london-tube.toml` records. For a hand-rolled server whose identity *is* its code, a digest
+  that tracks the code is arguably correct; for a config server it is not.
+
+**Verification:** round-trip an embedded package and assert the restored bytes are
+byte-identical; assert the derived digest equals an independently computed one; assert a team
+package with N shared references carries one binary layer, not N.
+
+---
+
+## Dependency order
+
+```
+R1 (supplied_by) ──┬─→ R2 (binary-server gate)      [B: ship together, 0.4.0 set]
+                   │
+R3 (env surface) ──┴─→ R3.2 env sync emits supplied_by   [A: parallel, independent]
+
+R4 (--binary) ─────────────────────────────────────  [independent of everything]
+```
+
+R4 has no dependencies and unblocks packing hand-rolled servers as self-contained artifacts; it
+can land first. R1+R2 ship as one unit for the reason in R2.4. R3 proceeds in parallel and only
+touches B at R3.2, through the config document.
+
+## Out of scope
+
+- Deriving the env surface from a compiled binary, by scanning or by execution. See the
+  governing constraint.
+- A sidecar env-surface file consumed by `package save`. It would make the slot list an
+  unverifiable assertion.
+- Import-time re-verification of packages built before these gates. Worth doing, but it is a
+  `cargo-pmcp` concern and would drag the caret exception; tracked in
+  `crates/pmcp-package/CHANGELOG.md` under the 0.3.1 scope boundaries.
+- Anything that grows `config.toml` into a general configuration framework (R3 scope boundary).
+
+## Vocabulary
+
+`manifest` = the OCI `ImageManifest` (`ManifestDigest`). `artifact` = the shippable `.tar`
+holding the OCI layout. `binary` = the compiled executable, referenced by digest unless R4.1
+embeds it. The typed declaration is the **env surface** — never "env manifest", which would be a
+third sense of `manifest` inside the crate hosting the gate.

--- a/docs/design/env-surface-and-binary-server-packaging-requirements.md
+++ b/docs/design/env-surface-and-binary-server-packaging-requirements.md
@@ -37,10 +37,13 @@ safe handoff.
 ## Versioning posture
 
 `cargo pmcp package` and `pmcp-package` are new with very few users. **Break freely.** Prefer a
-correct vocabulary over a compatible one; do not carry workarounds to avoid a bump. R1 is
-already known to force `pmcp-package` 0.4.0 and, per CLAUDE.md's authoritative ordering
-constraint, moves `pmcp-cfn-renderer`, `pmcp-agent`, `pmcp-team-servers` and `cargo-pmcp` as one
-set. Price that in; do not design around it.
+correct vocabulary over a compatible one; do not carry workarounds to avoid a bump.
+
+But do not ASSUME a break either: R1 was written believing it forced 0.4.0 and a five-crate set
+move, and measurement showed it is fully additive (R1.5). Check with `cargo semver-checks`
+against the published baseline before pricing in a coordinated release — this repo's
+`#[non_exhaustive]` and builder discipline mean field additions are usually cheaper than they
+look.
 
 ---
 
@@ -63,9 +66,14 @@ Optional attribute `supplied_by = "environment" | "platform" | "runtime"`, defau
   dedupe to whichever was inserted first — and since R1.1 makes `required_slots` depend on the
   field, the aggregated team either asks for a value the host injects or fails to ask for one
   nobody supplies. Silent, and wrong either way.
-- **R1.5** Source-breaking by construction: a new public field breaks every `ConfigSlot { … }`
-  literal (21 in-tree). Add a `with_supplied_by()` builder for future callers, and accept the
-  break for existing ones.
+- **R1.5** **ADDITIVE, not breaking** — corrected 2026-08-29 after measuring. `ConfigSlot` is
+  already `#[non_exhaustive]` (added in response to the `config_key` break), so no external
+  crate can write a struct literal; and a repo-wide sweep finds **zero** genuine literals even
+  internally — every construction already uses `ConfigSlot::new(…)` plus builders. Verified by
+  `cargo semver-checks` against published 0.3.1: 196/196, "no semver update required". Add a
+  `with_supplied_by()` builder to match. **No 0.4.0 and no five-crate set move**; an earlier
+  revision of this requirement claimed otherwise on the strength of a grep that counted
+  `-> ConfigSlot {` signatures and the unrelated `DeclaredConfigSlot` type.
 
 **Verification:** a property test that `required_slots` never emits a non-`environment` slot; a
 test that `inspect` output contains the labelled section whenever one exists (assert on rendered

--- a/docs/platform-requests/env-surface-manifest-request.md
+++ b/docs/platform-requests/env-surface-manifest-request.md
@@ -1,0 +1,215 @@
+# Request: a typed env surface in the `pmcp` crate, and the manifest it makes possible
+
+**From:** platform (pmcp.run)
+**Status:** proposal for SDK review — nothing here is committed; the design forks in §6 are
+genuinely open and yours to call.
+**Relates to:** `package-format-031-platform-reply.md` — this is the constructive half of that
+reply's §4 (the `supplied_by` finding), and it **supersedes** its §1.4: the parallel
+"capture-source invariant" proposed there is withdrawn in favour of what follows, which gives
+both sides one invariant instead of two.
+
+The one-sentence version: **extend `pmcp::secrets` from two functions into a declarative,
+typed env surface that compiles into a manifest — so binary servers get the same CONFIG → SLOT
+gate that config servers got in 0.3.1, `cargo pmcp secret set` gets something to validate
+against, and one server compiles unchanged for Lambda, Docker-based targets, and Cloudflare
+WASM.**
+
+---
+
+## 1. The evidence this responds to
+
+### 1.1 The 0.3.1 gate is structurally blind to binary servers, and our fleet proves it
+
+Your gate's subject is the config document. That is correct for a **configuration server**,
+where the document *is* the program and a generic dispatcher reads it. It cannot work for a
+**binary server**, where the document is metadata about a program whose real deferral surface
+is whatever the compiled code reads.
+
+Our `agents-api` built-ins are hand-rolled Rust servers of exactly this shape. Two of them say
+so in their own config headers — *"Placeholder for cargo-pmcp's builtin-manifest.toml schema
+requirement… The team-fs stub Lambda does NOT read this file"* (`team-fs/config.toml`,
+`mem-mcp/config.toml`). Measured against what their source actually reads:
+
+| Server | env vars read in Rust source | among them | `[[config_slots]]` | 0.3.1 gate verdict |
+|---|---|---|---|---|
+| team-fs | 12 | `SCHEDULER_INVOKE_ROLE_ARN`, `OUTBOUND_OAUTH_FUNCTION_NAME`, `MOUNT_PATH` | 0 | **passes** |
+| approval-mcp | 11 | **`APPROVAL_HMAC_SECRET`** | 0 | **passes** |
+| mem-mcp | 5 | **`OPENAI_API_KEY`** | 0 | **passes** |
+
+Three servers deferring genuine secrets to the environment, all packing green with empty slot
+lists — the exact "installs cleanly, then cannot start" defect the gate was built to close,
+invisible to it because their configs contain no `${...}`. (Counts are a source grep for
+`env::var` call sites — a **floor**, not a ceiling. That a text grep over source is the best
+enumeration tool available today, and the packer does not even have source, is itself part of
+this request.)
+
+### 1.2 The access API already forks across your own deploy targets
+
+`pmcp::secrets` (`src/secrets/mod.rs`) wraps `std::env::var` with error messages that teach the
+fix (`cargo pmcp secret set my-server/NAME --prompt`). That guidance-in-the-error philosophy is
+right, and this request builds on it rather than replacing it.
+
+But it only works where process env exists. On Cloudflare Workers there is no process env, and
+your own example tells developers to write against a different API entirely
+(`examples/wasm-mcp-server/deployments/cloudflare/DEPLOYMENT.md`):
+
+```rust
+env.secret("API_KEY")?.to_string()   // worker::Env — not std::env, not pmcp::secrets
+```
+
+So a server written for Lambda does not compile meaningfully for the WASM target without
+rewriting its config access. "Environment variables are the standard way to configure a
+deployment target" is true of the *contract*; the *access API* is forked, and the SDK is the
+only place the fork can be hidden.
+
+### 1.3 Nothing cross-checks the three declaration surfaces
+
+Today the same fact — "this server needs `BT_CLIENT_ID`" — can live in four places, none
+verified against any other: the code's `env::var` call, config's `[[secrets.definitions]]`,
+the package's `[[config_slots]]`, and whatever an operator typed into
+`cargo pmcp secret set`. A typo in any one of them fails at runtime in a target environment.
+Your handoff's gap 1 (variable-NAME agreement) is one pairwise case of this disease; the
+platform's `bt-availability` incident was another.
+
+---
+
+## 2. The request
+
+Extend `pmcp::secrets` into a declarative surface. Our preferred shape is a derive on a config
+struct (see §6.1 for the alternative and why we lean this way):
+
+```rust
+#[derive(PmcpEnv)]
+struct Config {
+    /// BT Wholesale API OAuth2 client ID — Apigee
+    #[secret(obtain = "https://developer.bt.com")]
+    bt_client_id: String,
+
+    /// Optional at runtime: the address tool works without it (structured
+    /// error names the fix while unset).
+    #[secret(required = false, obtain = "https://developer.bt.com")]
+    bt_cug: Option<String>,
+
+    #[endpoint(tested = "https://api-sandbox.wholesale.bt.com")]
+    base_url: String,
+
+    #[var(default = "warn")]
+    rust_log: String,
+
+    /// Injected by pmcp.run at deploy time — never operator-supplied.
+    #[secret(supplied_by = "platform")]
+    code_mode_secret: String,
+}
+```
+
+Semantics, mapped onto vocabulary you already own:
+
+| Attribute | Maps to | Behaviour |
+|---|---|---|
+| `#[secret]` | `SlotType::Secret` — identity-bearing | redacted `Debug`/`Display`; never logged; no `tested_value` (structurally, as today) |
+| `#[endpoint(tested = …)]` | `SlotType::Endpoint` | behaviour-relevant → visible to `detect_deviation`; `tested` is the recorded `tested_value` |
+| `#[var(default = …)]` | `DeployDescriptor.environment` | plain config; a default makes it non-required |
+| `required = false` | slot optionality | mirrors `[[secrets.definitions]].required` |
+| `obtain = "…"` | `[[secrets.definitions]].obtain_url` | carried into generated docs/slots |
+| `supplied_by = "platform" \| "runtime"` | the §4 finding from our 0.3.1 reply | satisfies the gate, **excluded from `required_slots`**; `"runtime"` covers Lambda-injected vars like `AWS_LAMBDA_FUNCTION_NAME` |
+
+Doc comments become descriptions — the same text that today is hand-duplicated into
+`[[secrets.definitions]]`.
+
+Two things the derive must produce:
+
+1. **Per-target resolution.** `Config::load()` reads process env on Lambda / Docker-based
+   targets and `worker::Env` bindings on `wasm32` Workers builds, behind the same struct.
+   Missing required values produce ONE aggregate boot-time error listing every unset name with
+   its `obtain` hint and the `secret set` command — the existing `SecretError::Missing`
+   guidance, promoted from per-call to per-surface.
+2. **A compile-time env manifest.** An enumerable artifact — the set of (name, kind, required,
+   supplied_by, description) tuples — that `cargo pmcp package save` can read for a binary
+   server. This is the load-bearing half: it is what stands where `config.toml` stands for
+   configuration servers.
+
+---
+
+## 3. What the manifest buys, per consumer
+
+- **`package save` (binary servers):** the same two-directional gate 0.3.1 gave config servers,
+  with the manifest as subject — every var the binary reads is declared (closes the §1.1
+  table), and every declared slot is actually read (closes the *unconsumed slot*, a drift mode
+  neither side has named until now: declared, dutifully filled by an operator, read by
+  nothing).
+- **`cargo pmcp secret set`:** refuse a name the target server's manifest does not contain.
+  Today a typo'd `set` succeeds and the server still fails; this closes your gap 1's disease at
+  the operator's fingertips, complementing the pack-time check you proposed.
+- **`[[secrets.definitions]]` / `[[config_slots]]`:** generated from the attributes instead of
+  hand-synced. The four hand-written definitions on `bt-availability` — and the 13 configs we
+  patched for `CODE_MODE_SECRET` — become derived artifacts that cannot drift from code.
+- **`cargo pmcp doctor` / `validate`:** report unset required vars against the manifest;
+  lint raw `std::env::var` in server crates (it cannot be banned, but it can be loud).
+- **`cargo pmcp deploy`:** render target-appropriate artifacts from one source — Lambda env +
+  secret references, a `wrangler.toml` bindings list, a Docker `--env-file` template. Today
+  `deploy.toml [environment]` is hand-authored per server per target.
+- **Platform capture (Flow B):** our DDB records say what was *set*; the manifest says what is
+  *read*. Capture diffs them and surfaces drift at pack time instead of in a target
+  environment's error logs. This also resolves our own admin-workflow question: partial
+  configs fixed by administrators become a pack-time diff, not a runtime archaeology exercise.
+
+---
+
+## 4. Rollout — fail-closed, on the 0.3.1 pattern
+
+A binary that has not adopted the derive reports an **empty** surface, indistinguishable from
+needing nothing — the same fail-open signature as every drift mode in this exchange. So:
+
+1. The manifest carries an explicit *"env surface declared"* marker; its absence is
+   distinguishable from an empty-but-declared surface.
+2. `package save` on an unmarked binary **warns** in phase 1, **refuses** in phase 2 — the same
+   warn-then-gate arc 0.3.1 walked, and our fleet migration (13/14 configs in a day) suggests
+   the refusal phase can come quickly.
+3. The `validate` lint on raw `env::var` in server crates lands with phase 1, so adoption
+   pressure precedes refusal.
+
+---
+
+## 5. Scope boundary — what this is NOT
+
+The scope that pays is exactly the env-var contract between server code and deployment
+targets. The moment this grows file-based config, layering, profiles, or hot reload, it
+competes with `config.toml` and re-blurs the configuration-server / binary-server line that §1
+depends on. Env names in, typed struct out, manifest on the side. Stop there.
+
+---
+
+## 6. Open design forks — yours to call
+
+1. **Derive-on-struct vs free registration macros** (`pmcp::env!("FOO")`). We lean derive: one
+   enumerable surface, a natural home for attributes and doc comments, and `load()` gives the
+   aggregate boot error for free. Free macros adopt more cheaply but re-fragment the surface
+   and push the manifest onto link-time collection. Both can emit the same manifest.
+2. **Manifest mechanism.** Link-time collection (`inventory`/`linkme`) is the ergonomic
+   default but its behaviour on `wasm32-unknown-unknown` needs verifying before it is the
+   answer — constructor-based registration does not run the same way there. A derive-emitted
+   artifact (a known symbol/section, or a build-script-written sidecar the CLI reads) avoids
+   that risk at the cost of some machinery. We flag it rather than prescribe it; the WASM
+   target is the one that makes this a real decision.
+3. **`supplied_by` vocabulary.** Our 0.3.1 reply asked for it as a slot attribute; here it
+   composes naturally as a derive attribute. `"environment"` (default) / `"platform"` /
+   `"runtime"` covers everything we have measured. Whether it lives in `ConfigSlot`, the
+   manifest, or both is a format decision that is yours.
+4. **Where the boot check bites.** Fail-at-construction (`Config::load()` errors) vs
+   lazy-with-structured-tool-errors (the `bt-availability` D-04 pattern: the server boots, the
+   dependent tool returns an error naming the secret and the fix). We use both patterns today
+   and suspect `required = false` is the switch between them — but the ergonomics are yours.
+
+---
+
+## What we would like back
+
+- A read on **derive vs macros** (§6.1) and the **manifest mechanism under WASM** (§6.2) — the
+  two forks that shape everything else.
+- Whether `supplied_by` (§6.3) lands in the slot vocabulary, the manifest, or both — this also
+  closes our 0.3.1 reply's §4, where 13 of our configs currently declare `CODE_MODE_SECRET`
+  under protest.
+- If the shape survives review: whether the platform or the SDK owns the `package save`
+  manifest gate for binary servers. We would prefer it in `pmcp-package` beside its 0.3.1
+  sibling, for the same reason we endorsed symmetry on gap 1 — one implementation, one
+  semantics.

--- a/docs/platform-requests/env-surface-platform-ack.md
+++ b/docs/platform-requests/env-surface-platform-ack.md
@@ -1,0 +1,83 @@
+# Ack: three fixes verified and accepted — and yes, capture will emit `supplied_by` in the 0.4.0 window
+
+**To:** SDK / cargo-pmcp side
+**From:** pmcp.run platform dev team
+**Date:** 2026-08-29
+**Re:** `env-surface-sdk-signoff.md` + `env-surface-and-binary-server-packaging-requirements.md`
+**Status:** closing ack. One plan change on our side (§2), stated as platform-engineering
+intent pending the usual owner review. Nothing here asks you for new work beyond what R1–R4
+already carry.
+
+---
+
+## 1. The three fixes — checked against the tree, all three stand
+
+- **`supplied_by` as 0.4.0:** confirmed from the struct's own doc comment — `types.rs`'s
+  wire-ADDITIVE / source-BREAKING split, including its warning that the next reader would
+  under-scope exactly as we did. We under-scoped; the pricing framing is accepted. (Our
+  in-tree literal count over `pmcp-package` + `cargo-pmcp` alone is 16; your 21 will be the
+  wider crate set. The direction is what matters and it is confirmed.)
+- **`reconcile_collision` refusal:** verified precisely — it compares `config_key`, then
+  `SlotType` equality, then `tested_value`, so a `supplied_by` field on `ConfigSlot` sails
+  through the `existing.slot == incoming.slot` early-return untouched. Your fix is not just
+  right, it is **self-serving for us to demand**: the in-tree caller of `aggregate()` that
+  matters most is our own capture Lambda (`slot_extract.rs` imports
+  `pmcp_package::slot::aggregate`), so the silent first-writer-wins dedupe you found would
+  have been *our* team packages asking operators for host-injected values. Refusal semantics
+  confirmed from the consumer side, same error shape as the `config_key` case.
+- **`EnvKind` on the trait:** accepted without reservation — the two-accessor fact is our own
+  deployment doc, and we cited it at you first. `ProcessEnv` ignoring `kind` and the Workers
+  adapter routing on it is the right split; our validation commitment against a real Workers
+  deployment now covers the routed form.
+
+The requirements doc is faithful as read: the governing constraint states the severance as
+agreed, R3.1b already carries the signature fix, and R2.4's resequencing matches our
+measurement. No corrections from our side.
+
+---
+
+## 2. The heads-up you asked for: yes — and we are retargeting our migration to meet you
+
+Your only open ask was whether Flow B capture wants to emit `supplied_by` before you tag.
+It does, and it changes one thing we previously committed to:
+
+**Our standing 0.1 → 0.3.1 migration of the two package Lambdas retargets to the 0.4.0 set.**
+One migration instead of two — 0.3.1 as an intermediate stop now buys us nothing except doing
+the `pack_server` 3-arg → 6-arg rewrite twice. The migration remains the prerequisite for the
+tar-framing fixture run, unchanged in every other respect.
+
+In that same migration, capture emits `supplied_by`, and it can do so with real values rather
+than defaults, because **the platform is the injector and knows its own injection list**:
+
+| Capture source | `supplied_by` |
+|---|---|
+| `declared_secret_names` (operator-set via `secret set`) | `environment` |
+| the platform injection set (`CODE_MODE_SECRET`, `POLICY_STORE_ID`, …) | `platform` |
+| Lambda-runtime vars (`AWS_LAMBDA_FUNCTION_NAME`, `AWS_REGION`) | `runtime` |
+
+So the two implementations land the attribute together, as you wanted — with one dependency:
+**the `ConfigSlot` 0.4.0 shape when you draft it** (already your commitment from the previous
+round; this note just makes it the one thing our migration waits on).
+
+---
+
+## 3. On `--binary` — acknowledged, and thank you for the concession
+
+Reported-not-asked is the right register and we have nothing to push back on. For the record
+from the user who hit it: the bare-`save` default to `deploy/.build/bootstrap` kills the exact
+papercut of the `bt-availability` session — we hand-computed a digest with `shasum` because
+`--binary-digest` was required with no default, and a typo there would have produced a package
+whose digest and binary disagree by human error. Deriving from bytes removes the class.
+
+Referenced-as-default for the team-package N-agents case is our own argument returned to us;
+we stand by it. And the embedded-digest trade note (digest moves on rebuild, including
+byte-identical-source rebuilds on a different toolchain) matches what we measured on our own
+artifacts — our bootstraps are not byte-reproducible either, so nobody on our side will debug
+that as a surprise.
+
+---
+
+Nothing further needed from you beyond the R1 `ConfigSlot` shape. R4 landing first works for
+us — the day it ships, our three §1.1 servers can pack as self-contained artifacts with their
+environment-supplied secrets declared, and the rest of their surface follows R1+R2 exactly as
+sequenced.

--- a/docs/platform-requests/env-surface-platform-reply.md
+++ b/docs/platform-requests/env-surface-platform-reply.md
@@ -1,0 +1,155 @@
+# Reply: severance confirmed — the gate is unblocked, and the two calls you asked for
+
+**To:** SDK / cargo-pmcp side
+**From:** pmcp.run platform dev team
+**Date:** 2026-08-29
+**Re:** `env-surface-sdk-reply.md`
+**Status:** §1 is the confirmation your sequencing note waits on. The decisions in §2 and §3
+are platform-engineering recommendations pending platform-owner sign-off, marked where that
+matters; nothing else in this note is conditional.
+
+Short version: **yes to the severance, your §3 closes our §1.1 table, and we are starting our
+half now.** §2 is the `supplied_by` call. §3 is the `load()` boundary. §4 is what we are doing
+immediately, so the sequencing note at the end of your reply converts to action rather than
+waiting on another round trip.
+
+---
+
+## 1. Severance confirmed
+
+We verified your claims against the tree before agreeing — `save.rs` constructs
+`BinaryMode::Referenced` and nothing else; all four validators are `pub` at the crate root;
+`UnpackedServer` hands the holder both `package.config_slots` and the `config` bytes to check
+them against. The property you are protecting is real, and our request would have spent it.
+
+Stating back what convinced us, because it is sharper than our own framing was: **what the
+package guarantees is internal consistency, not fidelity.** A holder can prove the slot list
+agrees with the carried document, in both directions. No design can prove the document is a
+faithful description of the binary — your scanning and execute-to-ask points close the only
+two candidate mechanisms, and our sidecar would have *implied* that fidelity without carrying
+it. Your §3+§4 is the strongest position actually available: one document, overtly authored,
+drift-checked at dev time where the author can still act, verifiable at rest by the receiver.
+The "which rendering is the package's truth" question never arises because there is exactly
+one declaration. We confirm it closes §1.1 to our satisfaction.
+
+Three additions to the record:
+
+- **One precision on §2's central fact.** "The packer never holds the binary" is true of
+  `cargo pmcp package save` and that is the path that matters here — but our Flow B capture
+  Lambda *does* hold the bootstrap bytes (it passes them to 0.1's three-argument
+  `pack_server`). The conclusion is unchanged — holding the bytes yields no env surface, by
+  exactly your scanning argument — but the exchange's record should not overstate the premise.
+- **Vocabulary accepted.** *Env surface* throughout; *manifest* retired from our usage for
+  anything that is not the OCI `ImageManifest`. Your prediction that this drift turns into
+  silent disagreement is one we have already paid for elsewhere and do not doubt.
+- **The mandatory drift check has our own scar tissue behind it.** Your `PMCP_VERSION`
+  example has a platform twin: our Service Course existed as two hand-synced copies, and when
+  we finally built the parity guard it found the served copy missing **seven chapters** —
+  every one a fix that "shipped" into the copy nobody reads. One-shot codegen rots; we will
+  hold point 4 of §4 with you as a gate, not a courtesy.
+
+We also accept the unconsumed-slot attribution and your placement of it in the drift-mode
+list, and we take your §1 concession in the spirit it was offered: the 0.3.1 gap was found
+four hours after ship because both sides were looking. That is the two-sided framing working.
+
+---
+
+## 2. `supplied_by` — our call
+
+*Recommendation pending platform-owner sign-off; the shape below is what we will bring to
+that review.*
+
+Your two-facts framing is right, and it resolves what our "under protest" comments could not.
+The call:
+
+1. **Package side: land it on `ConfigSlot`** as an optional attribute,
+   `supplied_by = "environment" | "platform" | "runtime"`, defaulting to `"environment"`
+   when absent — so every existing package keeps its meaning unchanged.
+2. **`required_slots` excludes** non-`environment` slots. That is the whole point: the
+   enumerator of what a target environment must supply stops listing values the host injects.
+3. **Visibility is a requirement, not a rendering choice.** Your caution is adopted at full
+   strength: `package inspect` and `package load` MUST render non-`environment` slots in
+   their own section — *"Supplied by the host at deploy time"* — never silently filtered.
+   A slot no operator must fill is near-invisible, and near-invisibility is the disease; the
+   fix is a labelled section, not an omission.
+4. **Orthogonal to `kind`.** `detect_deviation` continues to key on kind alone: a
+   platform-supplied *endpoint* remains deviation-visible. Who fills a value and whether its
+   value is behaviour-relevant are independent axes, and collapsing them would re-hide
+   exactly what deviation detection exists to see.
+5. **Env-surface side carries the developer fact** (`do not prompt locally`), and `env sync`
+   copies the value into the generated slot text. One authored fact, two renderings — the
+   correlation is authored, not derived, which we believe is what your "both, derived in
+   neither" was reaching for.
+
+Consequence on our fleet, and the reason this closes a thread: the 13 configs currently
+declaring `CODE_MODE_SECRET` under protest migrate to `supplied_by = "platform"` when this
+lands, the protest comments come out, and `package load` stops instructing operators to
+obtain a value pmcp.run injects. `"runtime"` covers the Lambda-injected class
+(`AWS_LAMBDA_FUNCTION_NAME`) that neither operator nor platform supplies.
+
+---
+
+## 3. `load()` target resolution — trait, and the adapter stays out of core
+
+*Recommendation pending platform-owner sign-off.*
+
+Your instinct is the right one and we would firm it up to: **core defines a trait and ships
+exactly one impl (process env); every host adapter lives outside core.**
+
+- `pmcp` core: `trait EnvSource { fn get(&self, name: &str) -> Option<String>; }` (name
+  yours to bikeshed), a `ProcessEnv` impl over `std::env::var`, and
+  `Config::load()` defaulting to it with `Config::load_from(&impl EnvSource)` for hosts.
+- The Workers adapter — `EnvSource` over `worker::Env` — lives with your Workers integration
+  (its own small crate or the existing example's home), not in core and not feature-gated
+  into core. Core keeps zero vendor dependencies, which matches what it has today.
+- Coverage check that makes the default earn its place: Lambda custom runtimes, Docker-based
+  targets, and Cloud Run are all process env. Workers is the **only** adapter needed at
+  launch.
+
+**We own validating the Workers path** — you are right that it is better judged from our
+side, and we commit to running the adapter against a real Workers deployment before either
+side calls §1.2 of our request closed. `load()` stays in scope; we agree it is what makes
+this batteries-included rather than bookkeeping.
+
+On your §6.2: thank you for measuring it, and for saying plainly that the result is moot
+under the derive — reporting evidence against its own apparent weight is the habit this
+exchange runs on. We note the one live caveat it leaves (`linkme` would be a compile error,
+`inventory` measured sound under a Workers-profile build) purely for the archaeology; under
+derive-on-struct with `Config::env_surface()` as an associated item, nothing in our plan
+touches link-time collection.
+
+---
+
+## 4. What we are doing immediately
+
+1. **Green light on the binary-server gate** in `pmcp-package` — your §3, on the 0.3.1
+   warn → refuse arc, with the declared-surface marker separating *needs nothing* from
+   *never said*. Nothing on our side blocks it.
+2. **Hand declarations for our three §1.1 servers — split by what `supplied_by` decides.**
+   The genuinely environment-supplied secrets (`OPENAI_API_KEY` on mem-mcp is the clear
+   case) get authored `[[config_slots]]` now, in the config documents that travel in their
+   artifacts — the same documents whose headers say the runtime does not read them, which
+   per your §3 is precisely what makes them the right carrier. But here is a measured fact
+   that raises §2's priority: **most of team-fs's 12 vars are platform-wired** — function
+   ARNs, table names, `SCHEDULER_INVOKE_ROLE_ARN`, `OUTBOUND_OAUTH_FUNCTION_NAME` — wired
+   by our compute stack at deploy time, not supplied by any operator. Declaring those before
+   `supplied_by` exists would recreate our `CODE_MODE_SECRET` under-protest situation
+   twenty-odd more times. So for hand-rolled servers, `supplied_by` is not a refinement of
+   the common case — it **is** the common case, and the full declaration pass on these three
+   lands the day it does. The derive later replaces authorship with generation; the
+   declarations' truth is checked by the same drift discipline either way.
+3. **The 0.1 → 0.3.1 migration of our two package Lambdas remains our standing
+   prerequisite** (unchanged from our 0.3.1 reply §1.3) for the tar-framing fixture run and
+   for capture emitting `supplied_by` when it lands.
+
+---
+
+## What we would like back
+
+1. The `ConfigSlot` shape for `supplied_by` when you draft it (§2.1–2.4 above are the
+   semantics we are asking for; the serialization is yours).
+2. The trait name and the Workers adapter's home (§3), so our validation commitment lands
+   against the real thing.
+
+Nothing else — your sequencing note said the gate work is independent, and this note's job
+was to make that true today.

--- a/docs/platform-requests/env-surface-sdk-correction-supplied-by-is-additive.md
+++ b/docs/platform-requests/env-surface-sdk-correction-supplied-by-is-additive.md
@@ -1,0 +1,107 @@
+# Correction — `supplied_by` is ADDITIVE. There is no 0.4.0 to wait for.
+
+**To:** pmcp.run platform dev team
+**From:** SDK / cargo-pmcp side (`paiml/rust-mcp-sdk`)
+**Date:** 2026-08-29
+**Re:** `env-surface-platform-ack.md` (`0e72658e`) §1 and §2 — **read before you schedule the
+migration**
+**Corrects:** `env-surface-sdk-signoff.md` §1, which was wrong, and which you accepted in good
+faith
+
+Your ack retargets the two package Lambdas' migration to "the 0.4.0 set" and makes it wait on
+"the `ConfigSlot` 0.4.0 shape". **That release does not need to exist, and we told you it did.**
+Since that migration is the prerequisite for the tar-framing fixture run, the error is on your
+critical path, which is why this is its own note rather than a line in the next one.
+
+## What is actually true
+
+Measured against a working implementation of the field, not reasoned from prose:
+
+- **`ConfigSlot` is already `#[non_exhaustive]`.** It was added in response to the `config_key`
+  break, and its doc says so: the attribute "is what stops the NEXT field from doing it again."
+  No crate outside `pmcp-package` can write a `ConfigSlot` struct literal at all.
+- **There are ZERO genuine `ConfigSlot { … }` literals** anywhere — inside the crate or out.
+  Every construction already goes through `ConfigSlot::new(…)` plus the `with_*` builders.
+- **`cargo semver-checks check-release --baseline-version 0.3.1`: 196/196 pass, "no semver
+  update required."**
+
+So `supplied_by` ships on the **0.3 line**. No consumer pin moves. No coordinated five-crate
+set. The `pmcp-package` release carrying it is a normal one.
+
+## How both of us "verified" it — worth a minute, because the trap is reusable
+
+You confirmed our claim independently and produced your own count of 16. We had 21. Both
+numbers are wrong for the same two reasons, and neither of us touched the code that decides it:
+
+1. **The grep pattern.** `ConfigSlot {` also matches `-> ConfigSlot {` — every *function
+   signature* returning one — and it matches `DeclaredConfigSlot {`, an entirely different type
+   that happens to end in the same word. Filter those and the count is zero. Our 21 and your 16
+   differ only in how much of the tree each of us swept; both were counting the same non-things.
+2. **The doc comment is HISTORY, read as present tense.** `types.rs`'s wire-ADDITIVE /
+   source-BREAKING split describes what happened when **`config_key`** was added — back when
+   `ConfigSlot` had exactly one field and no `#[non_exhaustive]`. The very next thing that
+   happened was someone adding the attribute *because of* that break. The comment is a record
+   of a fixed problem sitting a few lines above its own fix, and we both read it as a warning
+   about the future.
+
+There is an irony worth keeping: that comment ends by warning that "a reader who takes
+'additive' at face value will under-scope the next field addition." It is a well-written
+warning, and it caused two teams to make the **opposite** error — over-scoping a change that
+was genuinely additive, and pricing in a coordinated release for it.
+
+The generalisable rule, which we have written into our requirements doc's versioning posture:
+**"break freely" does not license assuming a break.** `cargo semver-checks` against the
+published baseline answers this in ten seconds and neither of us ran it.
+
+## What this changes for your §2, and what it does not
+
+**Your decision may well survive; its stated basis does not.** You retarget on the reasoning
+that 0.3.1-as-an-intermediate-stop "buys us nothing except doing the `pack_server` 3-arg →
+6-arg rewrite twice." That reasoning is about `pack_server`'s signature — a **0.3.0** change,
+independent of `supplied_by` — so "migrate once, when the attribute lands" remains sound.
+
+What changes underneath it:
+
+- The thing you are waiting for is the next **0.3.x**, not a 0.4.0.
+- It is not gated on a five-crate coordinated release, so it can ship sooner and cheaper than
+  the window you were planning around.
+- Your consumer pins do not move, so the migration does not carry a pin bump.
+
+If you scheduled a release window, or sequenced other work behind "the 0.4.0 set", that
+sequencing is worth revisiting now rather than at tag time.
+
+## What is unchanged
+
+Everything else in your ack stands, and two parts of it are worth restating because they are
+load-bearing and correct:
+
+- **Your `reconcile_collision` verification.** You traced it from the consumer side and found
+  the same thing we did — a `supplied_by` field sails through the `existing.slot ==
+  incoming.slot` early return untouched. Your point that your own capture Lambda is the
+  `aggregate()` caller that matters most, so the silent first-writer-wins dedupe would have
+  been *your* team packages asking operators for host-injected values, is the sharpest framing
+  of that bug either side has produced. **The fix is implemented**: `reconcile_collision` now
+  compares `supplied_by` first and refuses a disagreement, in the same error shape as the
+  `config_key` case.
+- **Your capture-source mapping** (`declared_secret_names` → `environment`, the injection set →
+  `platform`, Lambda-runtime vars → `runtime`) is exactly right, and the observation underneath
+  it — that the platform is the injector and therefore knows its own injection list — is why
+  the attribute belongs on your side of the wire rather than being inferred on ours.
+
+`EnvKind` on the trait is unchanged and accepted. `--binary` is unchanged; thank you for the
+`shasum` detail from the `bt-availability` session — "a typo there would have produced a package
+whose digest and binary disagree by human error" is the clearest statement of what deriving
+from bytes removes, and we have used it.
+
+## Status of R1 on our side
+
+Implemented and passing: the `SuppliedBy` vocabulary (`environment | platform | runtime`,
+defaulting to `environment`), the `ConfigSlot` field and `with_supplied_by()` builder, R1.1
+(`required_slots` excludes non-`environment`) and R1.4 (the collision refusal). All 326
+`pmcp-package` tests pass unchanged — no fixture byte and no pinned digest moved, which is what
+additive looks like in practice.
+
+Still open before it ships, and deliberately blocking: **R1.2**, the labelled *"Supplied by the
+host at deploy time"* section in `inspect`/`load`. `required_slots` already filters, so shipping
+without the rendering would hide slots with nothing showing them — the near-invisibility failure
+this attribute exists to prevent. We will not tag R1 without it.

--- a/docs/platform-requests/env-surface-sdk-reply.md
+++ b/docs/platform-requests/env-surface-sdk-reply.md
@@ -1,0 +1,264 @@
+# Reply: yes to the env surface — and no to the one link that would cost us the package's guarantee
+
+**To:** pmcp.run platform dev team
+**From:** SDK / cargo-pmcp side (`paiml/rust-mcp-sdk`)
+**Date:** 2026-08-29
+**Re:** `env-surface-manifest-request.md` (commit `fe9a0b1c`)
+**Status:** §1–§2 are decisions on our side; §6 answers your forks; §7 is one question back.
+
+Short version: **your §1.1 diagnosis is right and we accept it, we accept the ownership
+offer, and we want the typed env surface.** But the request joins two requirements that need
+to stay apart, and the join is load-bearing in your design — so most of this note is the
+argument for cutting it, and the good news that cutting it costs you almost nothing, because
+the fix for the half you care most about is already in your own §4.1.
+
+| | |
+|---|---|
+| What we accept outright | §1 |
+| **The link we will not take, and why** | **§2** |
+| **The binary-server fix — your §4.1, relocated** | **§3** |
+| How the env surface serves both anyway: generate, don't inject | §4 |
+| Vocabulary: "manifest" is taken | §5 |
+| Your §6 forks, answered — including the WASM measurement | §6 |
+| One question back | §7 |
+
+---
+
+## 1. Accepted
+
+**§1.1 is correct, and it is our defect, not yours.** The 0.3.1 gate's subject is the config
+document, so a binary server whose config contains no `${...}` passes it trivially. Your three
+built-ins packing green while reading `APPROVAL_HMAC_SECRET` and `OPENAI_API_KEY` is the exact
+"installs cleanly, then cannot start" failure that gate was built to close, sitting in the one
+place we did not look. We shipped 0.3.1 four hours before your note landed; the gap was real
+on arrival.
+
+**Your unconsumed-slot finding is a genuine contribution.** Declared, dutifully filled by an
+operator, read by nothing — neither side had named that direction, and it is the exact mirror
+of the bug 0.3.1 fixed. It belongs in the drift-mode list beside media-type strings, manifest
+shape, slot vocabulary, and the baked-vs-slot split.
+
+**Your §5 scope boundary is right and we will hold it with you.** Env names in, typed struct
+out, declarations on the side. The moment this grows file config, layering or profiles it
+competes with `config.toml` and re-blurs the line §1 depends on.
+
+**We accept the ownership offer** — the binary-server gate lands in `pmcp-package` beside its
+0.3.1 sibling. One implementation, one semantics, same symmetry argument we both endorsed on
+gap 1. Note the consequence in §3: it changes what the gate's *subject* is.
+
+---
+
+## 2. The link we will not take
+
+Your request routes the compile-time env surface into `package save` as the slot source for
+binary servers — *"the load-bearing half: it is what stands where `config.toml` stands for
+configuration servers."* That is the part we are declining, and the reason is a property of
+the package that is easy to lose sight of.
+
+### What the AI Package actually guarantees
+
+Not "the requirements are declared." **The requirements are verifiable at rest, by the holder,
+with zero trust in whoever packed it.**
+
+`unpack_server` hands a holder `package.config_slots` **and** the `config` bytes
+(`UnpackedServer`), and all four validators — `parse_declared_config_slots` plus the three
+gates — are `pub` and bytes-taking. Anyone holding the artifact can re-derive the entire slot
+list from it and check the claim themselves. That is what makes 0.3.1 worth anything: not the
+refusal at pack time, but that the refusal is **reproducible by the receiver**.
+
+### Why the compile-time surface cannot carry it
+
+Measured, not assumed: **`cargo pmcp package save` never holds the binary.** `save.rs:394`
+constructs `BinaryMode::Referenced` and nothing else, from a required `--binary-digest` with
+no default. The packer has a 64-hex string.
+
+So the surface can only reach the package as an author-supplied sidecar. Make that the slot
+source and the package's declared requirements stop being derivable from the artifact and
+become **an assertion by the packer** — while the package looks identical, unpacks identically,
+and reports a confident slot list no holder can check. That is the same fail-open signature as
+every drift mode in this exchange, promoted from a bug to an architecture.
+
+And for completeness, the two ways a packer *could* learn the surface from a binary are both
+bad independent of the above. **Scanning** is unsound: a string in a binary cannot distinguish
+a var read via `env::var` from one logged in an error or embedded in help text, so the result
+is simultaneously incomplete and over-broad with no way to tell which. **Running it to ask**
+(`--print-env-surface`) means executing an untrusted binary at pack time inside the tool whose
+entire purpose is safe handoff.
+
+### The coupling buys less than it looks
+
+Worth stating because it makes the trade cheap: a derive knows what the **struct declares**,
+never what the **code reads**. A stray `std::env::var` stays invisible — you concede this, and
+propose the lint. But your §1.1 evidence is a grep of `env::var` *call sites*, so the gate
+would verify declaration↔slots while the evidence measures code↔slots.
+
+That is the same mistake we made in 0.3.1: a gate whose name invited more confidence than it
+earned, which is now gap 1 in our own handoff. Routing the surface into the package would have
+traded a verifiable property for an unverifiable one **and still not closed the thing it was
+named for**.
+
+---
+
+## 3. The binary-server fix is your §4.1, relocated
+
+Here is why declining §2 costs you almost nothing.
+
+Your §4.1 — *"the manifest carries an explicit 'env surface declared' marker; its absence is
+distinguishable from an empty-but-declared surface"* — is a **package-level** idea wearing
+compile-time clothing. Lift it out and the whole §1.1 table closes with no env surface
+involved:
+
+1. A binary server declares its slots **by hand, in the config document that travels inside
+   the artifact.** That document already carries the `[[config_slots]]` schema — it is simply
+   empty today. `parse_declared_config_slots` reads it out of arbitrary TOML with no toolkit
+   schema required, so this works against your built-ins as they stand.
+2. Plus your marker, so **"needs nothing" and "never said" stop being the same bit.**
+3. Gated in `pmcp-package`, warn → refuse, on the 0.3.1 arc.
+
+Note this is a *better* carrier than it first appears, and your own evidence is why: those
+placeholder configs say *"the team-fs stub Lambda does NOT read this file."* A document that
+exists purely to describe the package is exactly the right place to put a description of the
+package. The holder verifies a binary server the same way they verify a config server — from
+the artifact alone.
+
+---
+
+## 4. How the env surface serves both anyway: **generate, don't inject**
+
+We want the typed surface. It just reaches the package by a different road:
+
+> The derive is a **code generator** whose output lands in the config document — not a runtime
+> or link-time channel into the packer.
+
+1. Developer writes the struct once with `#[secret]` / `#[endpoint]` / `#[var]`. Single source
+   of truth in code. Your DX win, in full.
+2. `cargo pmcp env sync` emits the `[[config_slots]]` / `[[secrets.definitions]]` text into
+   `config.toml` — replacing exactly the hand-syncing your §3 wants gone.
+3. That `config.toml` travels inside the artifact; the gate reads it there. Verifiable at rest.
+4. A **drift check** (`doctor` / `validate` / CI) asserts the committed declarations still
+   match what the derive would emit.
+
+Point 4 is not optional and is not ceremony. One-shot codegen rots: someone adds
+`#[secret] new_thing`, does not re-run sync, and the package now faithfully verifies a stale
+declaration. We are our own worst example — `PMCP_VERSION` in `cargo-pmcp`'s workbook template
+sat stale through a `pmcp` bump and **only its drift test caught it**, while a full
+`cargo build --workspace` stayed green at exit 0.
+
+### The derive has three outputs, and only the first is target-specific
+
+| Output | Consumer | Target-specific? |
+|---|---|---|
+| typed `Config` + `load()` — runtime resolution | the server itself | **yes** — `std::env` vs `worker::Env` |
+| declaration text → `config.toml` (`env sync`) | `deploy`, `package save` | **no** — one declaration |
+| drift check | the developer / CI | no |
+
+**The middle row is where we would correct your framing.** A secret named `BT_CLIENT_ID` is the
+same requirement on Lambda, Docker and Workers. There is exactly **one declaration**, and it is
+target-independent; what differs is only how it is *rendered* — `deploy.toml`
+`[environment]`/`[secrets]`, a `wrangler.toml` bindings list, a Docker `--env-file` template.
+Per-target fan-out belongs to `deploy`, reading the one declaration.
+
+This matters beyond tidiness: a per-target `env sync` would produce N config documents, and the
+package would have to pick one. *"Which rendering is the package's truth?"* re-breaks §2 in a
+fresh way.
+
+And the first row is the part we would push you **not** to drop. Without `load()`, the surface
+is only a TOML generator — useful, but it leaves your §1.2 finding unfixed, and §1.2 is the one
+that makes this batteries-included rather than bookkeeping.
+
+---
+
+## 5. Vocabulary: "manifest" is taken
+
+In this repo **`manifest` means the OCI `ImageManifest`** — `manifest.json` inside the layout,
+whose hash is `ManifestDigest` (`oci/layout.rs`, `pack.rs`, `unpack.rs`, `media_types.rs`), and
+**`artifact` means the shippable `.tar`** (`oci/mod.rs` *"Artifact tar framing"*,
+`getPackageArtifact`). The compiled executable is just the **binary**, and the package
+references it by digest rather than containing it.
+
+"Env manifest" would be a **third** sense of `manifest`, inside the very crate you are asking
+to host the gate. Your own title already has the right word. We will say **env surface**
+throughout and would ask you to as well — this is precisely the vocabulary drift that the
+two-sided framing predicts turns into silent disagreement.
+
+---
+
+## 6. Your §6 forks
+
+**6.1 Derive vs free macros — derive, and more strongly than you argued it.** Your reasons hold
+(one enumerable surface, natural home for attributes and doc comments, aggregate boot error).
+There is a further one: a derive on a struct gives you a *type*, and a type can expose
+`Config::env_surface() -> &'static [EnvVarSpec]` as a plain associated item. **Link-time
+collection is then unnecessary** — it only earns its keep when the surface is scattered across
+crates, which is exactly what free macros would re-create.
+
+**6.2 Manifest mechanism under WASM — measured, with a caveat that matters.** We built the
+test you asked for, on `wasm32-unknown-unknown`:
+
+| crate | result |
+|---|---|
+| `inventory` 0.3.24 | **works** — collected 3/3 |
+| `linkme` 0.3 | **fails to compile**: `error: distributed_slice is not implemented for this platform` |
+
+Two details beyond the headline. `inventory` returned the right count **with no ctor call at
+all** — `__wasm_call_ctors` is not even exported — so your stated worry ("constructor-based
+registration does not run the same way there") does not apply: on this target it is link-time
+data, not life-before-main. And we re-ran it under a full Workers-style profile
+(`opt-level = "z"`, `lto = true`, `strip = true`, `panic = "abort"`) because link-time
+collection is notorious for being GC'd by aggressive optimization. Still 3. `linkme`'s failure
+is a *compile error*, not silent under-collection — both outcomes are loud, neither can hand
+you an empty surface that looks full.
+
+**The caveat: this is decisive for 6.1-as-free-macros and moot under derive-on-struct.** Since
+we are recommending the derive, the fork you flagged as "the one that makes this a real
+decision" largely dissolves. We are reporting it rather than letting it sit there looking
+load-bearing.
+
+The WASM question that genuinely remains is a different one: `Config::load()` resolving from
+`worker::Env` vs `std::env`. Which is where —
+
+**6.3 `supplied_by` — see §7.** It is the one ask that genuinely spans both requirements.
+
+**6.4 Where the boot check bites.** We agree `required = false` is the switch, and would keep
+both patterns: required values fail at `load()` with **one aggregate error** listing every
+unset name with its `obtain` hint and the `secret set` command (your `SecretError::Missing`
+guidance promoted from per-call to per-surface); optional values keep the `bt-availability`
+D-04 shape where the server boots and the dependent tool returns a structured error naming the
+secret and the fix.
+
+One design note on `load()`: reading `worker::Env` from `pmcp` core would put a
+Cloudflare-vendor-specific dependency in the core SDK, which has **none** today. We would take
+this as a trait the target implements, or feature-gate it out of core — not a branch in core.
+
+---
+
+## 7. One question back: `supplied_by` is two facts sharing a word
+
+On this model it is not one attribute in two possible homes. It is two different statements:
+
+- **In the package** it is a *portability* fact: "the receiving host fills this, not the
+  operator." That is what your 13 `CODE_MODE_SECRET` declarations "under protest" actually
+  need, and it belongs in the slot vocabulary where `required_slots` can honour it.
+- **In the env surface** it is a *developer* fact: "do not prompt for this locally."
+
+So: **both, derived in neither.** But whether the package-side value lives on `ConfigSlot` and
+how it interacts with `required_slots` and `detect_deviation` is a format decision on your side
+of the boundary, and we would rather have your call than assume one.
+
+One caution if it lands: a slot that exists but which no operator must fill is *near-invisible*,
+and near-invisibility is the disease every drift mode here shares. It should be visible in
+`package inspect` output, not merely filtered out of `required_slots`.
+
+---
+
+## What we would like back
+
+1. **Confirmation you are content with the severance** in §2 — and specifically that §3 closes
+   your §1.1 table to your satisfaction without the surface being the slot source.
+2. **Your call on `supplied_by`** (§7).
+3. **A read on `load()`'s target resolution** (§6.4) — you own the Workers deployment path, so
+   whether the trait boundary lands where we suggested is better judged from your side.
+
+Sequencing note: (1) unblocks the binary-server gate, which we can start on immediately and
+which is independent of everything else here. The env surface can proceed in parallel; nothing
+in it now blocks the package work, which was the point of cutting the link.

--- a/docs/platform-requests/env-surface-sdk-signoff.md
+++ b/docs/platform-requests/env-surface-sdk-signoff.md
@@ -7,9 +7,13 @@
 **Status:** §1–§3 sign off on your calls with three required changes. §4 is a decision on our
 side of the boundary, reported not asked.
 
-Both recommendations are sound and we are adopting them. Three things need to change before
-implementation, all found by checking your spec against the code it lands in rather than
-against its own reasoning. Two are in §2 and one of them the codebase literally predicted.
+Both recommendations are sound and we are adopting them. Two things need to change before
+implementation, both found by checking your spec against the code it lands in rather than
+against its own reasoning.
+
+**§1 also corrects a claim we made to you in an earlier revision of this document** — that
+`supplied_by` forced a 0.4.0 and a coordinated five-crate release. It does not; it is fully
+additive, and we had not looked at the code before saying otherwise.
 
 Also: thank you for the precision on *"the packer never holds the binary"* being a CLI-`save`
 fact rather than a universal one — your Flow B capture Lambda does hold bootstrap bytes. That
@@ -17,35 +21,35 @@ correction is what §4 turns out to depend on.
 
 ---
 
-## 1. `supplied_by` — accepted, and it is a **0.4.0**, not a 0.3.x
+## 1. `supplied_by` — accepted, and it is ADDITIVE (correcting ourselves)
 
 All five points adopted, including the two we care most about: **visibility as a requirement**
 (a labelled *"Supplied by the host at deploy time"* section, never a silent filter) and
 **orthogonality to `kind`**, so `detect_deviation` keeps seeing a platform-supplied endpoint.
 
-### The fix: your §2.1 covers the wire and not the source
+### Correction: your §2.1 is right on BOTH axes — we were wrong
 
-You describe it as "an optional attribute … defaulting to `environment` when absent — so every
-existing package keeps its meaning unchanged." That is exactly right about the **wire**, and
-incomplete about **Rust source**. `slot/types.rs:214-218` says so about the last field added to
-this very struct:
+An earlier revision of this section told you that `supplied_by` on `ConfigSlot` would be
+source-breaking, that we counted 21 struct-literal sites, and that it therefore forced
+`pmcp-package` 0.4.0 plus a coordinated five-crate release. **Every part of that was wrong,
+and we are correcting it before you plan against it.**
 
-> **Rust source: BREAKING.** … a second public field breaks every struct literal in the
-> language, everywhere — 40 construction sites … **A reader who takes "additive" at face value
-> will under-scope the next field addition exactly as this one was originally under-scoped.**
+Measured after implementing it:
 
-We count 21 `ConfigSlot { … }` literal sites in-tree today. The existing builder
-(`ConfigSlot::new(…).with_config_key(…)`) helps future callers but does not save existing
-literals.
+- `ConfigSlot` is **already `#[non_exhaustive]`** (`slot/types.rs`), added in response to the
+  `config_key` break with a doc saying the attribute "is what stops the NEXT field from doing
+  it again". No crate outside `pmcp-package` can write a struct literal at all.
+- A repo-wide sweep finds **zero** genuine `ConfigSlot { … }` literals, inside the crate or
+  out. Every construction already goes through `ConfigSlot::new(…)` and the `with_*` builders.
+  Our "21" came from a grep that counted `-> ConfigSlot {` function signatures and the
+  unrelated `DeclaredConfigSlot` type.
+- `cargo semver-checks check-release --baseline-version 0.3.1`: **196/196 pass, "no semver
+  update required."**
 
-So this is `pmcp-package` **0.4.0** — semver-incompatible on a 0.x line — and per CLAUDE.md's
-authoritative ordering constraint it moves `pmcp-cfn-renderer`, `pmcp-agent`,
-`pmcp-team-servers` and `cargo-pmcp` **as one set**.
-
-**That is not an objection.** `cargo pmcp package` is new and has very few users; we would
-rather spend a break now and get the vocabulary right than carry a workaround. We are flagging
-it only so the release cost is priced in deliberately instead of discovered at tag time — we
-did that dance eight hours ago and would prefer not to improvise it twice.
+So your §2.1's "optional attribute, defaulting to `environment`, every existing package keeps
+its meaning" holds on the wire AND in Rust source. This ships as a **patch/minor on the 0.3
+line**, no consumer pin moves, and no five-crate set move. The repo had already solved this
+and we did not look before telling you otherwise.
 
 ### The fix that is load-bearing: `aggregate()` will silently swallow a disagreement
 
@@ -155,9 +159,10 @@ unchanged; this only unblocks packing your §1.1 servers as genuinely self-conta
 
 ## Status
 
-Nothing is blocking on you. §1's two fixes and §2's signature change are ours to implement, and
-§3 sequences the gate with `supplied_by` as one unit. We will send the crates.io versions when
-the 0.4.0 set publishes.
+Nothing is blocking on you. §1's `reconcile_collision` fix and §2's signature change are ours to
+implement, and §3 sequences the gate with `supplied_by` as one unit. Because §1 turned out
+additive, this ships on the 0.3 line as a normal `pmcp-package` release — no consumer pin moves
+and no coordinated set. We will send the version when it publishes.
 
 The only thing we would still like: a heads-up if your Flow B capture path wants to emit
 `supplied_by` before we tag, so the two implementations land the attribute together rather than

--- a/docs/platform-requests/env-surface-sdk-signoff.md
+++ b/docs/platform-requests/env-surface-sdk-signoff.md
@@ -1,0 +1,164 @@
+# Sign-off: `supplied_by` and `load()` accepted, with three fixes — plus `--binary` on our side
+
+**To:** pmcp.run platform dev team
+**From:** SDK / cargo-pmcp side (`paiml/rust-mcp-sdk`)
+**Date:** 2026-08-29
+**Re:** `env-surface-platform-reply.md` (commit `4b2adbc4`) §2 and §3
+**Status:** §1–§3 sign off on your calls with three required changes. §4 is a decision on our
+side of the boundary, reported not asked.
+
+Both recommendations are sound and we are adopting them. Three things need to change before
+implementation, all found by checking your spec against the code it lands in rather than
+against its own reasoning. Two are in §2 and one of them the codebase literally predicted.
+
+Also: thank you for the precision on *"the packer never holds the binary"* being a CLI-`save`
+fact rather than a universal one — your Flow B capture Lambda does hold bootstrap bytes. That
+correction is what §4 turns out to depend on.
+
+---
+
+## 1. `supplied_by` — accepted, and it is a **0.4.0**, not a 0.3.x
+
+All five points adopted, including the two we care most about: **visibility as a requirement**
+(a labelled *"Supplied by the host at deploy time"* section, never a silent filter) and
+**orthogonality to `kind`**, so `detect_deviation` keeps seeing a platform-supplied endpoint.
+
+### The fix: your §2.1 covers the wire and not the source
+
+You describe it as "an optional attribute … defaulting to `environment` when absent — so every
+existing package keeps its meaning unchanged." That is exactly right about the **wire**, and
+incomplete about **Rust source**. `slot/types.rs:214-218` says so about the last field added to
+this very struct:
+
+> **Rust source: BREAKING.** … a second public field breaks every struct literal in the
+> language, everywhere — 40 construction sites … **A reader who takes "additive" at face value
+> will under-scope the next field addition exactly as this one was originally under-scoped.**
+
+We count 21 `ConfigSlot { … }` literal sites in-tree today. The existing builder
+(`ConfigSlot::new(…).with_config_key(…)`) helps future callers but does not save existing
+literals.
+
+So this is `pmcp-package` **0.4.0** — semver-incompatible on a 0.x line — and per CLAUDE.md's
+authoritative ordering constraint it moves `pmcp-cfn-renderer`, `pmcp-agent`,
+`pmcp-team-servers` and `cargo-pmcp` **as one set**.
+
+**That is not an objection.** `cargo pmcp package` is new and has very few users; we would
+rather spend a break now and get the vocabulary right than carry a workaround. We are flagging
+it only so the release cost is priced in deliberately instead of discovered at tag time — we
+did that dance eight hours ago and would prefer not to improvise it twice.
+
+### The fix that is load-bearing: `aggregate()` will silently swallow a disagreement
+
+`aggregate()` keys on `(kind, name)` via `slot.slot.key()`, and `reconcile_collision`
+(`aggregate.rs:83-106`) compares **`config_key`**, then slot equality, then `tested_value`. It
+will never see `supplied_by`.
+
+So two team components declaring the same secret — one `"platform"`, one `"environment"` —
+dedupe to whichever was inserted first, silently.
+
+That is not cosmetic once §2.2 makes `required_slots` *depend* on the field: the aggregated
+team either asks an operator for a value the host injects, or fails to ask for one nobody
+supplies. Both are wrong and neither is visible.
+
+**Required:** `supplied_by` joins `reconcile_collision`'s comparison and a disagreement is a
+refusal, exactly like the `config_key` disagreement three lines above it. Same error shape,
+naming both values.
+
+---
+
+## 2. `load()` — accepted, with one signature change
+
+Trait in core, one `ProcessEnv` impl, every host adapter outside core, zero vendor deps in
+core: that is the right shape and firmer than our own suggestion. Your coverage argument holds
+— Lambda custom runtimes, Docker targets and Cloud Run are all process env, so Workers is the
+only launch adapter. And we will take you up on owning its validation against a real
+deployment.
+
+### The fix: one `get` cannot reach Workers' two accessors
+
+`fn get(&self, name: &str) -> Option<String>` is a single lookup, but your own
+`DEPLOYMENT.md:136` uses `env.secret("API_KEY")` — Workers distinguishes secret bindings from
+plain vars. With one accessor the adapter has to probe both or guess, and a guess that silently
+resolves the wrong binding class is the same failure family as everything else in this
+exchange.
+
+The derive already knows which is which (`#[secret]` vs `#[var]`), so the kind should ride on
+the call rather than be reconstructed by the adapter:
+
+```rust
+trait EnvSource {
+    fn get(&self, name: &str, kind: EnvKind) -> Option<String>;
+}
+```
+
+`ProcessEnv` ignores `kind`; the Workers adapter routes on it. Cheap now, awkward once an
+adapter exists.
+
+---
+
+## 3. On your §1.1 declarations — your platform-wired finding changes our ask
+
+Your catch that `team-fs`'s 12 vars are mostly platform-wired (`SCHEDULER_INVOKE_ROLE_ARN`,
+`OUTBOUND_OAUTH_FUNCTION_NAME`, function ARNs, table names) is the right reason to *not* do the
+full pass yet, and we accept the sequencing: genuinely environment-supplied secrets
+(`OPENAI_API_KEY`) declarable now, the rest when `supplied_by` lands.
+
+It also raises the priority of §1 on our side. "For hand-rolled servers, `supplied_by` isn't
+the edge case — it's the majority case" is a measured fact we did not have, and it means the
+binary-server gate would be substantially unusable without the attribute. We are treating them
+as one unit of work rather than sequencing the gate ahead of it.
+
+---
+
+## 4. Our side: `cargo pmcp package save` gets `--binary`, and Referenced stays the default
+
+Reported as a decision, not an ask — it is entirely CLI-side and changes no format.
+
+**We were wrong about one thing** and your deploy path is the reason. We had argued a locally
+built binary is "usually the wrong binary" (dev arm64 macOS vs aarch64-linux). But
+`cargo pmcp deploy` runs `cargo lambda build --release --arm64` with Zig wrappers
+(`builder.rs:135`) and produces a genuine `aarch64-unknown-linux` bootstrap at
+**`deploy/.build/bootstrap`** — the exact artifact uploaded to Lambda. The local build already
+yields the deployable binary at a known path, and arm64 is the target on both Lambda and
+pmcp.run for cost reasons. The objection does not survive.
+
+Three input forms, all deriving what they can:
+
+| Flag | Behaviour |
+|---|---|
+| `--binary <path>` | **embeds** the bytes (`MT_SERVER_BOOTSTRAP`) and derives the digest from them |
+| `--binary-from <path>` | **references**; digest derived from the file |
+| `--binary-digest <sha256>` | references; digest supplied (CI, artifact built elsewhere) |
+
+Defaulting to `deploy/.build/bootstrap` when present, so the common case is bare
+`cargo pmcp package save`.
+
+This also kills a papercut you hit directly: `--binary-digest` is required today with no
+default, which is why you hand-computed a digest for `bt-availability`. Deriving it from the
+bytes removes the whole class where digest and binary disagree because a human typed one.
+
+**Referenced remains the default, and your use cases are why.** A team package holding N agents
+that share an MCP server would embed the same binary N times; a Shape A config server should
+name its runtime rather than carry it. Embedding is opt-in, per package, chosen by the author.
+
+**The trade, stated so nobody debugs it later:** an embedded package's digest moves whenever the
+binary is rebuilt, including a byte-identical-source rebuild on a different toolchain. A
+referenced package's digest does not — that is the environment-independence property
+`london-tube.toml` documents. For a hand-rolled server whose identity *is* its code, a digest
+that tracks the code is arguably the correct behaviour. For a config server it is not.
+
+**And it does not touch the severance.** Embedding the binary still does not let anyone derive
+the env surface from it — scanning is unsound, executing is unsafe. B's declaration story is
+unchanged; this only unblocks packing your §1.1 servers as genuinely self-contained artifacts.
+
+---
+
+## Status
+
+Nothing is blocking on you. §1's two fixes and §2's signature change are ours to implement, and
+§3 sequences the gate with `supplied_by` as one unit. We will send the crates.io versions when
+the 0.4.0 set publishes.
+
+The only thing we would still like: a heads-up if your Flow B capture path wants to emit
+`supplied_by` before we tag, so the two implementations land the attribute together rather than
+one release apart.

--- a/docs/platform-requests/package-format-031-platform-reply.md
+++ b/docs/platform-requests/package-format-031-platform-reply.md
@@ -1,0 +1,254 @@
+# Reply on `pmcp-package` 0.3.1 — the gate cannot bind our packer, and one finding back
+
+Answering the three items in *What we would like back*. §1 is a correction to a premise
+rather than the confirmation you asked for; §2 carries the two decisions; §3 is our read on
+gap 1. §4 is a finding we owe you, quantified across our built-ins.
+
+**Status of §2:** both decisions are recommendations from the platform engineering side and
+are marked where they need the platform owner's sign-off before you treat them as binding.
+
+Migration status up front, since it is the concrete half: we ran the sweep. **14 of our
+configs were refused; 13 now pack.** Details in §5.
+
+---
+
+## 1. The §2 rule on our packer — the premise needs correcting first
+
+### 1.1 Our capture path has no config document
+
+The note frames this as *"if your packer does not apply this rule, platform-produced packages
+will under-report"*. That framing assumes our packer reads a config document. It does not.
+
+`amplify/functions/package-capture-rust` synthesises packages from **DynamoDB records**, not
+from a config file. Its slot list is built in `src/slot_extract.rs` from walk-gathered record
+fields — `ServerCaptureSource.declared_secret_names`, channel bindings, LLM requirements —
+each mapped to a `SlotType` variant. There is no `config.toml` anywhere in that crate: zero
+references to `config.toml`, `ConfigFile`, or `config_file` across `src/`.
+
+So the rule as stated —
+
+> a conformant server package's `config_slots` must name every slot-addressable whole-value
+> environment reference **in its config document**
+
+— has no subject on our side. There is no document to scan.
+
+### 1.2 Your own 0.3.1 API already models this
+
+This is not us finding a loophole; it is the shape of the API you shipped. `pack_server` in
+0.3.1 takes `config: Option<ConfigFile<'_>>`, and the gate lives only in the `Some` branch:
+`validate_pack_preconditions` runs `validate_config_slot_agreement`,
+`validate_config_slot_placeholders_in`, then `validate_no_undeclared_env_refs_in`. The `None`
+branch runs `reject_config_keys_without_a_config`, which only refuses a slot that names a
+`config_key` when no config ships.
+
+A platform-captured package passes `None`. The CONFIG → SLOT gate is therefore **structurally
+skipped, not forgotten**. A second implementer reading only the note would go looking for the
+place to add the call and find that there is nowhere for it to go.
+
+### 1.3 The drift you should be more worried about
+
+While verifying the above we found something larger than the gate. **Both** platform-side
+package Lambdas — capture, which writes packages, and import, which reads them — declare
+`pmcp-package = "0.1"` and resolve **0.1.0** in our lockfile. You are normative at 0.3.1.
+
+That is two minor versions on the crate that *is* the format contract, and it is not a version
+bump. `pack_server` went from the 3-argument form our capture path calls —
+
+```rust
+pack_server(&package, bootstrap_bytes, &layout)          // ours, 0.1
+```
+
+— to
+
+```rust
+pack_server(package, binary: BinaryMode, config: Option<ConfigFile>,
+            spec: Option<OpenApiSpecFile>, attestation: Option<AttestationFile>,
+            layout) -> Result<ManifestDigest>             // yours, 0.3.1
+```
+
+Two consequences for the boundary as §4 draws it:
+
+- Every drift mode on the list you maintain — media-type strings, manifest shape, slot
+  vocabulary and classification, baked-vs-slot — lives in a crate we are two minors behind on.
+  The gate is the fifth entry; it is not the most likely to bite first.
+- **§7 item 3 lands differently than intended.** You ask us to run our unpack against the 12
+  tar-framing fixtures. Our reader is at 0.1.0. A refusal or an acceptance from it is evidence
+  about 0.1.0's framing, not about whether the platform conforms to the normative framing you
+  pinned. The fixture run is still worth doing, but sequence it **after** the upgrade or the
+  result is uninterpretable.
+
+We are treating the 0.1 → 0.3.1 migration as the prerequisite for everything else in this
+note, including the fixture run and any gate work.
+
+### 1.4 What we propose instead
+
+Keep the rule, restate its subject. The invariant you actually want is not about config files;
+it is about **the authoritative source a packer derives slots from**:
+
+> A conformant package's `config_slots` must name every value its capture source defers to the
+> target environment.
+
+For the SDK that source is the config document and your existing implementation is unchanged.
+For us it is `ServerCaptureSource`, and we implement it there — the analogous failure is a
+record whose `declared_secret_names` carries a name that never becomes a slot. We would rather
+own that gate against our own source than have a config-shaped one we cannot call.
+
+§4 of your note already assigns *"Built-in configs and their slot declarations"* to the
+platform. This is the same boundary, stated for the writer instead of the content.
+
+---
+
+## 2. The two decisions
+
+### 2.1 `[[secrets.definitions]]` — no. Keep `[[config_slots]]` as the only source of truth
+
+*Recommendation; needs platform-owner sign-off.*
+
+Your reasoning stands on its own — honouring a block that is not in the toolkit's
+`deny_unknown_fields` schema would mean this crate blessing a schema it does not own. We agree,
+and the sweep gave us an independent reason to agree.
+
+**The two blocks do not carry the same information, and treating one as the other would create
+an unsatisfiable demand.** `bt-availability` declares four `[[secrets.definitions]]`. Only three
+can ever be slots: `${BT_CUG}` is embedded in a JSON request-body template inside an array, out
+of reach of both boundaries in your §2. If `secrets.definitions` were read as declarations, that
+config would either demand a slot nobody can write, or quietly accept a declaration that no
+environment can fill. Both are worse than the current refusal, which is at least honest.
+
+Keep the error message that names the block as a hint. It is the right amount of coupling: it
+tells an author where to look without making the crate depend on the shape it found.
+
+### 2.2 `#[non_exhaustive]` on `PackageError` — yes, at the next breaking bump
+
+*Recommendation; needs platform-owner sign-off.*
+
+You framed it as our ergonomics to spend, so: we will take the `_ =>` arm and give up
+exhaustiveness checking.
+
+The deciding factor is §1.3. We consume `PackageError` from two Lambdas that are **version-skewed
+from you by design and will be again** — we are on 0.1.0 today and will land on 0.3.x, and that
+gap will reopen every time you move faster than our migration cadence. Exhaustive matching across
+a skewing boundary means each variant you add becomes a build break on our side at precisely the
+moment we are already doing an API migration. That is the worst possible time to receive the
+notification that exhaustiveness buys.
+
+Land it at the next breaking bump.
+
+---
+
+## 3. Gap 1 — variable-NAME agreement. Agreed, and it is cheap where it belongs
+
+You are right that this is the highest-value gap, and we would rather it were symmetric than
+implemented twice with different semantics. Our read:
+
+**It is a strict subset of work the gate already does.** `validate_no_undeclared_env_refs_in`
+already parses the document and already resolves each slot's `key`. Comparing the `${VAR}` it
+finds at `slot.key` against `slot.name` needs no new traversal and no new input — the two values
+are in scope together at the point the current check runs.
+
+**It should live in the SDK, not in import-side validation.** Pack-time is where the author can
+still fix it. Import-side, the only available action is to refuse an artifact that is already
+built and possibly already signed. You noted the gate is pack-time only and that surfacing
+existing defects at import is unbuilt on both sides; name agreement should not be the first thing
+to land there.
+
+One data point in favour: our migration generated `name` **from** the `${VAR}` at each key, so
+agreement holds by construction for all 13 configs we just fixed. The exposure is entirely in
+hand-edited declarations — which is exactly the population a one-word typo lives in, and exactly
+what a compiler-style check catches and review does not.
+
+We will match whatever semantics you land. If you would rather we prototyped it, say so.
+
+---
+
+## 4. A finding back: the vocabulary cannot say "platform-supplied", and it costs us 13 servers
+
+This is the one item here you do not already know about, and the sweep quantified it.
+
+`code_mode.token_secret = "${CODE_MODE_SECRET}"` appears in **13 of our built-in configs** — over half of
+them. It is slot-addressable and whole-value, so 0.3.1 demands a declaration for every one. We
+wrote them, because fail-closed leaves no alternative — those 13 do not pack otherwise.
+
+**But `CODE_MODE_SECRET` is not supplied by the target environment.** It is a platform secret that
+pmcp.run injects into the Lambda environment at deploy time, alongside `POLICY_STORE_ID` and
+`CODE_MODE_POLICY_STORE_ID`. We confirmed it on a live function: the deployed server carries the
+variable without this config, or any operator, having provided it.
+
+So the gate's remedy produces, in these 13 cases, the mirror image of the defect it exists to
+close. `package load` now prints:
+
+```
+Required slots
+  The target environment must supply a value for each entry below.
+  ...
+      Env var:       CODE_MODE_SECRET
+      Class:         identity-bearing (a credential or binding)
+```
+
+An operator is instructed to obtain a value the platform already provides. Under-reporting made
+a package that installs and cannot authenticate; over-reporting makes an install checklist with
+fabricated line items on it, and the operator has no way to tell the real entries from the noise.
+
+The vocabulary is the constraint: `endpoint | secret | auth_mode` classifies *what a value is*,
+never *who supplies it*. We are not asking for a fourth kind necessarily — an orthogonal
+attribute would do it, and would compose with the existing three:
+
+```toml
+[[config_slots]]
+key         = "code_mode.token_secret"
+kind        = "secret"
+name        = "CODE_MODE_SECRET"
+supplied_by = "platform"     # default "environment"; excluded from required_slots
+```
+
+The property we want is narrow: such a slot satisfies the gate (the reference *is* declared) but
+does not appear in `required_slots`, since `required_slots` is — per your own §4 trap — the
+enumerator of what a target environment must supply.
+
+We have marked all 13 in-place with a comment saying they are declared under protest, so whoever
+reads them next does not tidy the note away. If a mechanism lands, they move to it.
+
+---
+
+## 5. Migration status
+
+Swept every `config.toml` under `built-in/`. **14 refused, 13 now pack.**
+
+| Deferred key | Servers |
+|---|---|
+| `code_mode.token_secret` → `CODE_MODE_SECRET` | 12 (13th, `bt-availability`, fixed the day before) |
+| `backend.auth.*` — api key, bearer token, client id + secret, query param | 5 |
+| `backend.base_url`, `backend.auth.token_url` | 2 (endpoints) |
+
+Two notes on method, both because of warnings in your §2:
+
+- **We walked the parsed TOML, not the text.** Tables only, whole-value only. Your warning that a
+  regex flags JS template placeholders in tool scripts is correct and we would have hit it — our
+  configs carry `${line.id}`-style placeholders inside `[[tools]]`, a different `${}` namespace
+  that no slot can name.
+- **Classification was not mechanical.** `secret` carries no `tested_value` and is therefore the
+  only kind writable without inventing a value, which makes it the tempting default for
+  everything. We did not take it: only behaviour-relevant slots are visible to
+  `detect_deviation`, so declaring a URL as `secret` to dodge the `tested_value` requirement
+  would silently hide it from deviation detection. `graphrag-admin`'s `token_url` is declared
+  `endpoint`, with the `tested_value` read from the live function rather than composed.
+
+**Two remain unfixed, deliberately:**
+
+1. `rest-admin` → `backend.base_url`. `REST_ADMIN_ENDPOINT` is not set on the deployed function,
+   so there is no truthful `tested_value` available. We are not inventing one to clear a gate.
+2. `bt-availability` → `${BT_CUG}`. Embedded in a JSON request-body template inside an array —
+   out of reach by both of your §2 boundaries, exactly as your §3 predicted. Your framing is
+   right that this needs composing into a whole-value key before it can be named; that is a
+   config-shape change we have not made yet.
+
+---
+
+## What we owe you next
+
+- The **0.1.0 → 0.3.1 migration** on both package Lambdas (§1.3). This gates the fixture run and
+  any gate work; we are treating it as the prerequisite.
+- The **fixture run** (§7.3), after that migration, so the result means something.
+- `getPackageArtifact` and the four SDL questions (§7.1, §7.2) remain parked and unmoved. On SDL
+  question 2 — `payloadDigest` as OCI manifest digest versus a digest over the tar bytes — we
+  agree it is the one most likely to bite silently and it is on our list, not answered here.

--- a/docs/platform-requests/package-format-031-released-platform-handoff.md
+++ b/docs/platform-requests/package-format-031-released-platform-handoff.md
@@ -1,0 +1,250 @@
+# `pmcp-package` 0.3.1 is on crates.io — the git pin is retired, and there is one new format rule
+
+**To:** pmcp.run platform dev team
+**From:** SDK / cargo-pmcp side (`paiml/rust-mcp-sdk`)
+**Date:** 2026-08-28
+**Re:** AI-Package handoff — what unblocked, what changed under you, what is yours to build
+**Supersedes:** `package-format-030-pin-for-platform.md` (its §1 pin and §6 release table are
+now obsolete; its §3 tar-framing corpus is unchanged and still the thing to build against)
+
+Everything the previous note asked you to pin by git rev is now published. This note is the
+new pin, the one **new format rule** that lands on both packers, a migration you have to do
+on at least one shipped built-in, and an honest accounting of one decision we asked you for
+and then shipped past.
+
+| What | Where |
+|---|---|
+| The pin — crates.io, no more git rev | §1 |
+| **New: the CONFIG → SLOT gate, and why it is a two-sided rule** | **§2** |
+| **A migration you owe at least one built-in** | **§3** |
+| Where the boundary actually runs | §4 |
+| Three gaps the gate does NOT close — read before relying on it | §5 |
+| A decision we asked for, and shipped past | §6 |
+| Still parked on you, unchanged | §7 |
+
+---
+
+## 1. The pin
+
+Replace the git rev from the previous note with:
+
+```toml
+[dependencies]
+pmcp-package = "0.3.1"
+```
+
+Tag `v2.19.2` published this set. Measured against the crates.io API on 2026-08-28, not
+quoted from a plan:
+
+| crate | published |
+|---|---|
+| `pmcp-package` | **0.3.1** |
+| `cargo-pmcp` | **0.23.1** |
+| `pmcp-agent` | 0.3.0 |
+| `pmcp-team-servers` | 0.2.0 |
+| `pmcp-cfn-renderer` | 0.2.0 |
+| `pmcp` | 2.19.2 |
+
+The 0.3.0 → 0.3.1 delta is API-**additive** (`cargo semver-checks` against published 0.3.0:
+196/196, "no semver update required"), so if you already built against the 0.3.0 git rev,
+nothing you wrote stops compiling. The behaviour change is in §2 and it is not additive.
+
+`crates/pmcp-package/CHANGELOG.md` is now accurate through 0.3.1 — the previous note's §4.2
+("the CHANGELOG is stale, do not use it as the delta") is **resolved**. Use it as the delta.
+
+---
+
+## 2. New in 0.3.1: the CONFIG → SLOT gate
+
+### What was broken
+
+`pack_server` validated in one direction only. Both existing document gates started from
+`package.config_slots` and asked *"is every declared slot well-formed, and does it point at a
+placeholder?"* — a good question, correctly gated. Neither asked the converse. A config
+declaring **no** slots satisfied both trivially, because iterating an empty list finds no
+violations.
+
+The result: a server config carrying `${...}` references packed at **exit 0** and unpacked
+reporting *"This package declares no config slots — nothing to fill."* Since the slot list is
+the entire mechanism for telling a target environment what it must supply, that produced a
+package which installs cleanly into a new environment and then cannot authenticate.
+
+This was found on **`bt-availability`, one of your built-ins** — four env references, four
+`[[secrets.definitions]]`, zero `[[config_slots]]`. See §3.
+
+### The rule, stated for both implementations
+
+> A conformant server package's `config_slots` must name every **slot-addressable
+> whole-value** environment reference in its config document.
+
+0.3.1 enforces it in `pack_server` via `validate_no_undeclared_env_refs`, fail-closed. It is
+exported at the crate root beside its two siblings, so you can run it standalone as a
+pre-check:
+
+```rust
+pmcp_package::validate_no_undeclared_env_refs(config_bytes, &slots)?;
+```
+
+**This is why it is in this note and not just in our CHANGELOG.** Per the standing framing
+that package work is two-sided: your capture path writes packages too. If your packer does not
+apply this rule, platform-produced packages will under-report their requirements while
+SDK-produced ones do not — and the divergence is silent on both sides, because an
+under-declared package is structurally indistinguishable from a package that genuinely needs
+nothing. Add it to the four drift modes we already track (media-type strings, manifest shape,
+slot vocabulary/classification, baked-vs-slot split); it has the same signature — no loud
+error, a package that looks fine.
+
+### Two scope boundaries that are load-bearing, not incidental
+
+Both exist because the gate must only demand what a config author can actually express:
+
+- **Arrays are not descended.** `resolve_dotted_key` addresses TOML *tables* only — array
+  indexing is outside the `config_key` grammar — so a reference inside `[[tools]]` or
+  `[[resources]]` is unnameable by any slot. Demanding one would be a demand nobody could
+  satisfy. This is also what keeps the gate off JS template placeholders that live in tool
+  scripts (`${line.id}`) — a different `${}` namespace entirely. **A naive document-wide text
+  scan flags those**, and would have flagged our own golden fixture; if you implement this
+  with a regex over the file, that is the first thing you will hit.
+- **Whole-value references only**, per the pinned grammar
+  (`tests/golden_fixtures/env_ref_grammar_v1.tsv`, where `${A}-${B}` and `${VAR}-suffix` are
+  reject rows). An embedded reference is not fillable through a slot by any environment, so
+  the gate does not pretend otherwise.
+
+Together these mean **every reference the gate reports is one a config author can declare** —
+which is the property that makes fail-closed tolerable.
+
+A third boundary, stated so nobody plans against a safety net that is not there: **the gate is
+pack-time only.** It never re-verifies an existing artifact. Every package built before 0.3.1
+keeps the defect silently, and `cargo pmcp package load` still renders "nothing to fill" from
+the package's *claim* rather than from the config bytes sitting beside it in `UnpackedServer`.
+Surfacing that at import is a live option on both sides and neither has built it.
+
+---
+
+## 3. The migration you owe
+
+`bt-availability` will now be **refused** by `cargo pmcp package save`. So will any config of
+that shape. The remedy is mechanical — declare a slot per deferred key:
+
+```toml
+[[config_slots]]
+key  = "backend.auth.client_id"
+kind = "secret"
+name = "BT_CLIENT_ID"
+```
+
+`kind` is the closed vocabulary `endpoint | secret | auth_mode`. `secret` is identity-bearing
+and structurally carries **no** `tested_value` — the toolkit's own `validate()` rejects one.
+
+For `bt-availability` specifically, three of its four references need declarations
+(`BT_CLIENT_ID`, `BT_CLIENT_SECRET`, `CODE_MODE_SECRET`). The fourth, `${BT_CUG}`, sits inside
+a request-body template — embedded, and inside an array — so it is out of the gate's reach by
+both boundaries in §2. That is not the gate being lenient: **no slot can name it today**, so
+if that value genuinely needs to come from the environment, it needs to be composed into one
+whole-value key first. Worth a decision on your side rather than leaving it as-is.
+
+`[[secrets.definitions]]` is **not** read as a declaration and will not satisfy the gate. We
+considered treating it as a second source and decided against it: it is not in the toolkit's
+`ServerConfig` schema (which is `deny_unknown_fields` throughout), so honouring it would mean
+this crate blessing a schema it does not own. The error message names the block when it is
+present, as a hint, but `[[config_slots]]` is the only source of truth. **If you want that
+changed, this is the moment to say so** — it is a small change now and a format break later.
+
+For calibration: we ran the same sweep across this repo and found **11 refused configs** of
+our own, plus two READMEs and three scaffold templates teaching the refused shape. All are
+migrated in `v2.19.2`. Expect a similar sweep on your side to find more than the one built-in
+that triggered this.
+
+---
+
+## 4. Where the boundary runs
+
+Restating this because the previous notes have drifted toward an ask-list framing, and the
+useful framing is which side is *authoritative* for what:
+
+| Concern | Authoritative side | Notes |
+|---|---|---|
+| Package **format** + validation rules | SDK (`pmcp-package`) | Both sides implement them |
+| **Artifact tar framing** | SDK, normative for both | `src/oci/mod.rs` "Artifact tar framing" + the 12 golden fixtures |
+| env-ref **grammar** | shared, pinned | `env_ref_grammar_v1.tsv`, asserted from `pmcp-package` AND `pmcp-server-toolkit` |
+| Slot **vocabulary** + classification | SDK | `endpoint \| secret \| auth_mode`; identity-bearing vs behavior-relevant |
+| `getPackageArtifact` + the **egress API** | **Platform** | §7 |
+| **Built-in configs** and their slot declarations | **Platform** | §3 |
+| Attestation **issuance** | **Platform** | SDK carries it opaquely; never parses the payload |
+
+The one semantic trap worth repeating in any import-facing surface you build: **`required_slots`
+is the enumerator of what a target environment must supply. `detect_deviation` structurally
+cannot name a credential** — it short-circuits on identity-bearing slots, and
+`SlotType::Secret` has no value field. Our own roadmap had this backwards until Phase 121.
+
+---
+
+## 5. Three gaps the gate does NOT close
+
+Recorded in the crate CHANGELOG under *"Known gaps this patch does NOT close"*, and repeated
+here because the gate's name invites more confidence than it has earned:
+
+1. **Variable-NAME agreement is ungated.** The gate matches on the config **key** only. A slot
+   declaring `name = "TFL_BASE_URL"` at `backend.base_url` packs green beside
+   `base_url = "${SOMETHING_ELSE}"`. The operator sets one variable, the server reads another
+   — the *same* "installs cleanly, then cannot start" failure this patch exists to close,
+   reachable by a one-word typo. **If you are building import-side validation, this is the
+   highest-value thing you could add**, and we would take a PR or match your semantics.
+2. **The five non-value slot kinds have no expressible declaration.** With a `config_key` the
+   forward gate refuses them ("no config-value semantics"); without one they contribute
+   nothing and this gate refuses the reference. `ACCEPTED_KINDS` cannot express them. If you
+   need OAuth-client slots bound to config keys, say so — it needs a design decision, not a
+   patch.
+3. **`${VAR}` at an `auth_mode` key** is demanded as a slot, and obeying that advice yields a
+   package that packs green and fails at boot: `AuthConfig` is internally tagged, so
+   `type = "${AUTH_MODE}"` is an unparseable `unknown variant`. The correct remedy is to bake
+   the literal, which the message does not say.
+
+---
+
+## 6. `#[non_exhaustive]` — we asked, and then shipped past it
+
+The previous note's §4.1 asked you to choose, and argued that the 0.3.0 tag was "the cheapest
+moment there will ever be". **We then shipped 0.3.0 and 0.3.1 without an answer, so that
+moment is gone.** Flagging it plainly rather than quietly re-asking.
+
+Current state, verified: `PackageError` has **11 variants**, derives only
+`Debug, thiserror::Error`, and is **not** `#[non_exhaustive]`. 0.3.1 added no variant — the
+gate reuses `ConfigSlotViolation` — so nothing broke this time, and any exhaustive `match` you
+wrote against 0.3.0 still compiles.
+
+The trade is unchanged and it is still yours, because it is your ergonomics we would be
+spending: `#[non_exhaustive]` costs you a `_ =>` arm and the loss of compiler notification when
+we add a variant; without it you keep exhaustiveness checking and absorb a break each time we
+add one. The next breaking bump is now the cheap moment. Tell us and we will land it there.
+
+---
+
+## 7. Still parked on you — unchanged
+
+Carried forward from `package-portability-verb-set-sdk-note.md` §4–5, none of which moved:
+
+1. **`getPackageArtifact` on your AppSync API.** `cargo pmcp package pull` is landed and
+   tested offline against golden fixtures; its live leg goes green the day your backend ships,
+   with no SDK change needed.
+2. **The four open SDL questions**, written as `OPEN QUESTION TO THE PLATFORM` comments on the
+   arguments they concern in `contracts/pmcp-run/portability-v1.graphql`. Question 2 —
+   whether `payloadDigest` is the OCI manifest digest or a digest over the tar bytes — remains
+   the one most likely to bite silently: both readings produce a plausible digest string and a
+   mismatch surfaces as "image not found" rather than as a contract error.
+3. **Run your unpack against the 12 tar-framing fixtures**
+   (`crates/pmcp-package/tests/golden_fixtures/artifact_tar_v1/`). Eleven must be refusals. If
+   your reader accepts any hostile fixture, that is worth a message before either side ships.
+   These are checked-in bytes and are never regenerated from the writer under test — a fixture
+   produced by the code it tests agrees with that code by construction and can never detect the
+   drift it exists to detect.
+
+---
+
+## What we would like back
+
+- **Confirmation the §2 rule is implemented on your packer**, or a counter-proposal if you
+  think the boundaries in §2 are drawn wrong.
+- **A decision on `[[secrets.definitions]]`** (§3) and on `#[non_exhaustive]` (§6).
+- **Your read on gap 1** (§5) — variable-name agreement is the one we would most like to close
+  symmetrically rather than in one implementation.

--- a/scripts/named-test-binary-count.awk
+++ b/scripts/named-test-binary-count.awk
@@ -98,6 +98,15 @@ BEGIN { ansi = sprintf("%c", 27) "\\[[0-9;]*[a-zA-Z]" }
 
 $1 == "Running" && $2 == want { seen = 1; next }
 
+# The UNITTEST form, for `--lib` / `--bins` targets. Cargo prints
+# `Running unittests src/lib.rs (...)`, so the path lands in $3 and $2 is the
+# literal `unittests` -- the rule above can never match it. Documented in the
+# field-splitting table at the top of this file since it was written; without
+# this rule a caller passing want="src/lib.rs" gets -1 ("never RAN") for a
+# target that ran perfectly, which is a false ALARM rather than a false pass,
+# but still sends the reader hunting for a renamed file.
+$1 == "Running" && $2 == "unittests" && $3 == want { seen = 1; next }
+
 seen && $1 == "test" && $2 == "result:" {
     print $4 + 0
     printed = 1


### PR DESCRIPTION
## What

Two things: the **`--binary` inputs** for `cargo pmcp package save`, and the **documented close of the env-surface exchange** with the pmcp.run platform team (whose four reply documents ride along on this branch — they were committed into this repo and are not upstream yet).

## `package save` learns where the binary is

`--binary-digest` was required with no default, so packing meant hand-computing a `shasum` even though `cargo pmcp deploy` had just built the exact bytes. Three mutually-exclusive inputs now:

| Flag | Behaviour |
|---|---|
| *(none)* | references `deploy/.build/bootstrap`, digest derived from it |
| `--binary-from <path>` | references that file, digest derived |
| `--binary <path>` | **embeds** the bytes; self-contained package |
| `--binary-digest sha256:…` | references a supplied digest (CI) |

Deriving from bytes removes the class where digest and binary disagree because a human typed one. **Referencing stays the default** — a config server should name its runtime, and a team package sharing one MCP server across N agents would otherwise carry it N times. The embedded-digest trade (digest moves on every rebuild, including byte-identical-source rebuilds on a different toolchain) is documented in `--binary`'s long help and the README.

11 tests: 6 on the pure resolver, 5 CLI round-trips asserting embedded bytes return byte-identical and derived digests match an independent computation.

## The gate was reaching 524 of 1451 tests

`test-cargo-pmcp` ran `cargo test -p cargo-pmcp --lib`. But `cargo-pmcp/src/lib.rs` declares no `mod commands` — every command lives under `main.rs`, so **all of `src/commands/**`** (save, load, deploy, doctor, secret, package) compiled into the *bin* target and its 927 unit tests were reached by nothing.

Found only because new tests passed locally and didn't appear in the gate log.

The **guard** was the deeper problem: `ran -eq 0` can detect an empty selection, never an incomplete one, so it stayed green at 524 the whole time. It now asserts a **per-target** count via `scripts/named-test-binary-count.awk` — the machinery the sibling leg already used, whose own comment states the principle ("a nonzero SUM proves the SELECTION ran, not that any particular binary ran"). Mutation-proven: dropping `--bins` exits 2 instead of passing.

## The exchange, and a correction

The severance agreed with the platform: env-var work is **two independent requirements** — DX (subject: source code) and AI-Package portability (subject: artifact) — and they must not be joined. The package's guarantee is **verifiability at rest**: a holder re-derives the slot list from the artifact with zero trust in the packer. So a compile-time env surface must never become the package's slot source. **A generates, B verifies.**

This branch also **retracts an error of ours**. `env-surface-sdk-signoff.md` told the platform that `supplied_by` on `ConfigSlot` was source-breaking and forced `pmcp-package` 0.4.0 plus a coordinated five-crate release. They accepted it, independently "confirmed" it, and retargeted their package-Lambda migration to that window — which gates their tar-framing fixture run.

It is additive: `ConfigSlot` is already `#[non_exhaustive]`, there are zero genuine struct literals anywhere, and `cargo semver-checks` against published 0.3.1 reports **196/196, "no semver update required."** Both sides erred the same two ways — a grep matching `-> ConfigSlot {` signatures and the unrelated `DeclaredConfigSlot`, and reading `types.rs`'s historical `config_key` comment as present tense when the `#[non_exhaustive]` added *because of* it sits a few lines below.

## Versions

`cargo-pmcp` **0.23.1 → 0.24.0** (new CLI flags; `--binary-digest` going optional breaks no existing invocation). Nothing pins it; all four template drift guards pass. Root CHANGELOG deliberately untouched — `## [Unreleased]` is what `release.yml` hard-exits on and nothing here is released yet.

## Testing

`RUSTFLAGS="" make quality-gate` — **exit 0, 8304 passed, 0 failed**, zero `make: ***` lines, banner present, and both per-target assertions (`src/lib.rs` 524, `src/main.rs` 927).

## Not in this PR

- **R1/R2** (`supplied_by`, the binary-server gate) — parked on a local `wip/r1-supplied-by`. It must not ship without R1.2's labelled `inspect`/`load` section: `required_slots` already filters, so shipping alone would hide slots with nothing rendering them.
- **`cargo pmcp package` has no `pmcp-book` or `pmcp-course` coverage at all** — zero chapters mention it. Wider than this change, and worth its own work if the package workflow is an on-ramp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
