### PR TITLE
feat(R1): config slots declare who fills them (supplied_by); pmcp 2.19.3 carrier release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.19.3] - 2026-08-30
+
+**A carrier release, following the v2.19.2 and v2.19.1 precedent.** No `pmcp`
+source changed since 2.19.2 — `pmcp` moves 2.19.2 → 2.19.3 solely to mint the
+tag that carries `pmcp-package` 0.4.0 and four sibling crates to crates.io,
+because this repo tags on the `pmcp` version and a `v*` tag is the only path
+those crates have to the registry.
+
+The heading is the version, NOT `[Unreleased]`:
+`.github/workflows/release.yml`'s `create-release` job extracts notes with
+`awk 'index($0, "## [" ver "]") == 1'` and **exits 1** when no section matches
+the tag, *before* any publish step runs.
+
+`pmcp`'s patch bump needs no downstream pin changes — the caret exception.
+Every in-tree `pmcp` requirement is `^2.x` with x ≤ 19, and `^2.19.0` already
+admits 2.19.3, so no pin moves and no crate is bumped on `pmcp`'s account.
+
+### What this tag carries
+
+| Crate | From | To | Why |
+|---|---|---|---|
+| `pmcp-package` | 0.3.1 | **0.4.0** | `supplied_by` on config slots; source-breaking |
+| `pmcp-agent` | 0.3.0 | 0.4.0 | pins `pmcp-package` `^0.3` → `^0.4` |
+| `pmcp-team-servers` | 0.2.0 | 0.3.0 | pins `pmcp-package` and `pmcp-agent` |
+| `pmcp-cfn-renderer` | 0.2.0 | 0.3.0 | pins `pmcp-package` |
+| `pmcp-server-toolkit` | 0.1.2 | 0.1.3 | `supplied_by` on `ConfigSlotDecl` |
+| `cargo-pmcp` | 0.24.0 | 0.24.0 | unpublished; R1 folds into it |
+
+### Added — a config slot can declare WHO fills it
+
+A `[[config_slots]]` entry may now carry `supplied_by = "environment"` (the
+default), `"platform"` or `"runtime"`:
+
+```toml
+[[config_slots]]
+key = "backend.base_url"
+kind = "endpoint"
+name = "TFL_BASE_URL"
+tested_value = "https://api.tfl.gov.uk"
+supplied_by = "platform"
+```
+
+`cargo pmcp package save` carries the declaration into the package;
+`package load`/`pull` render such slots under a labelled **"Supplied by the host
+at deploy time"** section rather than demanding them of an operator. Absent
+means `environment`, so every config written before this release keeps its exact
+meaning.
+
+This is the "A generates, B verifies" severance in practice: the config document
+is the source of truth for who fills a slot, it travels inside the artifact, and
+a holder re-derives the split from the artifact alone.
+
+**Three crates had to move together.** `pmcp-package` refuses to pack a config
+carrying a field the SERVER would reject at boot, and the toolkit's
+`ConfigSlotDecl` is `#[serde(deny_unknown_fields)]`. Teaching only the packer
+would make every config using the field unpackable; teaching only the runtime
+would have the packer reject configs the server boots from happily. Each side
+now carries a test pinning the other.
+
+An unrecognized `supplied_by` VALUE is **refused**, never defaulted — silently
+reading it as `environment` would tell an operator to supply a value the
+platform actually injects, which is the confusion the field exists to remove.
+
+### Breaking — `pmcp-package` 0.4.0
+
+Measured with `cargo semver-checks check-release --baseline-version 0.3.1`:
+one major failure. `DeclaredConfigSlot` was externally constructible, so its new
+`supplied_by` field breaks struct literals. It is now `#[non_exhaustive]` — the
+same remedy `ConfigSlot` received after the `config_key` break — so the next
+field addition costs nothing. Consumers move `^0.3` → `^0.4`; all four in-tree
+consumers already have.
+
+`required_slots` no longer enumerates host- or runtime-supplied slots, and
+`validate_config_slot_agreement` now refuses a `supplied_by` disagreement
+between the config and the package.
+
+### Note on `pmcp-server-toolkit` 0.1.3
+
+Its `ConfigSlotDecl` field addition is the same class of source break, taken as
+a PATCH by deliberate decision rather than oversight. `^0.1.x` admits 0.1.3, so
+its seven consumer pins do not move and this release is five crates rather than
+about twelve. Justified by zero in-tree `ConfigSlotDecl` struct literals (it is
+a deserialization target) and no CI semver gate. Recorded here so a future
+releaser sees the reasoning.
+
 ## [2.19.2] - 2026-08-28
 
 **A carrier release, following the v2.19.1 precedent.** No `pmcp` source changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp"
-version = "2.19.2"
+version = "2.19.3"
 edition = "2021"
 authors = ["PAIML Team"]
 description = "High-quality Rust SDK for Model Context Protocol (MCP) with full TypeScript SDK compatibility"

--- a/cargo-pmcp/CHANGELOG.md
+++ b/cargo-pmcp/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [0.24.0] - 2026-08-29
 
+### Added (R1, folded into this unreleased version)
+
+- **`package load`/`pull` render a *"Supplied by the host at deploy time"*
+  section.** Slots a config declares as `supplied_by = "platform"` or
+  `"runtime"` are excluded from *"Required slots"* — no operator fills them —
+  but are still shown, attributed, with their tested value. A slot nobody is
+  asked for and nothing displays is invisible, and a reader could not otherwise
+  tell "this package needs nothing here" from "this package never said".
+
+- **`package save` carries a declaration's `supplied_by` into the package.** The
+  config document is the source of truth for who fills a slot; the CLI does not
+  infer it.
+
+### Changed
+
+- `pmcp-package` pin moves `0.3` -> `0.4`, `pmcp-agent` `0.3` -> `0.4`,
+  `pmcp-team-servers` `0.2` -> `0.3`, `pmcp-cfn-renderer` `0.2` -> `0.3`. The
+  scaffold emitters `PMCP_PACKAGE_VERSION_REQ`, `PMCP_AGENT_VERSION` and
+  `TOOLKIT_VERSION` move with them; each has a drift test, and
+  `PMCP_AGENT_VERSION`/`TOOLKIT_VERSION` are invisible to the compiler because
+  they are emitted into scaffolded projects.
+
 ### Added
 
 - **`package save` learns where the binary is.** Three mutually-exclusive inputs

--- a/cargo-pmcp/Cargo.toml
+++ b/cargo-pmcp/Cargo.toml
@@ -76,20 +76,20 @@ pmcp-workbook-compiler = { version = "0.1.0", path = "../crates/pmcp-workbook-co
 # Phase 110 agent/team/package verbs. Path wins locally; the version req applies
 # at publish (design §5: cargo-pmcp now publishes AFTER all three).
 # `openai-compat` enables the default `agent dev` completion source.
-pmcp-agent = { version = "0.3", path = "../crates/pmcp-agent", features = ["openai-compat"] }
+pmcp-agent = { version = "0.4", path = "../crates/pmcp-agent", features = ["openai-compat"] }
 # `runtime` = the in-process team-dev server set; `http` = the HTTP-first
 # `team dev --serve` path AND transitively enables `member-llm` (so `team dev
 # --llm` works with `http` alone — do NOT list `member-llm` explicitly).
-pmcp-team-servers = { version = "0.2", path = "../crates/pmcp-team-servers", features = ["runtime", "http"] }
+pmcp-team-servers = { version = "0.3", path = "../crates/pmcp-team-servers", features = ["runtime", "http"] }
 # Caret "0.3" exactly (CLI-04 / D-04b — `tests/pmcp_package_pin.rs` asserts this
 # literal string; do NOT use `=0.3.0` or a fully-qualified `0.3.0`). Moved off
 # the 0.1 line by the D-08/D-09 wire break in Phase 120, and off the 0.2 line by
 # Phase 122's four source-breaking attestation-carriage changes.
-pmcp-package = { version = "0.3", path = "../crates/pmcp-package" }
+pmcp-package = { version = "0.4", path = "../crates/pmcp-package" }
 # CFN-renderer extraction, Task 7: the pmcp_run deploy target synthesizes its
 # CloudFormation template via this pure renderer instead of `npx cdk synth`
 # whenever `deploy/lib/stack.ts` is unmodified from the regenerated scaffold.
-pmcp-cfn-renderer = { version = "0.2", path = "../crates/pmcp-cfn-renderer" }
+pmcp-cfn-renderer = { version = "0.3", path = "../crates/pmcp-cfn-renderer" }
 # The `agent new` scaffold builds a starter `AgentPackage` from the real struct
 # (guaranteeing the emitted agent.package.json round-trips); its `version` field
 # is a `semver::Version`, so cargo-pmcp needs semver directly (matches the

--- a/cargo-pmcp/src/commands/package/render.rs
+++ b/cargo-pmcp/src/commands/package/render.rs
@@ -62,7 +62,9 @@ use std::fmt::Write as _;
 
 use pmcp_package::oci::UnpackedAttestation;
 use pmcp_package::reference::ComponentType;
-use pmcp_package::{required_slots, ComponentRef, ConfigSlot, SlotClass, SlotType};
+use pmcp_package::{
+    classify_slots, required_slots, ComponentRef, ConfigSlot, SlotClass, SlotType, SuppliedBy,
+};
 
 /// Width of the `label:` column, matching `inspect.rs`'s `field` helper so the
 /// two commands line up visually.
@@ -120,6 +122,7 @@ pub fn render_report(report: &PackageReport<'_>) -> String {
     let mut out = String::new();
     out.push_str(&render_identity(report));
     out.push_str(&render_required_slots(report.slots));
+    out.push_str(&render_host_supplied_slots(report.slots));
     out.push_str(&render_component_pins(report.components));
     out.push_str(&render_carriage(report.attestation));
     out
@@ -209,6 +212,89 @@ pub fn render_required_slots(slots: &[ConfigSlot]) -> String {
         // slot has no value field in the type at all, so there is nothing here
         // to leak — the absence is structural, not a filter that could be
         // forgotten.
+        if let Some(tested) = entry.slot.tested_value() {
+            field(&mut out, "      ", "Tested value", &untrusted(tested));
+        }
+    }
+    out
+}
+
+/// Render the slots the HOST or RUNTIME injects — the ones no operator fills.
+///
+/// # Why this section exists
+///
+/// [`required_slots`] deliberately excludes these: asking an operator to supply
+/// a value the platform injects is wrong, and a package that demanded them
+/// would be unfillable. But excluding them from the DEMAND must not exclude
+/// them from the RECORD. A slot nobody is asked for and nothing displays is
+/// invisible, and a reader cannot tell "this package needs nothing here" from
+/// "this package never said" — which is precisely the ambiguity
+/// [`SuppliedBy`] was introduced to remove.
+///
+/// So this section is not decoration; it is the other half of the filter. It is
+/// omitted entirely when there is nothing to report, so an ordinary
+/// all-operator-supplied package renders exactly as it did before.
+///
+/// # Complement by construction
+///
+/// Both sections are built from one [`classify_slots`] list split on one
+/// predicate, so every declared slot appears in exactly one of them. This is
+/// deliberately NOT a second independent filter over `slots` — two predicates
+/// could drift apart, and a slot that fell out of both would be invisible in
+/// the exact way this section exists to prevent.
+///
+/// # Ordering
+///
+/// Exactly [`classify_slots`]' order, which is `required_slots`' order. Nothing
+/// is re-sorted here.
+#[must_use]
+pub fn render_host_supplied_slots(slots: &[ConfigSlot]) -> String {
+    let mut out = String::new();
+
+    let host_supplied: Vec<_> = classify_slots(slots)
+        .into_iter()
+        .filter(|entry| !entry.supplied_by.is_operator_supplied())
+        .collect();
+
+    // Nothing to say: omit the heading rather than print an empty section, so a
+    // package with no host-supplied slots renders byte-identically to before.
+    if host_supplied.is_empty() {
+        return out;
+    }
+
+    section(&mut out, "Supplied by the host at deploy time");
+    let _ = writeln!(
+        out,
+        "  Listed for the record — no operator action is required for these."
+    );
+    for (position, entry) in host_supplied.iter().enumerate() {
+        let (kind, name) = entry.slot.key();
+        let source = match entry.supplied_by {
+            SuppliedBy::Platform => "platform (injected by the host at deploy time)",
+            SuppliedBy::Runtime => "runtime (injected by the execution environment)",
+            // `SuppliedBy` is `#[non_exhaustive]`, so this arm is required.
+            // `Environment` cannot reach it (filtered out above), which leaves
+            // only a variant added after this code was written. Say exactly
+            // that rather than guessing it resembles one of the two above — a
+            // wrong label here would misreport who fills a slot.
+            _ => "an unrecognized source — this package may need a newer CLI",
+        };
+        let _ = writeln!(out, "\n  [{}] {kind}", position + 1);
+        let name_label = match entry.slot {
+            SlotType::HumanRole { .. } => "Role",
+            _ => "Env var",
+        };
+        field(&mut out, "      ", name_label, &untrusted(name));
+        field(&mut out, "      ", "Supplied by", source);
+        match entry.config_key.as_deref() {
+            Some(key) => field(&mut out, "      ", "Config path", &untrusted(key)),
+            None => field(&mut out, "      ", "Config path", "fills no config key"),
+        }
+        // Shown because `supplied_by` is ORTHOGONAL to `kind`: a
+        // platform-supplied endpoint stays deviation-visible, and
+        // `detect_deviation` compares against exactly this value. Omitting it
+        // would hide the baseline of a comparison the package still makes.
+        // Identity-bearing slots structurally have none, so nothing prints.
         if let Some(tested) = entry.slot.tested_value() {
             field(&mut out, "      ", "Tested value", &untrusted(tested));
         }
@@ -485,6 +571,73 @@ mod tests {
             },
             issuer: "https://issuer.test.invalid/pmcp-run".to_string(),
             payload_type: "application/vnd.test.attestation-payload".to_string(),
+        }
+    }
+
+    /// R1.2: a host-supplied slot is EXCLUDED from "Required slots" but still
+    /// appears, under its own heading, naming who supplies it.
+    ///
+    /// This is the pair of assertions that matters: absent from the demand,
+    /// present in the record. Asserting only the first would pass on the
+    /// invisibility bug.
+    #[test]
+    fn a_host_supplied_slot_leaves_the_required_list_but_is_still_rendered() {
+        let platform_endpoint = endpoint_slot().with_supplied_by(SuppliedBy::Platform);
+        let slots = vec![secret_slot(), platform_endpoint];
+
+        let required = render_required_slots(&slots);
+        let host = render_host_supplied_slots(&slots);
+
+        // Absent from the demand: the operator is not asked for it.
+        assert!(
+            !required.contains("TFL_BASE_URL"),
+            "a platform-injected slot must not be demanded of the operator: {required}"
+        );
+        assert!(required.contains("TFL_APP_KEY"), "{required}");
+
+        // Present in the record, and attributed.
+        assert!(
+            host.contains("Supplied by the host at deploy time"),
+            "the section heading is missing: {host}"
+        );
+        assert!(
+            host.contains("TFL_BASE_URL"),
+            "the excluded slot vanished entirely — this is the invisibility bug: {host}"
+        );
+        assert!(host.contains("Supplied by:"), "{host}");
+        assert!(host.contains("platform"), "{host}");
+    }
+
+    /// The section is omitted entirely when nothing is host-supplied, so an
+    /// ordinary package's report is unchanged by this feature.
+    #[test]
+    fn an_all_operator_supplied_package_renders_no_host_section() {
+        let rendered = render_host_supplied_slots(&[secret_slot(), endpoint_slot()]);
+        assert!(
+            rendered.is_empty(),
+            "an all-operator-supplied package must render no extra section: {rendered}"
+        );
+    }
+
+    /// Every declared slot reaches exactly one of the two sections. A slot in
+    /// neither is invisible; a slot in both would be double-counted.
+    #[test]
+    fn the_two_sections_together_account_for_every_slot() {
+        let slots = vec![
+            secret_slot(),
+            endpoint_slot().with_supplied_by(SuppliedBy::Platform),
+        ];
+        let required = render_required_slots(&slots);
+        let host = render_host_supplied_slots(&slots);
+
+        for name in ["TFL_APP_KEY", "TFL_BASE_URL"] {
+            let in_required = required.contains(name);
+            let in_host = host.contains(name);
+            assert!(
+                in_required ^ in_host,
+                "{name} must appear in exactly one section \
+                 (required={in_required}, host={in_host})"
+            );
         }
     }
 

--- a/cargo-pmcp/src/commands/package/save.rs
+++ b/cargo-pmcp/src/commands/package/save.rs
@@ -421,7 +421,13 @@ fn slot_from_declaration(declaration: &DeclaredConfigSlot) -> Result<ConfigSlot>
             declaration.key
         ),
     };
-    Ok(ConfigSlot::new(slot).with_config_key(declaration.key.as_str()))
+    // `supplied_by` is carried straight through from the declaration: the config
+    // document is the source of truth for who fills a slot ("A generates, B
+    // verifies"), and `parse_declared_config_slots` has already refused anything
+    // outside the closed vocabulary.
+    Ok(ConfigSlot::new(slot)
+        .with_config_key(declaration.key.as_str())
+        .with_supplied_by(declaration.supplied_by))
 }
 
 /// Build the `ServerPackage` from the two files the user maintains (D-10).

--- a/cargo-pmcp/src/templates/agent.rs
+++ b/cargo-pmcp/src/templates/agent.rs
@@ -46,7 +46,7 @@ use pmcp_package::{AgentPackage, ConfigSlot, SlotType};
 /// asserts this equals the workspace `crates/pmcp-agent` package version so the
 /// hardcoded pin cannot silently drift from the released crate (D-05) —
 /// mirroring the `workbook_server::PMCP_VERSION` drift guard.
-const PMCP_AGENT_VERSION: &str = "0.3.0";
+const PMCP_AGENT_VERSION: &str = "0.4.0";
 
 /// The `pmcp-package` version REQUIREMENT the emitted `Cargo.toml` declares —
 /// a caret major.minor line, not a full version.
@@ -64,7 +64,7 @@ const PMCP_AGENT_VERSION: &str = "0.3.0";
 /// reverting ONLY this line leaves `cargo build --workspace` green while
 /// `emitted_package_requirement_matches_workspace_major_minor_line` goes red.
 /// The compiler is not this emitter's tripwire; that test is.
-const PMCP_PACKAGE_VERSION_REQ: &str = "0.3";
+const PMCP_PACKAGE_VERSION_REQ: &str = "0.4";
 
 /// Emit the files of a single runnable agent crate into `dir`.
 pub fn generate(dir: &Path, name: &str) -> Result<()> {

--- a/cargo-pmcp/src/templates/workbook_server.rs
+++ b/cargo-pmcp/src/templates/workbook_server.rs
@@ -56,7 +56,7 @@ const PMCP_VERSION: &str = "2.19.2";
 /// test asserts this equals the workspace `pmcp-server-toolkit` package version so
 /// the hardcoded pin cannot silently drift from the released crate (ME-01) —
 /// mirroring the `PMCP_VERSION` drift guard.
-const TOOLKIT_VERSION: &str = "0.1.2";
+const TOOLKIT_VERSION: &str = "0.1.3";
 
 /// Emit the files of a single runnable `workbook-server` crate into `dir`.
 pub fn generate(dir: &Path, name: &str) -> Result<()> {

--- a/cargo-pmcp/src/templates/workbook_server.rs
+++ b/cargo-pmcp/src/templates/workbook_server.rs
@@ -50,7 +50,7 @@ static EMBEDDED_XLSX: &[u8] = include_bytes!("workbook_bundle/tax-calc.xlsx");
 /// The pinned `pmcp` version the emitted `Cargo.toml` declares. A test asserts
 /// this equals the workspace-root `pmcp` version so the hardcoded pin cannot
 /// silently drift from the released crate (Codex MEDIUM).
-const PMCP_VERSION: &str = "2.19.2";
+const PMCP_VERSION: &str = "2.19.3";
 
 /// The pinned `pmcp-server-toolkit` version the emitted `Cargo.toml` declares. A
 /// test asserts this equals the workspace `pmcp-server-toolkit` package version so

--- a/cargo-pmcp/tests/package_save_load.rs
+++ b/cargo-pmcp/tests/package_save_load.rs
@@ -1338,6 +1338,62 @@ fn sample_team_package() -> pmcp_package::TeamPackage {
     }
 }
 
+/// R1 end-to-end: a `supplied_by` declared in the CONFIG reaches the PACKAGE
+/// and is rendered as host-supplied by `load`.
+///
+/// This is the whole "A generates, B verifies" path in one test. The config
+/// document is the source of truth for who fills a slot; `save` carries the
+/// declaration into the package; `load` re-derives the split from the artifact
+/// alone. Asserting only that it packs would miss the half that matters — a
+/// holder has to be able to SEE it.
+#[test]
+fn a_config_declared_supplied_by_survives_save_and_renders_as_host_supplied() {
+    let project = tempfile::tempdir().unwrap();
+    let config = london_tube_project(project.path());
+
+    // Mark the ENDPOINT as platform-injected, leaving the secret operator-supplied.
+    let original = std::fs::read_to_string(&config).unwrap();
+    let patched = original.replace(
+        "tested_value = \"https://api.tfl.gov.uk\"",
+        "tested_value = \"https://api.tfl.gov.uk\"\nsupplied_by = \"platform\"",
+    );
+    assert_ne!(original, patched, "the fixture must have been patched");
+    std::fs::write(&config, patched).unwrap();
+
+    let tar = project.path().join("london-tube.tar");
+    save_london_tube(project.path(), &config, &tar).success();
+    let tar_bytes = std::fs::read(&tar).unwrap();
+
+    let (_holder, _destination, assertion) = load_bytes(&tar_bytes, false);
+    assertion
+        .success()
+        // The operator-supplied secret is still DEMANDED.
+        .stdout(contains("Required slots"))
+        .stdout(contains("TFL_APP_KEY"))
+        // The platform-injected endpoint is NOT demanded, but IS recorded.
+        .stdout(contains("Supplied by the host at deploy time"))
+        .stdout(contains("TFL_BASE_URL"))
+        .stdout(contains("platform"));
+}
+
+/// The complement: without the declaration the same fixture renders no host
+/// section at all, so the assertions above are about the declaration rather
+/// than about the fixture.
+#[test]
+fn the_unmodified_fixture_renders_no_host_supplied_section() {
+    let project = tempfile::tempdir().unwrap();
+    let config = london_tube_project(project.path());
+    let tar = project.path().join("london-tube.tar");
+    save_london_tube(project.path(), &config, &tar).success();
+    let tar_bytes = std::fs::read(&tar).unwrap();
+
+    let (_holder, _destination, assertion) = load_bytes(&tar_bytes, false);
+    assertion
+        .success()
+        .stdout(contains("TFL_BASE_URL"))
+        .stdout(contains("Supplied by the host at deploy time").not());
+}
+
 /// Behavior 1: a SERVER package's report carries the identity, the required
 /// slots and the carriage state — and NO pin section, because a
 /// `ServerPackage` has no `ComponentRef` field at all (D-14's scope note).

--- a/cargo-pmcp/tests/pmcp_package_pin.rs
+++ b/cargo-pmcp/tests/pmcp_package_pin.rs
@@ -36,7 +36,7 @@
 const CARGO_PMCP_CARGO_TOML: &str = include_str!("../Cargo.toml");
 
 /// The exact version-requirement string cargo-pmcp must declare.
-const EXPECTED_PIN: &str = "0.3";
+const EXPECTED_PIN: &str = "0.4";
 
 /// Extract the version-requirement string for a `[dependencies]` entry, handling
 /// BOTH the `name = "x.y"` shorthand and the `name = { version = "x.y", .. }`

--- a/crates/pmcp-agent/Cargo.toml
+++ b/crates/pmcp-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-agent"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Deploy-anywhere agent decision loop for the PMCP SDK (experimental)"
 license = "MIT"
@@ -15,7 +15,7 @@ rust-version = "1.91.0"
 # gives us everything while staying wasm-clean (no reqwest). Do NOT add pmcp
 # transport features here — see the `url-connector` opt-in below.
 pmcp = { version = "2.17.0", path = "../..", default-features = false }
-pmcp-package = { version = "0.3", path = "../pmcp-package" }
+pmcp-package = { version = "0.4", path = "../pmcp-package" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 async-trait = "0.1"

--- a/crates/pmcp-cfn-renderer/Cargo.toml
+++ b/crates/pmcp-cfn-renderer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pmcp-cfn-renderer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Pure DeployDescriptor -> CloudFormation renderer for PMCP MCP servers"
 license = "MIT"
 repository = "https://github.com/paiml/rust-mcp-sdk"
 
 [dependencies]
-pmcp-package = { version = "0.3", path = "../pmcp-package" }
+pmcp-package = { version = "0.4", path = "../pmcp-package" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = { version = "1", features = ["serde"] }

--- a/crates/pmcp-openapi-server/tests/pmcp_package_pin.rs
+++ b/crates/pmcp-openapi-server/tests/pmcp_package_pin.rs
@@ -86,7 +86,7 @@ const OPENAPI_SERVER_CARGO_TOML: &str = include_str!("../Cargo.toml");
 const PMCP_PACKAGE_CARGO_TOML: &str = include_str!("../../pmcp-package/Cargo.toml");
 
 /// The major.minor line the round-trip E2E was written against.
-const EXPECTED_VERSION_LINE: &str = "0.3.";
+const EXPECTED_VERSION_LINE: &str = "0.4.";
 
 /// The path this crate's `pmcp-package` dev-dep must point at.
 const EXPECTED_DEP_PATH: &str = "../pmcp-package";

--- a/crates/pmcp-package/CHANGELOG.md
+++ b/crates/pmcp-package/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to `pmcp-package` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-08-30
+
+Declares WHO fills a config slot. **Source-breaking on the Rust API** —
+`cargo semver-checks check-release --baseline-version 0.3.1` reports 1 major
+failure — so `^0.3` consumers must move their pin to `^0.4`. The wire format is
+additive: a config with no `supplied_by` parses exactly as before.
+
+### Added
+
+- **`SuppliedBy` (`environment` | `platform` | `runtime`) on `ConfigSlot`,
+  declarable in the config document.** A `[[config_slots]]` entry may now carry
+  `supplied_by = "platform"`, and `parse_declared_config_slots` reads it.
+  Absent means `environment` — the operator supplies it — so every existing
+  config keeps its exact meaning. An unrecognized VALUE is refused rather than
+  defaulted: silently reading it as `environment` would demand an operator fill
+  a value the host injects, which is the confusion the field exists to remove.
+  The rejected value is not echoed, matching the `kind` rule.
+
+- **`classify_slots` -> `Vec<ClassifiedSlot>`**: every declared slot, classified,
+  carrying `supplied_by`. `required_slots` is now DEFINED as its
+  operator-supplied projection rather than filtering independently, so the
+  "required" and "host-supplied" groups are complements by construction — there
+  is no second filter that can drift.
+
+- `SuppliedBy` is re-exported at the crate root, alongside the vocabulary types
+  it belongs with (`ConfigSlot`, `SlotType`, `SlotClass`, `RequiredSlot`).
+
+### Changed
+
+- **`required_slots` no longer enumerates host- or runtime-supplied slots.**
+  Asking an operator to fill a value the platform injects is wrong, and a
+  package that demanded them would be unfillable. Those slots are NOT hidden:
+  `cargo pmcp package load`/`pull` render them under a labelled *"Supplied by the
+  host at deploy time"* section, built by splitting the same `classify_slots`
+  list. (`package inspect` reports a count over the raw `config_slots` and is
+  unaffected; `package show` renders the raw list flat.)
+
+- **`validate_config_slot_agreement` compares `supplied_by`.** A config saying
+  `platform` against a package slot saying `environment` is a refusal, not a
+  silent preference for one side — the package would otherwise demand a value
+  the config says the host injects. Same posture as the `kind` disagreement.
+
+- **`aggregate`'s `reconcile_collision` compares `supplied_by`** and refuses a
+  disagreement, so two team components declaring the same secret with different
+  suppliers can no longer dedupe to whichever was inserted first.
+
+### Breaking
+
+- **`DeclaredConfigSlot` gained a `supplied_by` field and is now
+  `#[non_exhaustive]`.** The field addition alone was source-breaking because
+  the struct was externally constructible — the same break `ConfigSlot` took
+  when `config_key` was added, and this is the same fix it received in response.
+  Taking it once here is what stops the next field from costing another major.
+  Build these by parsing a config document; read them by field.
+
 ## [0.3.1] - 2026-08-27
 
 A correctness patch closing a one-directional gate. **Additive on the Rust API**

--- a/crates/pmcp-package/Cargo.toml
+++ b/crates/pmcp-package/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "pmcp-package"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["PMCP SDK Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/pmcp-package/src/lib.rs
+++ b/crates/pmcp-package/src/lib.rs
@@ -77,7 +77,7 @@ pub use package::{
 };
 pub use reference::{ComponentRef, PinnedRef};
 pub use slot::{
-    aggregate, classify, detect_deviation, required_slots, ConfigSlot, Deviation, RequiredSlot,
-    SlotClass, SlotType,
+    aggregate, classify, classify_slots, detect_deviation, required_slots, ClassifiedSlot,
+    ConfigSlot, Deviation, RequiredSlot, SlotClass, SlotType, SuppliedBy,
 };
 pub use validation::validate as validate_deploy_descriptor;

--- a/crates/pmcp-package/src/oci/config_validation.rs
+++ b/crates/pmcp-package/src/oci/config_validation.rs
@@ -43,7 +43,7 @@
 //! that was violated.
 
 use crate::error::{PackageError, Result};
-use crate::slot::{ConfigSlot, SlotType};
+use crate::slot::{ConfigSlot, SlotType, SuppliedBy};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// The closed `kind` vocabulary a `[[config_slots]]` entry may declare. These
@@ -64,7 +64,16 @@ const ACCEPTED_KINDS: [&str; 3] = ["endpoint", "secret", "auth_mode"];
 /// with `unknown field`. That is the "packs cleanly and then fails to resolve
 /// at boot" class this module exists to close, so the vocabulary is enforced
 /// here too — see [`parse_declaration_entry`].
-const ACCEPTED_FIELDS: [&str; 4] = ["key", "kind", "name", "tested_value"];
+const ACCEPTED_FIELDS: [&str; 5] = ["key", "kind", "name", "tested_value", "supplied_by"];
+
+/// The closed `supplied_by` vocabulary, mirroring [`SuppliedBy`]'s serde names.
+///
+/// Re-validated here rather than deferring to serde because these bytes are
+/// untrusted input to this crate, and because an unknown value must be REFUSED
+/// rather than defaulted — silently reading an unrecognized `supplied_by` as
+/// `environment` would demand an operator fill a value the host injects, which
+/// is the exact confusion the field exists to remove.
+const ACCEPTED_SUPPLIED_BY: [&str; 3] = ["environment", "platform", "runtime"];
 
 /// Error label used when a failure is a property of the DOCUMENT rather than
 /// of any single declared key.
@@ -122,6 +131,13 @@ pub(crate) fn parse_document(config_bytes: &[u8]) -> Result<toml::Value> {
 /// that parses the real `london-tube.toml` the reference server boots from — if
 /// a field is renamed on either side, that test stops finding three slots.
 #[derive(Debug, Clone, PartialEq, Eq)]
+// Added with `supplied_by`, which was itself a source-break precisely because
+// this attribute was missing — the same break `ConfigSlot` took when
+// `config_key` was added, and got this same fix in response. Taking the break
+// once, here, is what stops the NEXT field from costing another major. Build
+// these by parsing a config document (`parse_declared_config_slots`); read them
+// by field.
+#[non_exhaustive]
 pub struct DeclaredConfigSlot {
     /// The dotted TOML path this slot fills, e.g. `backend.base_url`.
     pub key: String,
@@ -132,6 +148,10 @@ pub struct DeclaredConfigSlot {
     /// The value exercised when the server was tested. `None` for an
     /// identity-bearing slot, which structurally carries no value.
     pub tested_value: Option<String>,
+    /// Who fills this slot. Absent in the document means
+    /// [`SuppliedBy::Environment`] — the operator supplies it — so every config
+    /// written before this field existed keeps its meaning.
+    pub supplied_by: SuppliedBy,
 }
 
 /// Read the `[[config_slots]]` declaration table out of a server config
@@ -235,6 +255,8 @@ fn parse_declaration_entry(index: usize, entry: &toml::Value) -> Result<Declared
         Some(_) => return Err(violation(&label, "`tested_value` must be a string")),
     };
 
+    let supplied_by = parse_supplied_by(table, &label)?;
+
     // Match the runtime parser's `deny_unknown_fields` (see [`ACCEPTED_FIELDS`]).
     // The stray field name IS echoed: it is a KEY, not a value, and naming it is
     // the whole point — the same information `serde`'s own `unknown field` error
@@ -259,7 +281,39 @@ fn parse_declaration_entry(index: usize, entry: &toml::Value) -> Result<Declared
         kind,
         name,
         tested_value,
+        supplied_by,
     })
+}
+
+/// Read the optional `supplied_by` field, defaulting to
+/// [`SuppliedBy::Environment`] and refusing anything outside the vocabulary.
+///
+/// Absent is NOT an error: the field is additive, and a config that predates it
+/// means "the operator supplies it", which is the default. An unrecognized
+/// value IS an error — see [`ACCEPTED_SUPPLIED_BY`] for why defaulting would be
+/// the dangerous choice.
+fn parse_supplied_by(table: &toml::Table, label: &str) -> Result<SuppliedBy> {
+    let Some(raw) = table.get("supplied_by") else {
+        return Ok(SuppliedBy::Environment);
+    };
+    let Some(text) = raw.as_str() else {
+        return Err(violation(label, "`supplied_by` must be a string"));
+    };
+    match text {
+        "environment" => Ok(SuppliedBy::Environment),
+        "platform" => Ok(SuppliedBy::Platform),
+        "runtime" => Ok(SuppliedBy::Runtime),
+        // The rejected value is NOT echoed, matching the `kind` rule three
+        // functions up: it is attacker-controlled document CONTENT, and errors
+        // name the key and the rule rather than what the document said.
+        _ => Err(violation(
+            label,
+            format!(
+                "unknown `supplied_by`; the accepted values are {}",
+                ACCEPTED_SUPPLIED_BY.join(", ")
+            ),
+        )),
+    }
 }
 
 /// Read a required string field off a declaration entry.
@@ -275,7 +329,7 @@ fn required_string(table: &toml::Table, field: &str, label: &str) -> Result<Stri
 }
 
 /// The comparable projection of a slot: `(kind, name, tested_value)`.
-type SlotFacts<'a> = (&'a str, &'a str, Option<&'a str>);
+type SlotFacts<'a> = (&'a str, &'a str, Option<&'a str>, SuppliedBy);
 
 /// Require the config's `[[config_slots]]` declarations and the package's
 /// `config_slots` list to describe the SAME slots.
@@ -396,7 +450,40 @@ fn compare_facts(key: &str, declaration: SlotFacts<'_>, package: SlotFacts<'_>) 
             "the declared `tested_value` disagrees with the package slot's tested value",
         ));
     }
+    if declaration.3 != package.3 {
+        // A closed vocabulary, like `kind`, so naming both is safe and is what
+        // makes this actionable. Refused rather than reconciled: one side says
+        // an operator must fill this and the other says the host injects it, so
+        // the package would either demand a value nobody should supply or omit
+        // one nobody supplies. Both are wrong and neither is visible at deploy
+        // time — the same reasoning as `reconcile_collision`'s refusal.
+        return Err(violation(
+            key,
+            format!(
+                "the config declares supplied_by '{}' but the package slot is '{}'",
+                supplied_by_label(declaration.3),
+                supplied_by_label(package.3)
+            ),
+        ));
+    }
     Ok(())
+}
+
+/// The TOML spelling of a [`SuppliedBy`], for error text.
+///
+/// A closed vocabulary — never config content — so echoing it is safe.
+fn supplied_by_label(supplied_by: SuppliedBy) -> &'static str {
+    match supplied_by {
+        SuppliedBy::Environment => "environment",
+        SuppliedBy::Platform => "platform",
+        SuppliedBy::Runtime => "runtime",
+        // NO catch-all arm. `#[non_exhaustive]` constrains only OTHER crates;
+        // inside the defining crate this match is exhaustive, so a `_` arm is
+        // unreachable (clippy rejects it) AND would defeat the point — the
+        // compiler error a new variant produces HERE is what forces its
+        // spelling to be added. Consumers in other crates do need a catch-all;
+        // `cargo-pmcp`'s renderer has one.
+    }
 }
 
 /// Index the declarations by config key, rejecting a duplicated key.
@@ -407,6 +494,7 @@ fn declared_fact_map(declared: &[DeclaredConfigSlot]) -> Result<BTreeMap<&str, S
             declaration.kind.as_str(),
             declaration.name.as_str(),
             declaration.tested_value.as_deref(),
+            declaration.supplied_by,
         );
         if map.insert(declaration.key.as_str(), facts).is_some() {
             return Err(violation(
@@ -427,7 +515,7 @@ fn package_fact_map(package_slots: &[ConfigSlot]) -> Result<BTreeMap<&str, SlotF
             continue;
         };
         let (kind, name) = slot.slot.key();
-        let facts = (kind, name, slot.slot.tested_value());
+        let facts = (kind, name, slot.slot.tested_value(), slot.supplied_by);
         if map.insert(config_key, facts).is_some() {
             return Err(violation(
                 config_key,
@@ -1237,6 +1325,181 @@ mod tests {
         assert_eq!(declared[2].tested_value.as_deref(), Some("api_key"));
     }
 
+    // --- supplied_by parsing ----------------------------------------------
+
+    /// Absent means `environment`, so every config written before this field
+    /// existed keeps its exact meaning rather than becoming unparseable.
+    #[test]
+    fn a_declaration_without_supplied_by_defaults_to_environment() {
+        let declared = parse_declared_config_slots(LONDON_TUBE_TOML).unwrap();
+        assert_eq!(declared.len(), 3);
+        for entry in &declared {
+            assert_eq!(entry.supplied_by, SuppliedBy::Environment);
+        }
+    }
+
+    /// The whole point of the field: a config can now SAY the host injects a
+    /// value, and that reaches the package.
+    #[test]
+    fn a_declaration_can_name_platform_or_runtime() {
+        let config = br#"
+[[config_slots]]
+key = "backend.base_url"
+kind = "endpoint"
+name = "TFL_BASE_URL"
+tested_value = "https://api.tfl.gov.uk"
+supplied_by = "platform"
+
+[[config_slots]]
+key = "backend.function_name"
+kind = "secret"
+name = "AWS_LAMBDA_FUNCTION_NAME"
+supplied_by = "runtime"
+"#;
+        let declared = parse_declared_config_slots(config).unwrap();
+        assert_eq!(declared[0].supplied_by, SuppliedBy::Platform);
+        assert_eq!(declared[1].supplied_by, SuppliedBy::Runtime);
+    }
+
+    /// An unrecognized value is REFUSED, never defaulted. Defaulting would make
+    /// a typo'd `suplied_by = "platform"`... well, that trips the unknown-FIELD
+    /// gate. This is the other half: a correct field name with a wrong value,
+    /// which would silently become "the operator must supply it" and demand a
+    /// value the host actually injects.
+    #[test]
+    fn an_unknown_supplied_by_value_is_refused_and_never_echoed() {
+        let config = br#"
+[[config_slots]]
+key = "backend.base_url"
+kind = "endpoint"
+name = "TFL_BASE_URL"
+tested_value = "x"
+supplied_by = "sekrit-injector"
+"#;
+        let (key, reason) = expect_violation(parse_declared_config_slots(config).unwrap_err());
+        assert_eq!(key, "backend.base_url");
+        assert!(reason.contains("unknown `supplied_by`"), "was: {reason}");
+        // Document CONTENT is never echoed — same rule as the `kind` error.
+        assert!(
+            !reason.contains("sekrit-injector"),
+            "the rejected value leaked into the error: {reason}"
+        );
+    }
+
+    #[test]
+    fn a_non_string_supplied_by_is_refused() {
+        let config = br#"
+[[config_slots]]
+key = "backend.base_url"
+kind = "endpoint"
+name = "TFL_BASE_URL"
+tested_value = "x"
+supplied_by = 3
+"#;
+        let (_, reason) = expect_violation(parse_declared_config_slots(config).unwrap_err());
+        assert!(reason.contains("must be a string"), "was: {reason}");
+    }
+
+    /// `supplied_by` must be in ACCEPTED_FIELDS, or the unknown-field gate
+    /// rejects the very configs this feature exists to allow. Guards the
+    /// two-sided failure: the packer refusing what the server can now boot.
+    #[test]
+    fn supplied_by_is_an_accepted_field_not_an_unknown_one() {
+        assert!(ACCEPTED_FIELDS.contains(&"supplied_by"));
+        let config = br#"
+[[config_slots]]
+key = "backend.base_url"
+kind = "endpoint"
+name = "TFL_BASE_URL"
+tested_value = "x"
+supplied_by = "platform"
+"#;
+        parse_declared_config_slots(config)
+            .expect("a declaration carrying supplied_by must not trip the unknown-field gate");
+    }
+
+    /// The vocabulary const is a hand-written mirror of `SuppliedBy`'s serde
+    /// names. Nothing derives one from the other, so this pin is what turns a
+    /// fourth variant added on only ONE side into a red test rather than a
+    /// parse-time refusal of a value the type system already supports.
+    #[test]
+    fn accepted_supplied_by_matches_the_supplied_by_variants() {
+        let round_tripped: Vec<SuppliedBy> = ACCEPTED_SUPPLIED_BY
+            .iter()
+            .map(|name| {
+                serde_json::from_value::<SuppliedBy>(serde_json::Value::String((*name).to_string()))
+                    .unwrap_or_else(|_| panic!("`{name}` is not a SuppliedBy serde name"))
+            })
+            .collect();
+        assert_eq!(
+            round_tripped,
+            vec![
+                SuppliedBy::Environment,
+                SuppliedBy::Platform,
+                SuppliedBy::Runtime
+            ],
+            "ACCEPTED_SUPPLIED_BY must stay in step with SuppliedBy's serde names"
+        );
+        // And the labels used in error text round-trip to the same values.
+        for (name, value) in ACCEPTED_SUPPLIED_BY.iter().zip(round_tripped.iter()) {
+            assert_eq!(supplied_by_label(*value), *name);
+        }
+    }
+
+    /// A disagreement between the config and the package is a REFUSAL, not a
+    /// silent preference for one side — the same posture as the `kind`
+    /// disagreement, and for the same reason: the package would otherwise demand
+    /// a value the config says the host injects.
+    #[test]
+    fn a_supplied_by_disagreement_between_config_and_package_is_refused() {
+        let config = br#"
+[[config_slots]]
+key = "backend.base_url"
+kind = "endpoint"
+name = "TFL_BASE_URL"
+tested_value = "https://api.tfl.gov.uk"
+supplied_by = "platform"
+"#;
+        let declared = parse_declared_config_slots(config).unwrap();
+        // The package slot says the OPERATOR supplies it.
+        let package = vec![ConfigSlot::new(SlotType::Endpoint {
+            name: "TFL_BASE_URL".to_string(),
+            tested_value: "https://api.tfl.gov.uk".to_string(),
+        })
+        .with_config_key("backend.base_url")];
+
+        let (key, reason) =
+            expect_violation(validate_config_slot_agreement(&declared, &package).unwrap_err());
+        assert_eq!(key, "backend.base_url");
+        assert!(reason.contains("supplied_by"), "was: {reason}");
+        assert!(reason.contains("platform"), "was: {reason}");
+        assert!(reason.contains("environment"), "was: {reason}");
+    }
+
+    /// The matching case still passes, so the new comparison did not make every
+    /// agreement fail — the non-vacuity check for the test above.
+    #[test]
+    fn agreement_holds_when_both_sides_name_the_same_supplied_by() {
+        let config = br#"
+[[config_slots]]
+key = "backend.base_url"
+kind = "endpoint"
+name = "TFL_BASE_URL"
+tested_value = "https://api.tfl.gov.uk"
+supplied_by = "platform"
+"#;
+        let declared = parse_declared_config_slots(config).unwrap();
+        let package = vec![ConfigSlot::new(SlotType::Endpoint {
+            name: "TFL_BASE_URL".to_string(),
+            tested_value: "https://api.tfl.gov.uk".to_string(),
+        })
+        .with_config_key("backend.base_url")
+        .with_supplied_by(SuppliedBy::Platform)];
+
+        validate_config_slot_agreement(&declared, &package)
+            .expect("both sides name platform — this must agree");
+    }
+
     // --- The ACCEPTED_KINDS const cannot drift from SlotType ---------------
 
     #[test]
@@ -1417,12 +1680,14 @@ mod tests {
                 kind: "endpoint".to_string(),
                 name: "A".to_string(),
                 tested_value: None,
+                supplied_by: SuppliedBy::Environment,
             },
             DeclaredConfigSlot {
                 key: "backend.base_url".to_string(),
                 kind: "endpoint".to_string(),
                 name: "B".to_string(),
                 tested_value: None,
+                supplied_by: SuppliedBy::Environment,
             },
         ];
         let (key, reason) = expect_violation(

--- a/crates/pmcp-package/src/slot/aggregate.rs
+++ b/crates/pmcp-package/src/slot/aggregate.rs
@@ -80,6 +80,16 @@ pub fn aggregate<'a>(slots: impl IntoIterator<Item = &'a ConfigSlot>) -> Result<
 /// [`PackageError::ConfigSlotViolation`] for cases 1 and 3,
 /// [`PackageError::SlotConflict`] for a differing `tested_value`.
 fn reconcile_collision(name: &str, existing: &ConfigSlot, incoming: &ConfigSlot) -> Result<()> {
+    if existing.supplied_by != incoming.supplied_by {
+        return Err(PackageError::ConfigSlotViolation {
+            key: name.to_string(),
+            reason: "declared with two different `supplied_by` values by different components; \
+                     since `required_slots` enumerates only environment-supplied slots, \
+                     resolving this by input order would either ask an operator for a value the \
+                     host injects or fail to ask for one nobody supplies — both silent"
+                .to_string(),
+        });
+    }
     if existing.config_key != incoming.config_key {
         return Err(PackageError::ConfigSlotViolation {
             key: name.to_string(),

--- a/crates/pmcp-package/src/slot/mod.rs
+++ b/crates/pmcp-package/src/slot/mod.rs
@@ -21,4 +21,4 @@ pub use aggregate::aggregate;
 pub use classification::{classify, SlotClass};
 pub use deviation::{detect_deviation, Deviation};
 pub use required::{required_slots, RequiredSlot};
-pub use types::{ConfigSlot, SlotType};
+pub use types::{ConfigSlot, SlotType, SuppliedBy};

--- a/crates/pmcp-package/src/slot/mod.rs
+++ b/crates/pmcp-package/src/slot/mod.rs
@@ -20,5 +20,5 @@ pub mod types;
 pub use aggregate::aggregate;
 pub use classification::{classify, SlotClass};
 pub use deviation::{detect_deviation, Deviation};
-pub use required::{required_slots, RequiredSlot};
+pub use required::{classify_slots, required_slots, ClassifiedSlot, RequiredSlot};
 pub use types::{ConfigSlot, SlotType, SuppliedBy};

--- a/crates/pmcp-package/src/slot/required.rs
+++ b/crates/pmcp-package/src/slot/required.rs
@@ -100,6 +100,13 @@ pub struct RequiredSlot {
 pub fn required_slots(slots: &[ConfigSlot]) -> Vec<RequiredSlot> {
     let mut required: Vec<RequiredSlot> = slots
         .iter()
+        // R1.1: this is the enumerator of what a TARGET ENVIRONMENT must supply,
+        // so a value the host or the runtime injects does not belong in it. The
+        // excluded slots are NOT hidden — `package inspect`/`load` render them
+        // in their own labelled section, because a slot no operator must fill is
+        // near-invisible and near-invisibility is the failure mode this whole
+        // vocabulary exists to prevent.
+        .filter(|entry| entry.supplied_by.is_operator_supplied())
         .map(|entry| RequiredSlot {
             slot: entry.slot.clone(),
             class: classify(&entry.slot),

--- a/crates/pmcp-package/src/slot/required.rs
+++ b/crates/pmcp-package/src/slot/required.rs
@@ -13,7 +13,7 @@
 //! credential inventory.
 
 use crate::slot::classification::{classify, SlotClass};
-use crate::slot::types::{ConfigSlot, SlotType};
+use crate::slot::types::{ConfigSlot, SlotType, SuppliedBy};
 
 /// One slot a target environment must supply a value for, with the family it belongs to and
 /// the dotted TOML config path it fills (if any).
@@ -37,6 +37,58 @@ pub struct RequiredSlot {
     /// The dotted TOML path in the server's own `config.toml` this slot fills, copied from
     /// [`ConfigSlot::config_key`]. `None` for a slot that fills no config key.
     pub config_key: Option<String>,
+}
+
+/// Every declared slot, classified and ordered — including the ones no operator
+/// fills.
+///
+/// [`required_slots`] is this list minus the host- and runtime-supplied entries;
+/// it is *defined* as such rather than filtering independently, so the two can
+/// never disagree about which group a slot belongs to.
+///
+/// This exists because the excluded slots still have to be SHOWN. A slot that
+/// nobody is asked to fill and that nothing renders is invisible, and
+/// invisibility is the failure mode [`SuppliedBy`] was introduced to prevent. A
+/// renderer takes this one list and splits it on
+/// [`SuppliedBy::is_operator_supplied`], so every slot lands in exactly one
+/// section by construction — there is no second filter that could drift out of
+/// step with the first.
+///
+/// Ordering matches `required_slots`: stable sort by [`SlotType::key`].
+#[must_use]
+pub fn classify_slots(slots: &[ConfigSlot]) -> Vec<ClassifiedSlot> {
+    let mut all: Vec<ClassifiedSlot> = slots
+        .iter()
+        .map(|entry| ClassifiedSlot {
+            slot: entry.slot.clone(),
+            class: classify(&entry.slot),
+            config_key: entry.config_key.clone(),
+            supplied_by: entry.supplied_by,
+        })
+        .collect();
+    // Stable sort: duplicates (equal keys) keep their relative input order.
+    all.sort_by(|a, b| a.slot.key().cmp(&b.slot.key()));
+    all
+}
+
+/// One declared slot, classified, carrying who supplies it.
+///
+/// The superset element type: [`RequiredSlot`] is the operator-supplied
+/// projection of this. `#[non_exhaustive]` for the same reason `RequiredSlot`
+/// is — [`class`](Self::class) is DERIVED by [`classify`], never chosen, and a
+/// caller-built value whose `class` disagreed with its `slot` would mislead
+/// every consumer that branches on `.class`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ClassifiedSlot {
+    /// The slot's typed declaration.
+    pub slot: SlotType,
+    /// Which family the slot belongs to, derived from [`classify`].
+    pub class: SlotClass,
+    /// The dotted TOML path in the server's own `config.toml` this slot fills.
+    pub config_key: Option<String>,
+    /// Who fills this slot's value.
+    pub supplied_by: SuppliedBy,
 }
 
 /// Enumerate every slot a target environment must fill, in deterministic order.
@@ -98,25 +150,28 @@ pub struct RequiredSlot {
 /// ```
 #[must_use]
 pub fn required_slots(slots: &[ConfigSlot]) -> Vec<RequiredSlot> {
-    let mut required: Vec<RequiredSlot> = slots
-        .iter()
-        // R1.1: this is the enumerator of what a TARGET ENVIRONMENT must supply,
-        // so a value the host or the runtime injects does not belong in it. The
-        // excluded slots are NOT hidden — `package inspect`/`load` render them
-        // in their own labelled section, because a slot no operator must fill is
-        // near-invisible and near-invisibility is the failure mode this whole
-        // vocabulary exists to prevent.
+    // R1.1: this is the enumerator of what a TARGET ENVIRONMENT must supply, so
+    // a value the host or the runtime injects does not belong in it.
+    //
+    // Defined as a projection of `classify_slots` rather than as its own filter
+    // over `slots`, so the "required" and "host-supplied" groups are complements
+    // by construction. The excluded slots are NOT hidden: `package load`/`pull`
+    // render them in their own labelled section, built by splitting that same
+    // one list. (`package inspect` shows a count over the RAW `config_slots` and
+    // is unaffected by this filter; `package show` renders the raw list flat.)
+    // A slot no operator must fill is near-invisible, and near-invisibility is
+    // the failure mode this whole vocabulary exists to prevent.
+    //
+    // Already ordered by `classify_slots`; filtering preserves that order.
+    classify_slots(slots)
+        .into_iter()
         .filter(|entry| entry.supplied_by.is_operator_supplied())
         .map(|entry| RequiredSlot {
-            slot: entry.slot.clone(),
-            class: classify(&entry.slot),
-            config_key: entry.config_key.clone(),
+            slot: entry.slot,
+            class: entry.class,
+            config_key: entry.config_key,
         })
-        .collect();
-    // Stable sort: duplicates (equal keys) keep their relative input order rather than
-    // being reordered arbitrarily.
-    required.sort_by(|a, b| a.slot.key().cmp(&b.slot.key()));
-    required
+        .collect()
 }
 
 #[cfg(test)]
@@ -219,6 +274,81 @@ mod tests {
         let required = required_slots(&slots);
         assert_eq!(required.len(), 2);
         assert_eq!(required[0].slot.key(), required[1].slot.key());
+    }
+
+    /// R1.3: `required_slots` is the operator-supplied PROJECTION of
+    /// `classify_slots`, so the two agree on membership by construction.
+    ///
+    /// Asserts the split is a genuine partition — every declared slot lands in
+    /// exactly one group, none in both, none in neither. A slot in neither is
+    /// the invisibility bug `SuppliedBy` exists to prevent; a slot in both would
+    /// have an operator filling a value the host also injects.
+    #[test]
+    fn classify_and_required_partition_every_slot_exactly_once() {
+        let slots = vec![
+            secret(),
+            endpoint().with_supplied_by(SuppliedBy::Platform),
+            ConfigSlot::new(SlotType::OauthClient {
+                name: "primary-oauth".to_string(),
+            })
+            .with_supplied_by(SuppliedBy::Runtime),
+        ];
+
+        let all = classify_slots(&slots);
+        let required = required_slots(&slots);
+        let host_supplied: Vec<_> = all
+            .iter()
+            .filter(|e| !e.supplied_by.is_operator_supplied())
+            .collect();
+
+        // Total coverage: nothing falls out of both groups.
+        assert_eq!(all.len(), slots.len());
+        assert_eq!(required.len() + host_supplied.len(), slots.len());
+
+        // Disjoint: no key appears in both groups.
+        for entry in &required {
+            assert!(
+                !host_supplied
+                    .iter()
+                    .any(|h| h.slot.key() == entry.slot.key()),
+                "{:?} appears in BOTH groups",
+                entry.slot.key()
+            );
+        }
+
+        assert_eq!(required.len(), 1);
+        assert_eq!(required[0].slot.key(), ("secret", "TFL_APP_KEY"));
+    }
+
+    /// The projection must preserve the classification, not recompute it — a
+    /// `RequiredSlot` built from a `ClassifiedSlot` carries that entry's own
+    /// `class` and `config_key`, so the two views can never describe the same
+    /// slot differently.
+    #[test]
+    fn the_projection_preserves_class_and_config_key() {
+        let slots = vec![secret(), endpoint()];
+        let all = classify_slots(&slots);
+        let required = required_slots(&slots);
+
+        assert_eq!(required.len(), all.len());
+        for (projected, full) in required.iter().zip(all.iter()) {
+            assert_eq!(projected.slot, full.slot);
+            assert_eq!(projected.class, full.class);
+            assert_eq!(projected.config_key, full.config_key);
+        }
+    }
+
+    /// `supplied_by` is ORTHOGONAL to `kind`: a platform-supplied endpoint is
+    /// still an endpoint and still behavior-relevant. Collapsing the two axes
+    /// would re-hide exactly what `detect_deviation` exists to see.
+    #[test]
+    fn supplied_by_does_not_change_a_slots_class() {
+        let operator = classify_slots(&[endpoint()]);
+        let platform = classify_slots(&[endpoint().with_supplied_by(SuppliedBy::Platform)]);
+
+        assert_eq!(operator[0].class, platform[0].class);
+        assert_eq!(operator[0].slot.key(), platform[0].slot.key());
+        assert_ne!(operator[0].supplied_by, platform[0].supplied_by);
     }
 
     proptest! {

--- a/crates/pmcp-package/src/slot/types.rs
+++ b/crates/pmcp-package/src/slot/types.rs
@@ -188,6 +188,46 @@ impl SlotType {
 /// `#[non_exhaustive]`: construct with [`ConfigSlot::new`] and [`ConfigSlot::with_config_key`]
 /// rather than a struct literal. Adding `config_key` broke every struct literal in this
 /// repository; the attribute is what stops the NEXT field from doing it again.
+/// WHO fills a slot's value — orthogonal to WHAT kind of value it is.
+///
+/// Who supplies a value and whether its value is behaviour-relevant are
+/// independent axes, so this never touches [`crate::slot::classify`] or
+/// [`crate::slot::detect_deviation`]: a platform-supplied ENDPOINT stays
+/// deviation-visible. Collapsing the two would re-hide exactly what deviation
+/// detection exists to see.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SuppliedBy {
+    /// The operator supplies it in the target environment. The default, and the
+    /// only class [`crate::slot::required_slots`] enumerates.
+    #[default]
+    Environment,
+    /// The hosting platform injects it at deploy time — never operator-supplied.
+    Platform,
+    /// The runtime injects it (e.g. `AWS_LAMBDA_FUNCTION_NAME`): neither the
+    /// operator nor the platform supplies it, and nothing needs to.
+    Runtime,
+}
+
+impl SuppliedBy {
+    /// Whether a target environment's operator must supply this value.
+    ///
+    /// The one predicate `required_slots` and every renderer key on, so "who is
+    /// asked for this" has a single definition rather than a `!= Environment`
+    /// test repeated at each call site.
+    #[must_use]
+    pub fn is_operator_supplied(self) -> bool {
+        matches!(self, Self::Environment)
+    }
+}
+
+/// `skip_serializing_if` hands the field by reference, so the public
+/// `Copy`-taking predicate cannot be named there directly.
+fn is_environment_supplied(supplied_by: &SuppliedBy) -> bool {
+    supplied_by.is_operator_supplied()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ConfigSlot {
@@ -219,6 +259,21 @@ pub struct ConfigSlot {
     ///   originally under-scoped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_key: Option<String>,
+    /// Who fills this slot's value. Defaults to [`SuppliedBy::Environment`].
+    ///
+    /// # Compatibility — ADDITIVE on both axes, unlike `config_key`
+    ///
+    /// - **Serde/wire:** `#[serde(default)]` deserializes pre-`supplied_by` slot
+    ///   JSON to `Environment`, and `skip_serializing_if` emits nothing for it,
+    ///   so no checked-in fixture byte and no pinned digest moves.
+    /// - **Rust source:** ALSO additive, which is the difference from
+    ///   `config_key`'s addition. `ConfigSlot` is `#[non_exhaustive]` — added in
+    ///   response to that break — so no crate outside this one can write a
+    ///   struct literal, and a repo-wide sweep finds ZERO literals even inside
+    ///   it: every construction goes through [`ConfigSlot::new`] and the
+    ///   `with_*` builders. The attribute did the job it was added for.
+    #[serde(default, skip_serializing_if = "is_environment_supplied")]
+    pub supplied_by: SuppliedBy,
 }
 
 impl ConfigSlot {
@@ -239,6 +294,7 @@ impl ConfigSlot {
         Self {
             slot,
             config_key: None,
+            supplied_by: SuppliedBy::Environment,
         }
     }
 
@@ -265,6 +321,13 @@ impl ConfigSlot {
     #[must_use]
     pub fn with_config_key(mut self, key: impl Into<String>) -> Self {
         self.config_key = Some(key.into());
+        self
+    }
+
+    /// Declare who fills this slot. See [`SuppliedBy`].
+    #[must_use]
+    pub fn with_supplied_by(mut self, supplied_by: SuppliedBy) -> Self {
+        self.supplied_by = supplied_by;
         self
     }
 }

--- a/crates/pmcp-server-toolkit/Cargo.toml
+++ b/crates/pmcp-server-toolkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-server-toolkit"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paiml/rust-mcp-sdk"

--- a/crates/pmcp-server-toolkit/src/config.rs
+++ b/crates/pmcp-server-toolkit/src/config.rs
@@ -758,6 +758,31 @@ pub enum ConfigSlotKind {
 /// name = "TFL_BASE_URL"
 /// tested_value = "https://api.tfl.gov.uk"
 /// ```
+/// Who fills a config slot's value.
+///
+/// Mirrors `pmcp-package`'s `SuppliedBy` **by TOML value name, never by shared
+/// type** — the same arrangement as [`ConfigSlotKind`], and for the same
+/// reason: the toolkit must NOT depend on `pmcp-package` (the
+/// workspace-excluded leaf), and a dependency the other way inverts the
+/// layering. The agreement is enforced by the package side re-parsing these
+/// same config bytes, not by a shared definition.
+///
+/// Defaults to [`Environment`](Self::Environment), so every config written
+/// before this field existed keeps its exact meaning: the operator supplies it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigSlotSuppliedBy {
+    /// The operator supplies it in the target environment. The default, and the
+    /// only class a package enumerates as REQUIRED of an operator.
+    #[default]
+    Environment,
+    /// The hosting platform injects it at deploy time.
+    Platform,
+    /// The execution environment injects it (e.g. `AWS_LAMBDA_FUNCTION_NAME`);
+    /// neither the operator nor the platform supplies it.
+    Runtime,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigSlotDecl {
@@ -781,6 +806,17 @@ pub struct ConfigSlotDecl {
     /// never packed.
     #[serde(default)]
     pub tested_value: Option<String>,
+    /// Who fills this slot — see [`ConfigSlotSuppliedBy`]. Defaults to
+    /// `environment` (the operator supplies it), so a config written before this
+    /// field existed is unchanged in meaning.
+    ///
+    /// This field is why the toolkit had to move in the same change as the
+    /// packer: `deny_unknown_fields` above means a config carrying
+    /// `supplied_by` would FAIL TO BOOT if only the package side learned it,
+    /// and `pmcp-package` refuses to pack a config it knows the server cannot
+    /// parse. Both sides accept it, or neither does.
+    #[serde(default)]
+    pub supplied_by: ConfigSlotSuppliedBy,
 }
 
 // -----------------------------------------------------------------------------
@@ -1693,6 +1729,80 @@ mod tests {
         assert_eq!(cfg.config_slots[1].kind, ConfigSlotKind::Secret);
         assert_eq!(cfg.config_slots[1].name, "TFL_APP_KEY");
         assert_eq!(cfg.config_slots[2].kind, ConfigSlotKind::AuthMode);
+    }
+
+    /// A `[[config_slots]]` entry carrying `supplied_by` must BOOT.
+    ///
+    /// This is the load-bearing half of a two-crate change. `pmcp-package`
+    /// refuses to pack a config whose fields this struct's
+    /// `deny_unknown_fields` would reject, on the grounds that packing it would
+    /// ship a server that cannot start. So if the packer learns `supplied_by`
+    /// and this struct does not, every config using the field becomes
+    /// unpackable; if this struct learns it and the packer does not, the packer
+    /// rejects configs the server boots from happily. Both sides move together
+    /// or neither does, and this test is the runtime half of that pin.
+    #[test]
+    fn a_config_slot_declaring_supplied_by_parses_through_the_strict_entry_point() {
+        let toml = r#"
+            [server]
+            name = "tube"
+            version = "0.1.0"
+
+            [[config_slots]]
+            key = "backend.base_url"
+            kind = "endpoint"
+            name = "TFL_BASE_URL"
+            tested_value = "https://api.tfl.gov.uk"
+            supplied_by = "platform"
+
+            [[config_slots]]
+            key = "backend.function_name"
+            kind = "secret"
+            name = "AWS_LAMBDA_FUNCTION_NAME"
+            supplied_by = "runtime"
+        "#;
+        let cfg = ServerConfig::from_toml_strict_validated(toml)
+            .expect("`supplied_by` must parse under deny_unknown_fields");
+        assert_eq!(
+            cfg.config_slots[0].supplied_by,
+            ConfigSlotSuppliedBy::Platform
+        );
+        assert_eq!(
+            cfg.config_slots[1].supplied_by,
+            ConfigSlotSuppliedBy::Runtime
+        );
+    }
+
+    /// Omitting it means `environment`, so every config written before the
+    /// field existed keeps its meaning rather than failing to parse.
+    #[test]
+    fn a_config_slot_without_supplied_by_defaults_to_environment() {
+        let cfg = ServerConfig::from_toml_strict_validated(CONFIG_SLOTS_TOML)
+            .expect("the pre-existing fixture must still parse");
+        for slot in &cfg.config_slots {
+            assert_eq!(slot.supplied_by, ConfigSlotSuppliedBy::Environment);
+        }
+    }
+
+    /// An unrecognized value is a parse ERROR, not a silent default — strict
+    /// parse discipline (D-13). A defaulted typo here would tell an operator to
+    /// supply a value the platform actually injects.
+    #[test]
+    fn an_unknown_supplied_by_value_is_a_parse_error() {
+        let toml = r#"
+            [server]
+            name = "tube"
+            version = "0.1.0"
+
+            [[config_slots]]
+            key = "backend.base_url"
+            kind = "endpoint"
+            name = "TFL_BASE_URL"
+            tested_value = "x"
+            supplied_by = "platfrom"
+        "#;
+        ServerConfig::from_toml_strict_validated(toml)
+            .expect_err("a misspelled supplied_by must not silently default");
     }
 
     /// Test 2: the field is ADDITIVE — a config with no `[[config_slots]]` block

--- a/crates/pmcp-team-servers/Cargo.toml
+++ b/crates/pmcp-team-servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmcp-team-servers"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Dev-grade reference team servers (team-fs, mem-mcp, approval-mcp, team-mcp) for the PMCP SDK (experimental)"
 license = "MIT"
@@ -20,8 +20,8 @@ exclude = [".planning/", "fuzz/", "tests/"]
 # (RequestHandlerExtra.request_meta) landed additively in the local 2.17.x via
 # 109-00; the path dep provides the source regardless of exact minor.
 pmcp = { version = "2.17.0", path = "../..", default-features = false }
-pmcp-agent = { version = "0.3", path = "../pmcp-agent" }
-pmcp-package = { version = "0.3", path = "../pmcp-package" }
+pmcp-agent = { version = "0.4", path = "../pmcp-agent" }
+pmcp-package = { version = "0.4", path = "../pmcp-package" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 async-trait = "0.1"


### PR DESCRIPTION
## What

Completes **R1** of the env-surface work: a config slot can declare **who fills it**, and that declaration reaches the package and the reader.

```toml
[[config_slots]]
key = "backend.base_url"
kind = "endpoint"
name = "TFL_BASE_URL"
tested_value = "https://api.tfl.gov.uk"
supplied_by = "platform"      # environment (default) | platform | runtime
```

`cargo pmcp package save` carries the declaration into the package; `package load`/`pull` render such slots under a labelled **"Supplied by the host at deploy time"** section instead of demanding them of an operator.

This is the "A generates, B verifies" severance in practice: the config document is the source of truth for who fills a slot, it travels inside the artifact, and a holder re-derives the split from the artifact alone with zero trust in the packer.

## Why three crates had to move together

`pmcp-package` refuses to pack a config carrying a field the **server** would reject at boot, and the toolkit's `ConfigSlotDecl` is `#[serde(deny_unknown_fields)]`.

- Teaching only the packer → every config using the field becomes unpackable.
- Teaching only the runtime → the packer rejects configs the server boots from happily.

Each side now carries a test pinning the other. The toolkit mirrors the vocabulary **by TOML value name, never by shared type** — it must not depend on the workspace-excluded leaf crate, and the reverse inverts the layering.

## Design calls worth review

**An unrecognized `supplied_by` value is refused, never defaulted.** Silently reading it as `environment` would tell an operator to supply a value the platform actually injects — the exact confusion the field exists to remove. The rejected value is not echoed, matching the `kind` rule.

**The two rendered sections are complements by construction.** `classify_slots()` returns every slot classified; `required_slots()` is *defined* as its operator-supplied projection; the renderer splits that one list on one predicate. There is no second filter that can drift, which is stronger than testing that two filters agree.

**`validate_config_slot_agreement` compares `supplied_by`.** A config saying `platform` against a package slot saying `environment` is a refusal, not a silent preference for one side.

## Versions

Measured with `cargo semver-checks check-release --baseline-version 0.3.1`: **1 major failure** — `DeclaredConfigSlot` was externally constructible, so its new field breaks struct literals. Now `#[non_exhaustive]`, the same remedy `ConfigSlot` got after the `config_key` break, so the next field is free.

| Crate | From | To |
|---|---|---|
| `pmcp` | 2.19.2 | 2.19.3 (carrier only) |
| `pmcp-package` | 0.3.1 | **0.4.0** |
| `pmcp-agent` | 0.3.0 | 0.4.0 |
| `pmcp-team-servers` | 0.2.0 | 0.3.0 |
| `pmcp-cfn-renderer` | 0.2.0 | 0.3.0 |
| `pmcp-server-toolkit` | 0.1.2 | 0.1.3 |
| `cargo-pmcp` | 0.24.0 | 0.24.0 (unpublished; folds in) |

`pmcp` is a **carrier bump** following the v2.19.2/v2.19.1 precedent — no `pmcp` source changed; the tag is the only path `pmcp-package` has to crates.io. Its patch bump moves no pins (caret exception: every `pmcp` requirement is `^2.x`, x ≤ 19).

**`pmcp-server-toolkit` 0.1.3 is a deliberate under-call.** Its `ConfigSlotDecl` field addition is the same class of source break, taken as a PATCH so its seven `^0.1.x` consumer pins do not move — five crates in this release rather than about twelve. Justified by zero in-tree `ConfigSlotDecl` struct literals (it is purely a deserialization target) and no CI semver gate. Called out in the changelog so a future releaser sees reasoning rather than infers an oversight.

**Twelve version emitters moved**, not the nine CLAUDE.md documents — that list covers `pmcp-package` alone. Bumping the toolkit, `pmcp-agent` and `pmcp` also required `TOOLKIT_VERSION`, `PMCP_AGENT_VERSION` and `PMCP_VERSION`, all three invisible to the compiler because they are emitted into scaffolded projects. Their drift tests caught all three while `cargo build --workspace` stayed at 0 errors. `pmcp-openapi-server`'s `pmcp-package` dep stays **path-only** per CR-01.

## Verification

- `RUSTFLAGS="" make quality-gate` — exit 0, zero `make: ***` lines, zero `test result: FAILED` lines, banner present
- `pmat quality-gate --fail-on-violation --checks complexity` — 0 violations
- `cargo semver-checks` against the published 0.3.1 baseline — measured, not reasoned
- The exact `release.yml` awk extraction against `2.19.3` — 3956 bytes, terminates at the next `## [`
- `pmcp-package` 218 · `cargo-pmcp` lib 527 · package integration 44 + 22 + 42 · both pin tripwires · release-coverage 25/25
- **Mutation-tested**: dropping the `save.rs` carry-through, removing the `required_slots` filter, filtering inside `classify_slots`, and discarding `supplied_by` each fail the suite

## Follow-up (not in this PR)

R2 — the declared-surface marker and the binary-server gate, so "needs nothing" and "never said" stop being the same bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
