### PR TITLE
fix(cargo-pmcp): scaffold emits the maintainer's absolute SDK path, breaking every generated workspace

### DIFF
--- a/cargo-pmcp/src/templates/workspace.rs
+++ b/cargo-pmcp/src/templates/workspace.rs
@@ -5,6 +5,33 @@ use colored::Colorize;
 use std::fs;
 use std::path::Path;
 
+/// The `pmcp` version REQUIREMENT the emitted workspace `Cargo.toml` declares —
+/// a caret major.minor line, not a full version.
+///
+/// This MUST be a requirement that the PUBLISHED crates.io `pmcp` satisfies, and
+/// must never be a filesystem path. Users of `cargo pmcp new` do not have — and
+/// must never need — a local SDK checkout.
+///
+/// This shipped once as `pmcp = { path = "/Users/<maintainer>/..." }` in
+/// cargo-pmcp 0.23.1 and broke every scaffolded workspace on every machine
+/// except the maintainer's own: `crates/server-common` inherits this pin via
+/// `pmcp = { workspace = true }`, so `cargo metadata` — and therefore
+/// `cargo pmcp deploy init` — failed with "No such file or directory". It was
+/// invisible in-house precisely because the hardcoded path resolves there, so a
+/// green local run is not evidence for this class of defect.
+///
+/// MAJOR.MINOR, not the exact root version, deliberately — mirroring
+/// `templates/agent.rs`'s `PMCP_PACKAGE_VERSION_REQ`. The workspace root is
+/// routinely a patch ahead of crates.io during a release cycle, and an exact pin
+/// on an unpublished patch makes every scaffolded project fail to resolve
+/// (measured: `failed to select a version for the requirement pmcp = "^2.19.3"`,
+/// exit 101). A caret major.minor line resolves against the currently published
+/// crate AND admits the newer patch once it ships.
+///
+/// `emitted_pmcp_requirement_matches_workspace_major_minor_line` asserts this
+/// tracks the workspace-root `pmcp` version so it cannot silently drift.
+const PMCP_VERSION_REQ: &str = "2.19";
+
 /// Generate workspace files (Cargo.toml, Makefile, README.md)
 pub fn generate(workspace_dir: &Path, name: &str) -> Result<()> {
     generate_cargo_toml(workspace_dir, name)?;
@@ -17,7 +44,8 @@ pub fn generate(workspace_dir: &Path, name: &str) -> Result<()> {
 }
 
 fn generate_cargo_toml(workspace_dir: &Path, _name: &str) -> Result<()> {
-    let content = r#"[workspace]
+    let content = format!(
+        r#"[workspace]
 resolver = "2"
 members = [
     "crates/server-common",
@@ -31,22 +59,22 @@ license = "MIT OR Apache-2.0"
 authors = ["Your Name <you@example.com>"]
 
 [workspace.dependencies]
-# MCP SDK (using local path for development - change to git for production)
-pmcp = { path = "/Users/guy/Development/mcp/sdk/rust-mcp-sdk", features = ["streamable-http", "schema-generation"] }
+# MCP SDK
+pmcp = {{ version = "{PMCP_VERSION_REQ}", features = ["streamable-http", "schema-generation"] }}
 
 # HTTP transport
 axum = "0.7"
-tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.6", features = ["trace", "cors"] }
+tokio = {{ version = "1", features = ["full"] }}
+tower-http = {{ version = "0.6", features = ["trace", "cors"] }}
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
+serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
-schemars = { version = "1.0", features = ["preserve_order"] }
+schemars = {{ version = "1.0", features = ["preserve_order"] }}
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-subscriber = {{ version = "0.3", features = ["env-filter", "json"] }}
 async-trait = "0.1"
 
 # Error handling
@@ -54,16 +82,17 @@ anyhow = "1"
 thiserror = "1"
 
 # Validation
-validator = { version = "0.18", features = ["derive"] }
+validator = {{ version = "0.18", features = ["derive"] }}
 
 [profile.release]
 opt-level = "z"     # Optimize for size
 lto = true          # Enable link-time optimization
 codegen-units = 1   # Better optimization
 strip = true        # Strip symbols for smaller binaries
-"#;
+"#
+    );
 
-    fs::write(workspace_dir.join("Cargo.toml"), content).context("Failed to create Cargo.toml")?;
+    fs::write(workspace_dir.join("Cargo.toml"), &content).context("Failed to create Cargo.toml")?;
 
     Ok(())
 }
@@ -299,4 +328,137 @@ lambda/node_modules/
     fs::write(workspace_dir.join(".gitignore"), content).context("Failed to create .gitignore")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The workspace-root `Cargo.toml`, embedded so the drift guard can compare
+    /// the scaffold's pin against the real `pmcp` version.
+    const ROOT_CARGO_TOML: &str = include_str!("../../../Cargo.toml");
+
+    /// Render the emitted workspace `Cargo.toml` into a tempdir and read it back,
+    /// exercising the real `generate_cargo_toml` rather than a copy of its string.
+    fn render_workspace_cargo_toml() -> String {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        generate_cargo_toml(tmp.path(), "testws").expect("generate workspace Cargo.toml");
+        fs::read_to_string(tmp.path().join("Cargo.toml")).expect("read emitted Cargo.toml")
+    }
+
+    /// DIRECT REGRESSION GUARD for the `deploy-init-abs-path-dep` defect.
+    ///
+    /// `cargo pmcp new` once emitted a `pmcp = { path = "..." }` dependency
+    /// carrying an ABSOLUTE path to the maintainer's own SDK checkout into every
+    /// scaffolded workspace. `crates/server-common` inherits that pin via
+    /// `pmcp = { workspace = true }`, so `cargo metadata` — and therefore
+    /// `cargo pmcp deploy init` — failed on every machine except the
+    /// maintainer's. The bug was invisible in-house precisely because the
+    /// hardcoded path resolves fine there.
+    ///
+    /// Oracle: `derived` (contract) — asserts the structural property "no
+    /// absolute filesystem path may appear in generated output", not one
+    /// literal. Boundary neighbors cover the macOS, Linux and Windows shapes so
+    /// re-introducing the defect under a different home directory still fails.
+    #[test]
+    fn emitted_cargo_toml_contains_no_absolute_path() {
+        let content = render_workspace_cargo_toml();
+
+        for needle in [
+            "/Users/",
+            "/home/",
+            "/root/",
+            "C:\\",
+            "/private/var",
+            "/tmp/",
+        ] {
+            assert!(
+                !content.contains(needle),
+                "emitted workspace Cargo.toml leaked an absolute filesystem path \
+                 containing `{needle}` — scaffolded projects must never reference a \
+                 local SDK checkout. Emitted:\n{content}"
+            );
+        }
+    }
+
+    /// The `pmcp` dependency must be pinned BY VERSION and must carry no `path`
+    /// key at all — the shape that caused the original defect.
+    ///
+    /// Oracle: `derived` — parses the emitted TOML and asserts on the dependency
+    /// table's structure rather than string-matching, so a reformatting of the
+    /// template cannot make this pass vacuously.
+    #[test]
+    fn emitted_pmcp_dep_is_pinned_by_version_not_path() {
+        let content = render_workspace_cargo_toml();
+        let parsed: toml::Value = toml::from_str(&content).expect("emitted Cargo.toml must parse");
+
+        let pmcp = parsed
+            .get("workspace")
+            .and_then(|w| w.get("dependencies"))
+            .and_then(|d| d.get("pmcp"))
+            .expect("emitted [workspace.dependencies] must declare pmcp");
+
+        assert!(
+            pmcp.get("path").is_none(),
+            "emitted pmcp dependency carries a `path` key — scaffolded workspaces \
+             must resolve pmcp from crates.io, never from a local checkout. Got: {pmcp:?}"
+        );
+        assert_eq!(
+            pmcp.get("version").and_then(toml::Value::as_str),
+            Some(PMCP_VERSION_REQ),
+            "emitted pmcp dependency must declare PMCP_VERSION_REQ. Got: {pmcp:?}"
+        );
+    }
+
+    /// `PMCP_VERSION_REQ` must track the workspace-root `pmcp` MAJOR.MINOR line.
+    ///
+    /// This is a version emitter `cargo build` cannot see: the workspace resolves
+    /// green while every project scaffolded by `cargo pmcp new` requests whatever
+    /// this constant says. Without this guard a stale requirement ships silently.
+    ///
+    /// Compared at major.minor (not the full version) ON PURPOSE — see
+    /// `PMCP_VERSION_REQ`'s docs. An exact-version guard here would force the
+    /// scaffold to pin an unpublished patch during every release cycle.
+    #[test]
+    fn emitted_pmcp_requirement_matches_workspace_major_minor_line() {
+        let parsed: toml::Value =
+            toml::from_str(ROOT_CARGO_TOML).expect("parse workspace root Cargo.toml");
+        let root_version = parsed
+            .get("package")
+            .and_then(|p| p.get("version"))
+            .and_then(|v| v.as_str())
+            .expect("root Cargo.toml has [package] version");
+        let mut parts = root_version.split('.');
+        let major = parts.next().unwrap_or("0");
+        let minor = parts.next().unwrap_or("0");
+        let expected = format!("{major}.{minor}");
+        assert_eq!(
+            PMCP_VERSION_REQ, expected,
+            "the scaffold's pmcp requirement `{PMCP_VERSION_REQ}` drifted from the \
+             workspace-root version `{root_version}` — bump PMCP_VERSION_REQ in \
+             templates/workspace.rs"
+        );
+    }
+
+    /// The generated `server-common` member inherits the root pin via
+    /// `workspace = true`. This is the hop that turned one bad literal into a
+    /// broken workspace, so assert the member list and the emitted workspace
+    /// table stay consistent.
+    #[test]
+    fn emitted_workspace_declares_the_server_common_member() {
+        let content = render_workspace_cargo_toml();
+        let parsed: toml::Value = toml::from_str(&content).expect("emitted Cargo.toml must parse");
+        let members = parsed
+            .get("workspace")
+            .and_then(|w| w.get("members"))
+            .and_then(toml::Value::as_array)
+            .expect("emitted [workspace] must declare members");
+        assert!(
+            members
+                .iter()
+                .any(|m| m.as_str() == Some("crates/server-common")),
+            "emitted workspace must list crates/server-common — it is the member that \
+             inherits the pmcp pin. Got: {members:?}"
+        );
+    }
 }


### PR DESCRIPTION
## The bug

`cargo pmcp new <name>` wrote a maintainer's filesystem path into every workspace it scaffolded. In published **0.23.1** — the build the reporting user installed — `src/templates/workspace.rs:35` emits:

```toml
[workspace.dependencies]
# MCP SDK (using local path for development - change to git for production)
pmcp = { path = "/Users/guy/Development/mcp/sdk/rust-mcp-sdk", features = [...] }
```

The generated `crates/server-common` inherits it via `pmcp = { workspace = true }`, so **every `cargo metadata` in a scaffolded workspace fails on any machine that is not the maintainer's**:

```
failed to load manifest for workspace member `/home/nikos/.../crates/server-common`
  Caused by: failed to load manifest for dependency `pmcp`
  Caused by: failed to read `/Users/guy/Development/mcp/sdk/rust-mcp-sdk/Cargo.toml`
  Caused by: No such file or directory (os error 2)
```

`deploy init` is the messenger, not the culprit — it is simply the first command that shells out to `cargo metadata`.

**Verified against the artifact the user actually installed**, not just HEAD: unpacked the published `cargo-pmcp-0.23.1.crate` from the crates.io API and swept it — exactly **one** `/Users/` hit in the whole published `src/`, and it is this line.

## Why it survived to release

The generated workspace exits 0 on the maintainer's machine, because the hardcoded path exists there. The defect is structurally invisible to the only person positioned to catch it before publishing — a green local check was never evidence for this class.

## The fix

Replaces the path with a caret **major.minor** crates.io requirement behind a named `PMCP_VERSION_REQ` constant.

**Major.minor, not the exact root version — this is the load-bearing choice.** The obvious move was to copy `workbook_server.rs`'s exact-version idiom. That would have shipped a *second* broken scaffold: the workspace root runs a patch ahead of crates.io during a release cycle (root **2.19.3**, published **2.19.2**), so an exact pin makes every scaffolded project fail to resolve — measured, `failed to select a version for the requirement pmcp = "^2.19.3"`, exit 101. The `agent.rs` major.minor idiom resolves against what is published today and admits the newer patch when it ships.

## Tests

Four, all **structural rather than literal-matching** — they parse the emitted TOML, so reformatting the template cannot make them pass vacuously:

| Test | Asserts |
|---|---|
| `emitted_cargo_toml_contains_no_absolute_path` | no `/Users/`, `/home/`, `/root/`, `C:\`, … — the contract, not one literal |
| `emitted_pmcp_dep_is_pinned_by_version_not_path` | `pmcp` has a `version` and **no `path` key at all** |
| `emitted_pmcp_requirement_matches_workspace_major_minor_line` | drift guard vs the workspace root |
| `emitted_workspace_declares_the_server_common_member` | the member hop that carried the defect |

⚠️ **These live in the BIN target.** `templates::workspace` is not wired into the lib (unlike `templates_agent` / `templates_workbook_server`), so `cargo test --lib templates_workspace` matches **zero tests and reports a false green**. Run `--bins`.

## Residual risk, recorded not hidden

The drift guard enforces **not-stale**. The invariant this bug violated is **resolvable** — different things. At a pmcp *minor* bump the guard forces `PMCP_VERSION_REQ` forward while crates.io still carries only the old minor, which would emit an unresolvable scaffold: same class, one notch narrower.

Release **order** protects this in practice, not the test — `release.yml` publishes `pmcp` at item 2, far ahead of `cargo-pmcp` at 15a. The residual exposure is a **partial publish**: pmcp failing while cargo-pmcp succeeds. Not hypothetical — that is the crates.io ownership 403 that cost v2.19.1 three crates. A guard asserting real resolvability needs network and does not belong in the unit suite.

## Adjacent, deliberately not fixed

Five other templates emit stale pmcp pins. All **resolve**, so none is broken the way this was, but they hand new users ancient majors:

- `oauth/proxy.rs:468` and `oauth/authorizer.rs:216` — `pmcp = "0.3"`
- `mcp_app.rs:348` — `pmcp = "1.10"`
- `sql_server.rs:57`, `openapi_server.rs:73` — `pmcp = "2.8.1"` (caret resolves fine, text is stale)

Only `workspace.rs`, `workbook_server.rs` and `agent.rs` have drift guards. Worth a follow-up phase giving every scaffold pin the same named-constant + guard treatment.

## Shipping

The fix rides the already-bumped, still-unpublished `cargo-pmcp` **0.24.0**, so it reaches users on the pending **v2.19.3** tag — no separate release needed. **This must merge before that tag is pushed.**

Users with an already-scaffolded project need a one-line manual edit; the fix cannot repair generated files retroactively. In their root `Cargo.toml` under `[workspace.dependencies]`:

```toml
pmcp = { version = "2.19", features = ["streamable-http", "schema-generation"] }
```

Debug session: `.planning/debug/resolved/deploy-init-abs-path-dep.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
